### PR TITLE
fix: stabilize BleSharedBridge lifecycle

### DIFF
--- a/examples/TEST-BRIDGE/README.md
+++ b/examples/TEST-BRIDGE/README.md
@@ -7,8 +7,9 @@ ORPHE COREのBLE接続を複数タブ間で共有する `BleSharedBridge` 機能
 | ファイル | 用途 |
 |---------|------|
 | `index.html` | 実機BLEを使った動作確認ページ |
+| `physical-reconnect-test.html` | 実機BLEの前回デバイス記憶・自動再接続・手動切り替え確認ページ |
 | `unit-test.html` | BleSharedBridge クラスの単体テスト（25ケース、実機不要） |
-| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（17ケース、実機不要） |
+| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（34ケース、実機不要） |
 | `test-frame.html` | テスト用の補助iframe |
 
 ## 実機での動作確認手順
@@ -36,6 +37,17 @@ python3 -m http.server 8765
    - Tab B は自動で再接続を試みる（Fast Reconnect）
    - ペアリング済みなら数秒でBLE接続に切り替わり Primary に昇格
    - ペアリング情報がない場合は手動再接続が必要
+
+### 前回デバイス記憶・切り替え確認
+
+`physical-reconnect-test.html` を使うと、前回接続した Bluetooth デバイスの記憶と再接続を確認できます。
+
+1. Tab A / Tab B で `physical-reconnect-test.html` を開く
+2. Tab A で「接続 / 再接続」を押して ORPHE CORE を選ぶ
+3. Tab B で「接続 / 再接続」を押し、Secondary になることを確認
+4. Tab A で「切断」を押す
+5. Tab B が前回記憶した ORPHE CORE へ自動再接続して Primary になることを確認
+6. 別の ORPHE CORE へ切り替える場合は「前回デバイスを忘れる」を押してから接続し直す
 
 ## 自動テスト
 

--- a/examples/TEST-BRIDGE/README.md
+++ b/examples/TEST-BRIDGE/README.md
@@ -8,6 +8,7 @@ ORPHE COREのBLE接続を複数タブ間で共有する `BleSharedBridge` 機能
 |---------|------|
 | `index.html` | 実機BLEを使った動作確認ページ |
 | `physical-reconnect-test.html` | 実機BLEの前回デバイス記憶・自動再接続・手動切り替え確認ページ |
+| `physical-range-test.html` | 物理的なBLE距離断・復帰時間・再接続試行回数の確認ページ |
 | `unit-test.html` | BleSharedBridge クラスの単体テスト（25ケース、実機不要） |
 | `integration-test.html` | Orphe + BleSharedBridge の統合テスト（43ケース、実機不要） |
 | `test-frame.html` | テスト用の補助iframe |
@@ -48,6 +49,17 @@ python3 -m http.server 8765
 4. Tab A で「切断」を押す
 5. Tab B が前回記憶した ORPHE CORE へ自動再接続して Primary になることを確認
 6. 別の ORPHE CORE へ切り替える場合は、Primary接続中に「接続 / 再接続 / 切り替え」をもう一度押してBLE選択ダイアログから選び直す
+
+### 物理的なBLE距離断・自動復帰確認
+
+`physical-range-test.html` は、ORPHE CORE を持って離れた時のBLE切断と、近づいた時の自動再接続をログで確認するページです。
+
+1. `physical-range-test.html` を開く
+2. 「デバイス選択して開始」でORPHE COREを選ぶ
+3. センサーデータが流れ始めたら、ORPHE COREを持って通信圏外まで離れる
+4. ログに `disconnect detected` と `reconnect attempt` が出ることを確認
+5. ORPHE COREを近づける
+6. ログに `reconnect success` が出て、復帰時間と試行回数が記録されることを確認
 
 ## 自動テスト
 

--- a/examples/TEST-BRIDGE/README.md
+++ b/examples/TEST-BRIDGE/README.md
@@ -9,7 +9,7 @@ ORPHE COREのBLE接続を複数タブ間で共有する `BleSharedBridge` 機能
 | `index.html` | 実機BLEを使った動作確認ページ |
 | `physical-reconnect-test.html` | 実機BLEの前回デバイス記憶・自動再接続・手動切り替え確認ページ |
 | `unit-test.html` | BleSharedBridge クラスの単体テスト（25ケース、実機不要） |
-| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（34ケース、実機不要） |
+| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（40ケース、実機不要） |
 | `test-frame.html` | テスト用の補助iframe |
 
 ## 実機での動作確認手順
@@ -47,7 +47,7 @@ python3 -m http.server 8765
 3. Tab B で「接続 / 再接続」を押し、Secondary になることを確認
 4. Tab A で「切断」を押す
 5. Tab B が前回記憶した ORPHE CORE へ自動再接続して Primary になることを確認
-6. 別の ORPHE CORE へ切り替える場合は「前回デバイスを忘れる」を押してから接続し直す
+6. 別の ORPHE CORE へ切り替える場合は、Primary接続中に「接続 / 再接続 / 切り替え」をもう一度押してBLE選択ダイアログから選び直す
 
 ## 自動テスト
 

--- a/examples/TEST-BRIDGE/README.md
+++ b/examples/TEST-BRIDGE/README.md
@@ -10,7 +10,7 @@ ORPHE COREのBLE接続を複数タブ間で共有する `BleSharedBridge` 機能
 | `physical-reconnect-test.html` | 実機BLEの前回デバイス記憶・自動再接続・手動切り替え確認ページ |
 | `physical-range-test.html` | 物理的なBLE距離断・復帰時間・再接続試行回数の確認ページ |
 | `unit-test.html` | BleSharedBridge クラスの単体テスト（25ケース、実機不要） |
-| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（43ケース、実機不要） |
+| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（55ケース、実機不要） |
 | `test-frame.html` | テスト用の補助iframe |
 
 ## 実機での動作確認手順

--- a/examples/TEST-BRIDGE/README.md
+++ b/examples/TEST-BRIDGE/README.md
@@ -1,0 +1,53 @@
+# TEST-BRIDGE — BleSharedBridge 動作確認
+
+ORPHE COREのBLE接続を複数タブ間で共有する `BleSharedBridge` 機能の動作確認用サンプルです。
+
+## ファイル構成
+
+| ファイル | 用途 |
+|---------|------|
+| `index.html` | 実機BLEを使った動作確認ページ |
+| `unit-test.html` | BleSharedBridge クラスの単体テスト（25ケース、実機不要） |
+| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（17ケース、実機不要） |
+| `test-frame.html` | テスト用の補助iframe |
+
+## 実機での動作確認手順
+
+### 準備
+ローカルHTTPサーバーで配信してください（`file://`だとBroadcastChannelが動作しない場合があります）。
+
+```bash
+# プロジェクトルートで
+python3 -m http.server 8765
+```
+
+### テスト手順
+
+1. **Tab A を開く**: http://localhost:8765/examples/TEST-BRIDGE/index.html
+2. Tab A でスイッチをONにして ORPHE CORE に **BLE接続**
+   - バッジが「🔵 BLE接続中（Primary）」になることを確認
+   - センサーデータ（加速度、歩行方向、歩数）が表示される
+3. **Tab B を開く**（同じURL）
+4. Tab B でスイッチをONにする
+   - **BLEデバイス選択ダイアログは表示されない**
+   - バッジが「📡 共有接続中（Secondary）」になる
+   - Tab A と同じセンサーデータが Tab B にも流れる
+5. Tab A を閉じる / リロードする
+   - Tab B は自動で再接続を試みる（Fast Reconnect）
+   - ペアリング済みなら数秒でBLE接続に切り替わり Primary に昇格
+   - ペアリング情報がない場合は手動再接続が必要
+
+## 自動テスト
+
+BLE実機がなくても以下の2つのテストが実行可能：
+
+- 単体テスト: http://localhost:8765/examples/TEST-BRIDGE/unit-test.html
+- 統合テスト: http://localhost:8765/examples/TEST-BRIDGE/integration-test.html
+
+各ページで「テスト実行」ボタンを押すと、タブ間通信・LeaderElection・バッチ配信などを自動検証します。
+
+## ブラウザ要件
+
+- **Chrome 85+ 推奨**（Web Bluetooth + BroadcastChannel + navigator.bluetooth.getDevices が必要）
+- Edge、Opera も可
+- Firefox / Safari は Web Bluetooth 非対応のため動作しません

--- a/examples/TEST-BRIDGE/README.md
+++ b/examples/TEST-BRIDGE/README.md
@@ -9,7 +9,7 @@ ORPHE COREのBLE接続を複数タブ間で共有する `BleSharedBridge` 機能
 | `index.html` | 実機BLEを使った動作確認ページ |
 | `physical-reconnect-test.html` | 実機BLEの前回デバイス記憶・自動再接続・手動切り替え確認ページ |
 | `unit-test.html` | BleSharedBridge クラスの単体テスト（25ケース、実機不要） |
-| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（40ケース、実機不要） |
+| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（43ケース、実機不要） |
 | `test-frame.html` | テスト用の補助iframe |
 
 ## 実機での動作確認手順

--- a/examples/TEST-BRIDGE/README.md
+++ b/examples/TEST-BRIDGE/README.md
@@ -10,7 +10,7 @@ ORPHE COREのBLE接続を複数タブ間で共有する `BleSharedBridge` 機能
 | `physical-reconnect-test.html` | 実機BLEの前回デバイス記憶・自動再接続・手動切り替え確認ページ |
 | `physical-range-test.html` | 物理的なBLE距離断・復帰時間・再接続試行回数の確認ページ |
 | `unit-test.html` | BleSharedBridge クラスの単体テスト（25ケース、実機不要） |
-| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（55ケース、実機不要） |
+| `integration-test.html` | Orphe + BleSharedBridge の統合テスト（58ケース、実機不要） |
 | `test-frame.html` | テスト用の補助iframe |
 
 ## 実機での動作確認手順

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BLE Shared Bridge テスト</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <script src="../../js/ORPHE-CORE.js"></script>
+  <script src="../../js/BleSharedBridge.js"></script>
+  <script src="../../js/CoreToolkit.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"></script>
+  <style>
+    body { padding: 20px; background: #f8f9fa; }
+    .card { margin-bottom: 12px; }
+    .status-badge {
+      display: inline-block;
+      padding: 4px 12px;
+      border-radius: 20px;
+      font-size: 0.85em;
+      font-weight: bold;
+    }
+    .status-primary   { background: #d1e7dd; color: #0f5132; }
+    .status-secondary { background: #cfe2ff; color: #084298; }
+    .status-offline   { background: #e2e3e5; color: #41464b; }
+    .data-val { font-family: monospace; font-size: 1.1em; }
+    #log { height: 160px; overflow-y: auto; font-size: 0.78em; background: #212529; color: #adb5bd; padding: 8px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <div class="container-fluid" style="max-width:640px">
+    <h5 class="mb-3">BLE Shared Bridge テスト
+      <span id="mode_badge" class="status-badge status-offline ms-2">未接続</span>
+    </h5>
+
+    <div id="toolkit_placeholder"></div>
+
+    <div class="card">
+      <div class="card-body">
+        <div class="row g-2">
+          <div class="col-6">
+            <div class="card bg-light">
+              <div class="card-body py-2">
+                <small class="text-muted">加速度 X / Y / Z</small>
+                <div class="data-val" id="acc_val">-- / -- / --</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-6">
+            <div class="card bg-light">
+              <div class="card-body py-2">
+                <small class="text-muted">歩行方向</small>
+                <div class="data-val" id="dir_val">--</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-6">
+            <div class="card bg-light">
+              <div class="card-body py-2">
+                <small class="text-muted">歩数</small>
+                <div class="data-val" id="steps_val">--</div>
+              </div>
+            </div>
+          </div>
+          <div class="col-6">
+            <div class="card bg-light">
+              <div class="card-body py-2">
+                <small class="text-muted">Euler pitch / roll</small>
+                <div class="data-val" id="euler_val">-- / --</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-body py-2">
+        <small class="text-muted d-block mb-1">イベントログ</small>
+        <div id="log"></div>
+      </div>
+    </div>
+
+    <div class="alert alert-info py-2 mt-2" style="font-size:0.82em">
+      <b>使い方:</b> このページを2つのタブで開き、片方で接続ボタンをONにしてください。
+      もう一方のタブで同じボタンをONにすると、BLE接続なしに「共有接続中」でデータを受信します。
+    </div>
+  </div>
+
+  <script>
+    const DIR_NAMES = { 0: '左', 2: '前', 4: '後', 6: '右' };
+
+    function addLog(msg) {
+      const el = document.getElementById('log');
+      const t = new Date().toLocaleTimeString();
+      el.innerHTML = `<span class="text-warning">[${t}]</span> ${msg}<br>` + el.innerHTML;
+    }
+
+    function updateModeBadge() {
+      const badge = document.getElementById('mode_badge');
+      const ble = bles[0];
+      if (!ble) return;
+      if (ble._isBridgeSecondary) {
+        badge.className = 'status-badge status-secondary ms-2';
+        badge.textContent = '📡 共有接続中（Secondary）';
+      } else if (ble.bluetoothDevice && ble.bluetoothDevice.gatt.connected) {
+        badge.className = 'status-badge status-primary ms-2';
+        badge.textContent = '🔵 BLE接続中（Primary）';
+      } else {
+        badge.className = 'status-badge status-offline ms-2';
+        badge.textContent = '未接続';
+      }
+    }
+
+    buildCoreToolkit(
+      document.getElementById('toolkit_placeholder'),
+      'ORPHE CORE',
+      0,
+      'STEP_ANALYSIS_AND_SENSOR_VALUES'
+    );
+
+    window.onload = function () {
+      bles[0].setup();
+
+      bles[0].gotAcc = function (acc) {
+        document.getElementById('acc_val').textContent =
+          `${acc.x.toFixed(2)} / ${acc.y.toFixed(2)} / ${acc.z.toFixed(2)}`;
+      };
+
+      bles[0].gotGait = function (gait) {
+        document.getElementById('dir_val').textContent =
+          DIR_NAMES[gait.direction] ?? gait.direction;
+      };
+
+      bles[0].gotStepsNumber = function (s) {
+        document.getElementById('steps_val').textContent = s.value;
+      };
+
+      bles[0].gotEuler = function (euler) {
+        document.getElementById('euler_val').textContent =
+          `${(euler.pitch * 180 / Math.PI).toFixed(1)}° / ${(euler.roll * 180 / Math.PI).toFixed(1)}°`;
+      };
+
+      bles[0].onConnect = function (uuid) {
+        addLog(`接続: ${uuid}`);
+        updateModeBadge();
+      };
+
+      bles[0].onDisconnect = function () {
+        addLog('切断');
+        updateModeBadge();
+      };
+
+      bles[0].onError = function (err) {
+        addLog(`エラー: ${err}`);
+      };
+
+      // モードバッジを定期更新
+      setInterval(updateModeBadge, 2000);
+    };
+  </script>
+</body>
+</html>

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -89,7 +89,7 @@
     <div class="mt-3" style="font-size:0.85em">
       <b>自動テスト（実機不要）:</b>
       <a href="unit-test.html" class="badge bg-primary text-decoration-none">単体テスト (25)</a>
-      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (34)</a>
+      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (40)</a>
       <a href="physical-reconnect-test.html" class="badge bg-success text-decoration-none">実機再接続テスト</a>
       <a href="README.md" class="badge bg-secondary text-decoration-none">手順書</a>
     </div>

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -85,6 +85,13 @@
       <b>使い方:</b> このページを2つのタブで開き、片方で接続ボタンをONにしてください。
       もう一方のタブで同じボタンをONにすると、BLE接続なしに「共有接続中」でデータを受信します。
     </div>
+
+    <div class="mt-3" style="font-size:0.85em">
+      <b>自動テスト（実機不要）:</b>
+      <a href="unit-test.html" class="badge bg-primary text-decoration-none">単体テスト (25)</a>
+      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (17)</a>
+      <a href="README.md" class="badge bg-secondary text-decoration-none">手順書</a>
+    </div>
   </div>
 
   <script>

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -89,7 +89,7 @@
     <div class="mt-3" style="font-size:0.85em">
       <b>自動テスト（実機不要）:</b>
       <a href="unit-test.html" class="badge bg-primary text-decoration-none">単体テスト (25)</a>
-      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (40)</a>
+      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (43)</a>
       <a href="physical-reconnect-test.html" class="badge bg-success text-decoration-none">実機再接続テスト</a>
       <a href="README.md" class="badge bg-secondary text-decoration-none">手順書</a>
     </div>

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -89,7 +89,7 @@
     <div class="mt-3" style="font-size:0.85em">
       <b>自動テスト（実機不要）:</b>
       <a href="unit-test.html" class="badge bg-primary text-decoration-none">単体テスト (25)</a>
-      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (43)</a>
+      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (55)</a>
       <a href="physical-reconnect-test.html" class="badge bg-success text-decoration-none">実機再接続テスト</a>
       <a href="physical-range-test.html" class="badge bg-success text-decoration-none">距離断テスト</a>
       <a href="README.md" class="badge bg-secondary text-decoration-none">手順書</a>

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -91,6 +91,7 @@
       <a href="unit-test.html" class="badge bg-primary text-decoration-none">単体テスト (25)</a>
       <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (43)</a>
       <a href="physical-reconnect-test.html" class="badge bg-success text-decoration-none">実機再接続テスト</a>
+      <a href="physical-range-test.html" class="badge bg-success text-decoration-none">距離断テスト</a>
       <a href="README.md" class="badge bg-secondary text-decoration-none">手順書</a>
     </div>
   </div>

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -89,7 +89,7 @@
     <div class="mt-3" style="font-size:0.85em">
       <b>自動テスト（実機不要）:</b>
       <a href="unit-test.html" class="badge bg-primary text-decoration-none">単体テスト (25)</a>
-      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (55)</a>
+      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (58)</a>
       <a href="physical-reconnect-test.html" class="badge bg-success text-decoration-none">実機再接続テスト</a>
       <a href="physical-range-test.html" class="badge bg-success text-decoration-none">距離断テスト</a>
       <a href="README.md" class="badge bg-secondary text-decoration-none">手順書</a>

--- a/examples/TEST-BRIDGE/index.html
+++ b/examples/TEST-BRIDGE/index.html
@@ -89,7 +89,8 @@
     <div class="mt-3" style="font-size:0.85em">
       <b>自動テスト（実機不要）:</b>
       <a href="unit-test.html" class="badge bg-primary text-decoration-none">単体テスト (25)</a>
-      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (17)</a>
+      <a href="integration-test.html" class="badge bg-primary text-decoration-none">統合テスト (34)</a>
+      <a href="physical-reconnect-test.html" class="badge bg-success text-decoration-none">実機再接続テスト</a>
       <a href="README.md" class="badge bg-secondary text-decoration-none">手順書</a>
     </div>
   </div>

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -338,6 +338,41 @@
       ble7.forgetLastBluetoothDevice();
       assert(ble7._getLastBluetoothDeviceInfo() === null, 'forgetLastBluetoothDeviceで記憶を削除');
 
+      head('■ テスト12: 通常scanでも記憶済みデバイスを自動選択する');
+      const ble8 = new Orphe(DEVICE_ID);
+      ble8._rememberBluetoothDevice({ id: 'core-auto', name: 'CR-AUTO' });
+      let scanRequestDeviceCalled = false;
+      ble8.requestDevice = async function() {
+        scanRequestDeviceCalled = true;
+        throw new Error('requestDevice should not be called');
+      };
+      Object.defineProperty(navigator, 'bluetooth', {
+        configurable: true,
+        value: {
+          getDevices: async function() {
+            return [
+              { id: 'core-other', name: 'CR-OTHER', addEventListener: function() {} },
+              { id: 'core-auto', name: 'CR-AUTO', addEventListener: function() {} },
+            ];
+          },
+        },
+      });
+      await ble8.scan('DEVICE_INFORMATION');
+      assert(ble8.bluetoothDevice?.id === 'core-auto', 'scanで記憶済みidに一致するデバイスを選ぶ');
+      assert(scanRequestDeviceCalled === false, '記憶済みデバイスがあればrequestDeviceを呼ばない');
+
+      head('■ テスト13: 記憶削除後のscanは手動選択へフォールバックする');
+      ble8.bluetoothDevice = null;
+      ble8.forgetLastBluetoothDevice();
+      scanRequestDeviceCalled = false;
+      ble8.requestDevice = async function() {
+        scanRequestDeviceCalled = true;
+        this.bluetoothDevice = { id: 'core-manual', name: 'CR-MANUAL', addEventListener: function() {} };
+      };
+      await ble8.scan('DEVICE_INFORMATION');
+      assert(scanRequestDeviceCalled === true, '記憶削除後はrequestDeviceを呼ぶ');
+      assert(ble8.bluetoothDevice?.id === 'core-manual', '手動選択したデバイスへ切り替えられる');
+
       Math.random = originalRandom;
       if (hadBluetooth) {
         Object.defineProperty(navigator, 'bluetooth', { configurable: true, value: originalBluetooth });

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -153,9 +153,12 @@
       assert(receivedGait !== null && receivedGait.direction === 4, 'ble.gotGaitが正しいデータで呼ばれる');
 
       head('■ テスト4: reset() でBridgeがリリースされる');
+      let secondaryResetError = null;
+      ble2.onError = function(error) { secondaryResetError = error; };
       ble2.reset();
       assert(ble2._bridge === null, 'reset後、_bridgeがnull');
       assert(ble2._isBridgeSecondary === false, 'reset後、_isBridgeSecondary=false');
+      assert(secondaryResetError === null, 'SecondaryのresetでBLE未接続エラーを出さない');
 
       head('■ テスト5: Primary側の_notifyBridgeBatchが配信される');
       // ble3 を Primary として直接セットアップ
@@ -197,6 +200,79 @@
       ble3._notifyBridgeBatch({ gotAcc: { x: 99, y: 99, z: 99 } });
       await wait(100);
       assert(selfLoopback === false, 'Primaryは自身の送信したbroadcastで自gotAccを発火させない');
+
+      head('■ テスト7: begin()再実行で古いPrimary Bridgeを解放する');
+      ble3._bridge?.release();
+      ble3._bridge = null;
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      await wait(50);
+
+      const ble4 = new Orphe(DEVICE_ID);
+      ble4.bluetoothDevice = {
+        gatt: { connected: true, disconnect: function() { this.connected = false; } },
+        addEventListener: function() {},
+      };
+      ble4.getDeviceInformation = async function() {
+        return {
+          lr: 0,
+          led_brightness: 0,
+          rec_auto_run: 0,
+          range: { acc: 0, gyro: 0 },
+        };
+      };
+      ble4.setDeviceInformation = async function() {};
+      ble4.syncCoreTime = async function() {};
+      ble4.startNotify = async function() {};
+
+      await ble4.begin('STEP_ANALYSIS');
+      const firstBridge = ble4._bridge;
+      assert(firstBridge && firstBridge.isPrimary === true, '1回目のbeginでPrimary Bridgeを作成');
+
+      await ble4.begin('STEP_ANALYSIS');
+      assert(ble4._bridge !== firstBridge, '2回目のbeginでBridgeを差し替える');
+      assert(firstBridge.isPrimary === false, '古いBridgeはPrimary状態を解除済み');
+      assert(firstBridge._heartbeatInterval === null, '古いBridgeのheartbeat intervalを停止済み');
+      ble4._bridge?.release();
+      ble4._bridge = null;
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+
+      head('■ テスト8: Fast Reconnectは複数候補を自動選択しない');
+      const ble5 = new Orphe(DEVICE_ID);
+      ble5._isBridgeSecondary = true;
+      ble5._bridge = new BleSharedBridge(DEVICE_ID);
+      let reconnectError = null;
+      let reconnectDisconnectCalled = false;
+      ble5.onDisconnect = function() { reconnectDisconnectCalled = true; };
+      ble5.onError = function(error) { reconnectError = error; };
+
+      const originalRandom = Math.random;
+      const hadBluetooth = Object.prototype.hasOwnProperty.call(navigator, 'bluetooth');
+      const originalBluetooth = navigator.bluetooth;
+      Math.random = function() { return 0; };
+      Object.defineProperty(navigator, 'bluetooth', {
+        configurable: true,
+        value: {
+          getDevices: async function() {
+            return [
+              { name: 'CR-1', addEventListener: function() {} },
+              { name: 'CR-2', addEventListener: function() {} },
+            ];
+          },
+        },
+      });
+
+      await ble5._handlePrimaryLost('STEP_ANALYSIS');
+      assert(reconnectDisconnectCalled === true, 'Primary喪失時にonDisconnectを通知');
+      assert(ble5.bluetoothDevice === null, '複数候補ではbluetoothDeviceを自動選択しない');
+      assert(reconnectError === 'Multiple paired devices found. Please reconnect manually.',
+        '複数候補では手動再接続を促す');
+
+      Math.random = originalRandom;
+      if (hadBluetooth) {
+        Object.defineProperty(navigator, 'bluetooth', { configurable: true, value: originalBluetooth });
+      } else {
+        delete navigator.bluetooth;
+      }
 
       head('■ クリーンアップ');
       ble3._bridge?.release();

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -267,6 +267,77 @@
       assert(reconnectError === 'Multiple paired devices found. Please reconnect manually.',
         '複数候補では手動再接続を促す');
 
+      head('■ テスト9: 接続成功時に最後のBluetoothデバイスを記憶する');
+      const ble6 = new Orphe(DEVICE_ID);
+      ble6.bluetoothDevice = {
+        id: 'core-left',
+        name: 'CR-L',
+        gatt: { connected: true, disconnect: function() { this.connected = false; } },
+        addEventListener: function() {},
+      };
+      ble6.getDeviceInformation = async function() {
+        return {
+          lr: 0,
+          led_brightness: 0,
+          rec_auto_run: 0,
+          range: { acc: 0, gyro: 0 },
+        };
+      };
+      ble6.setDeviceInformation = async function() {};
+      ble6.syncCoreTime = async function() {};
+      ble6.startNotify = async function() {};
+
+      await ble6.begin('STEP_ANALYSIS');
+      const remembered = ble6._getLastBluetoothDeviceInfo();
+      assert(remembered?.bluetoothId === 'core-left', '接続成功したBluetooth idを保存');
+      assert(remembered?.bluetoothName === 'CR-L', '接続成功したBluetooth nameを保存');
+      ble6._bridge?.release();
+      ble6._bridge = null;
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+
+      head('■ テスト10: 複数候補でも記憶済みデバイスへ自動再接続する');
+      const ble7 = new Orphe(DEVICE_ID);
+      ble7._rememberBluetoothDevice({ id: 'core-right', name: 'CR-R' });
+      ble7._isBridgeSecondary = true;
+      ble7._bridge = new BleSharedBridge(DEVICE_ID);
+      let rememberedReconnectError = null;
+      ble7.onError = function(error) { rememberedReconnectError = error; };
+      ble7.onDisconnect = function() {};
+      ble7.getDeviceInformation = async function() {
+        return {
+          lr: 0,
+          led_brightness: 0,
+          rec_auto_run: 0,
+          range: { acc: 0, gyro: 0 },
+        };
+      };
+      ble7.setDeviceInformation = async function() {};
+      ble7.syncCoreTime = async function() {};
+      ble7.startNotify = async function() {};
+
+      Object.defineProperty(navigator, 'bluetooth', {
+        configurable: true,
+        value: {
+          getDevices: async function() {
+            return [
+              { id: 'core-left', name: 'CR-L', addEventListener: function() {} },
+              { id: 'core-right', name: 'CR-R', addEventListener: function() {} },
+            ];
+          },
+        },
+      });
+
+      await ble7._handlePrimaryLost('STEP_ANALYSIS');
+      assert(ble7.bluetoothDevice?.id === 'core-right', '記憶済みidに一致するデバイスを選ぶ');
+      assert(rememberedReconnectError === null, '記憶済みデバイスがあれば複数候補でもエラーにしない');
+      ble7._bridge?.release();
+      ble7._bridge = null;
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+
+      head('■ テスト11: 記憶を消すと複数候補は手動選択に戻る');
+      ble7.forgetLastBluetoothDevice();
+      assert(ble7._getLastBluetoothDeviceInfo() === null, 'forgetLastBluetoothDeviceで記憶を削除');
+
       Math.random = originalRandom;
       if (hadBluetooth) {
         Object.defineProperty(navigator, 'bluetooth', { configurable: true, value: originalBluetooth });
@@ -280,6 +351,7 @@
       await iframeCall('release');
       iframe.remove();
       localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      localStorage.removeItem(`orphe_last_bluetooth_device_${DEVICE_ID}`);
       log('  OK');
     }
 

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -370,7 +370,25 @@
       await ble8.scan('DATE_TIME');
       assert(scanRequestDeviceCalled === false, 'bluetoothDevice保持中はrequestDeviceを呼ばない');
 
-      head('■ テスト14: 記憶削除後のscanは手動選択へフォールバックする');
+      head('■ テスト14: 記憶済みデバイス接続失敗後は次回手動選択へ戻る');
+      ble8.bluetoothDevice = {
+        id: 'core-auto',
+        name: 'CR-AUTO',
+        gatt: {
+          connected: false,
+          connect: async function() { throw new Error('remembered device unavailable'); },
+        },
+        addEventListener: function() {},
+      };
+      ble8._usingRememberedBluetoothDevice = true;
+      let rememberedConnectError = null;
+      ble8.onError = function(error) { rememberedConnectError = error; };
+      try { await ble8.connectGATT('DEVICE_INFORMATION'); } catch (_) {}
+      assert(rememberedConnectError !== null, '記憶済みデバイスの接続失敗を通知');
+      assert(ble8._rememberedBluetoothDeviceUnavailable === true, '記憶済みデバイスを一時的に利用不可として扱う');
+      assert(ble8.bluetoothDevice === null, '失敗した保持デバイスをクリア');
+
+      head('■ テスト15: 記憶削除後のscanは手動選択へフォールバックする');
       ble8.bluetoothDevice = null;
       ble8.forgetLastBluetoothDevice();
       scanRequestDeviceCalled = false;
@@ -395,7 +413,7 @@
       assert(scanGetDevicesCalled === false, '記憶がない初回接続ではgetDevicesを先に呼ばない');
       assert(ble8.bluetoothDevice?.id === 'core-manual', '手動選択したデバイスへ切り替えられる');
 
-      head('■ テスト15: selectBluetoothDeviceは接続中でも手動選択へ切り替える');
+      head('■ テスト16: selectBluetoothDeviceは接続中でも手動選択へ切り替える');
       ble8._rememberBluetoothDevice({ id: 'core-manual', name: 'CR-MANUAL' });
       ble8._bridge = new BleSharedBridge(DEVICE_ID);
       ble8._bridge.claimPrimary();

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -267,7 +267,40 @@
       assert(reconnectError === 'Multiple paired devices found. Please reconnect manually.',
         '複数候補では手動再接続を促す');
 
-      head('■ テスト9: 接続成功時に最後のBluetoothデバイスを記憶する');
+      head('■ テスト9: 手動選択済みデバイスがあれば複数候補でも引き継ぐ');
+      const ble5b = new Orphe(DEVICE_ID);
+      ble5b._isBridgeSecondary = true;
+      ble5b._bridge = new BleSharedBridge(DEVICE_ID);
+      ble5b.bluetoothDevice = { id: 'core-selected', name: 'CR-SELECTED', addEventListener: function() {} };
+      let selectedReconnectError = null;
+      let selectedReconnectType = null;
+      ble5b.onDisconnect = function() {};
+      ble5b.onError = function(error) { selectedReconnectError = error; };
+      ble5b.begin = async function(str_type) {
+        selectedReconnectType = str_type;
+        return 'done begin(); STEP ANALYSIS';
+      };
+      localStorage.removeItem(`orphe_last_bluetooth_device_${DEVICE_ID}`);
+      Object.defineProperty(navigator, 'bluetooth', {
+        configurable: true,
+        value: {
+          getDevices: async function() {
+            return [
+              { id: 'core-other', name: 'CR-OTHER', addEventListener: function() {} },
+              { id: 'core-selected', name: 'CR-SELECTED', addEventListener: function() {} },
+            ];
+          },
+        },
+      });
+      await ble5b._handlePrimaryLost('STEP_ANALYSIS');
+      assert(ble5b.bluetoothDevice?.id === 'core-selected', '手動選択済みidに一致するデバイスを選ぶ');
+      assert(selectedReconnectType === 'STEP_ANALYSIS', '手動選択済みデバイスでbeginを再実行する');
+      assert(selectedReconnectError === null, '手動選択済みデバイスがあれば複数候補エラーにしない');
+      ble5b._bridge?.release();
+      ble5b._bridge = null;
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+
+      head('■ テスト10: 接続成功時に最後のBluetoothデバイスを記憶する');
       const ble6 = new Orphe(DEVICE_ID);
       ble6.bluetoothDevice = {
         id: 'core-left',
@@ -295,7 +328,7 @@
       ble6._bridge = null;
       localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
 
-      head('■ テスト10: 複数候補でも記憶済みデバイスへ自動再接続する');
+      head('■ テスト11: 複数候補でも記憶済みデバイスへ自動再接続する');
       const ble7 = new Orphe(DEVICE_ID);
       ble7._rememberBluetoothDevice({ id: 'core-right', name: 'CR-R' });
       ble7._isBridgeSecondary = true;
@@ -334,11 +367,11 @@
       ble7._bridge = null;
       localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
 
-      head('■ テスト11: 記憶を消すと複数候補は手動選択に戻る');
+      head('■ テスト12: 記憶を消すと複数候補は手動選択に戻る');
       ble7.forgetLastBluetoothDevice();
       assert(ble7._getLastBluetoothDeviceInfo() === null, 'forgetLastBluetoothDeviceで記憶を削除');
 
-      head('■ テスト12: 通常scanでも記憶済みデバイスを自動選択する');
+      head('■ テスト13: 通常scanでも記憶済みデバイスを自動選択する');
       const ble8 = new Orphe(DEVICE_ID);
       ble8._rememberBluetoothDevice({ id: 'core-auto', name: 'CR-AUTO' });
       let scanRequestDeviceCalled = false;
@@ -361,7 +394,7 @@
       assert(ble8.bluetoothDevice?.id === 'core-auto', 'scanで記憶済みidに一致するデバイスを選ぶ');
       assert(scanRequestDeviceCalled === false, '記憶済みデバイスがあればrequestDeviceを呼ばない');
 
-      head('■ テスト13: 接続済みscanは追加のBLE選択を行わない');
+      head('■ テスト14: 接続済みscanは追加のBLE選択を行わない');
       ble8.requestDevice = async function() {
         scanRequestDeviceCalled = true;
         throw new Error('requestDevice should not be called');
@@ -370,7 +403,7 @@
       await ble8.scan('DATE_TIME');
       assert(scanRequestDeviceCalled === false, 'bluetoothDevice保持中はrequestDeviceを呼ばない');
 
-      head('■ テスト14: 記憶済みデバイス接続失敗後は次回手動選択へ戻る');
+      head('■ テスト15: 記憶済みデバイス接続失敗後は次回手動選択へ戻る');
       ble8.bluetoothDevice = {
         id: 'core-auto',
         name: 'CR-AUTO',
@@ -388,7 +421,7 @@
       assert(ble8._rememberedBluetoothDeviceUnavailable === true, '記憶済みデバイスを一時的に利用不可として扱う');
       assert(ble8.bluetoothDevice === null, '失敗した保持デバイスをクリア');
 
-      head('■ テスト15: 記憶削除後のscanは手動選択へフォールバックする');
+      head('■ テスト16: 記憶削除後のscanは手動選択へフォールバックする');
       ble8.bluetoothDevice = null;
       ble8.forgetLastBluetoothDevice();
       scanRequestDeviceCalled = false;
@@ -413,7 +446,7 @@
       assert(scanGetDevicesCalled === false, '記憶がない初回接続ではgetDevicesを先に呼ばない');
       assert(ble8.bluetoothDevice?.id === 'core-manual', '手動選択したデバイスへ切り替えられる');
 
-      head('■ テスト16: selectBluetoothDeviceは接続中でも手動選択へ切り替える');
+      head('■ テスト17: selectBluetoothDeviceは接続中でも手動選択へ切り替える');
       ble8._rememberBluetoothDevice({ id: 'core-manual', name: 'CR-MANUAL' });
       ble8._bridge = new BleSharedBridge(DEVICE_ID);
       ble8._bridge.claimPrimary();
@@ -435,7 +468,7 @@
       assert(ble8.bluetoothDevice?.id === 'core-switched', 'selectBluetoothDeviceで選んだ別デバイスを保持');
       localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
 
-      head('■ テスト17: autoReconnectはbegin()のopt-in時だけ有効');
+      head('■ テスト18: autoReconnectはbegin()のopt-in時だけ有効');
       const ble9 = new Orphe(DEVICE_ID);
       ble9.bluetoothDevice = { id: 'core-no-auto', name: 'CR-NO-AUTO', gatt: { connected: false }, addEventListener: function() {} };
       ble9.getDeviceInformation = async function() {
@@ -455,7 +488,7 @@
       ble9._bridge = null;
       localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
 
-      head('■ テスト18: autoReconnect opt-inは設定と切断ハンドラを保持する');
+      head('■ テスト19: autoReconnect opt-inは設定と切断ハンドラを保持する');
       const ble10 = new Orphe(DEVICE_ID);
       const autoEvents = [];
       ble10.bluetoothDevice = {
@@ -487,7 +520,7 @@
       ble10._bridge = null;
       localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
 
-      head('■ テスト19: autoReconnect loopは失敗後に再試行して成功通知する');
+      head('■ テスト20: autoReconnect loopは失敗後に再試行して成功通知する');
       const ble11 = new Orphe(DEVICE_ID);
       ble11.bluetoothDevice = { id: 'core-loop', name: 'CR-LOOP', gatt: { connected: false }, addEventListener: function() {} };
       ble11._enableAutoReconnect('STEP_ANALYSIS', { autoReconnect: true, reconnectIntervalMs: 1, reconnectMaxAttempts: 3 });

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -435,6 +435,86 @@
       assert(ble8.bluetoothDevice?.id === 'core-switched', 'selectBluetoothDeviceで選んだ別デバイスを保持');
       localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
 
+      head('■ テスト17: autoReconnectはbegin()のopt-in時だけ有効');
+      const ble9 = new Orphe(DEVICE_ID);
+      ble9.bluetoothDevice = { id: 'core-no-auto', name: 'CR-NO-AUTO', gatt: { connected: false }, addEventListener: function() {} };
+      ble9.getDeviceInformation = async function() {
+        return {
+          lr: 0,
+          led_brightness: 0,
+          rec_auto_run: 0,
+          range: { acc: 0, gyro: 0 },
+        };
+      };
+      ble9.setDeviceInformation = async function() {};
+      ble9.syncCoreTime = async function() {};
+      ble9.startNotify = async function() {};
+      await ble9.begin('STEP_ANALYSIS');
+      assert(ble9._autoReconnectEnabled === false, '通常begin()ではautoReconnectを有効化しない');
+      ble9._bridge?.release();
+      ble9._bridge = null;
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+
+      head('■ テスト18: autoReconnect opt-inは設定と切断ハンドラを保持する');
+      const ble10 = new Orphe(DEVICE_ID);
+      const autoEvents = [];
+      ble10.bluetoothDevice = {
+        id: 'core-auto-reconnect',
+        name: 'CR-AUTO-RECONNECT',
+        gatt: { connected: false },
+        addEventListener: function(name) { autoEvents.push(name); },
+        removeEventListener: function() {},
+      };
+      ble10.getDeviceInformation = async function() {
+        return {
+          lr: 0,
+          led_brightness: 0,
+          rec_auto_run: 0,
+          range: { acc: 0, gyro: 0 },
+        };
+      };
+      ble10.setDeviceInformation = async function() {};
+      ble10.syncCoreTime = async function() {};
+      ble10.startNotify = async function() {};
+      await ble10.begin('STEP_ANALYSIS', { autoReconnect: true, reconnectIntervalMs: 5, reconnectMaxAttempts: 3 });
+      assert(ble10._autoReconnectEnabled === true, 'autoReconnect:trueで有効化する');
+      assert(ble10._autoReconnectNotificationType === 'STEP_ANALYSIS', '再接続時の通知タイプを保持する');
+      assert(ble10._autoReconnectOptions.reconnectIntervalMs === 5, '再接続間隔を保持する');
+      assert(autoEvents.includes('gattserverdisconnected'), 'GATT切断ハンドラを登録する');
+      ble10.reset();
+      assert(ble10._autoReconnectEnabled === false, 'reset()でautoReconnectを停止する');
+      ble10._bridge?.release();
+      ble10._bridge = null;
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+
+      head('■ テスト19: autoReconnect loopは失敗後に再試行して成功通知する');
+      const ble11 = new Orphe(DEVICE_ID);
+      ble11.bluetoothDevice = { id: 'core-loop', name: 'CR-LOOP', gatt: { connected: false }, addEventListener: function() {} };
+      ble11._enableAutoReconnect('STEP_ANALYSIS', { autoReconnect: true, reconnectIntervalMs: 1, reconnectMaxAttempts: 3 });
+      let reconnectBeginCalls = 0;
+      const reconnectTypes = [];
+      const reconnectOptions = [];
+      let reconnectAttemptCount = 0;
+      let reconnectSuccessInfo = null;
+      let autoReconnectLoopError = null;
+      ble11.begin = async function(str_type, options) {
+        reconnectBeginCalls++;
+        reconnectTypes.push(str_type);
+        reconnectOptions.push(options);
+        if (reconnectBeginCalls < 2) return;
+        return 'done begin(); STEP ANALYSIS';
+      };
+      ble11.onReconnectAttempt = function(info) { reconnectAttemptCount = info.attempt; };
+      ble11.onReconnectSuccess = function(info) { reconnectSuccessInfo = info; };
+      ble11.onError = function(error) { autoReconnectLoopError = error; };
+      await ble11._startAutoReconnect();
+      assert(reconnectBeginCalls === 2, '1回失敗後に再試行する');
+      assert(reconnectTypes.every(type => type === 'STEP_ANALYSIS'), '再接続時に前回通知タイプを使う');
+      assert(reconnectOptions.every(options => options.autoReconnect === true), '再接続時もautoReconnect設定を維持する');
+      assert(reconnectAttemptCount === 2, '再接続試行イベントを更新する');
+      assert(reconnectSuccessInfo?.attempt === 2, '成功イベントに成功試行回数を渡す');
+      assert(autoReconnectLoopError === null, '成功時はonErrorを出さない');
+
       Math.random = originalRandom;
       if (hadBluetooth) {
         Object.defineProperty(navigator, 'bluetooth', { configurable: true, value: originalBluetooth });

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>Orphe + BleSharedBridge 統合テスト</title>
+  <style>
+    body { font-family: -apple-system, system-ui, sans-serif; padding: 20px; max-width: 900px; margin: 0 auto; background: #f8f9fa; }
+    h1 { font-size: 1.3em; }
+    #results { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; padding: 16px; font-family: "SF Mono", Menlo, monospace; font-size: 0.88em; white-space: pre-wrap; }
+    .pass { color: #0f5132; }
+    .fail { color: #842029; font-weight: bold; }
+    .info { color: #6c757d; }
+    .head { color: #084298; font-weight: bold; margin-top: 10px; }
+    .summary { margin-top: 20px; padding: 12px; border-radius: 6px; }
+    .ok   { background: #d1e7dd; color: #0f5132; }
+    .ng   { background: #f8d7da; color: #842029; }
+    button { padding: 8px 20px; background: #0d6efd; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 1em; }
+  </style>
+</head>
+<body>
+  <h1>🧪 Orphe + BleSharedBridge 統合テスト</h1>
+  <p>Orpheクラスのbegin()・reset()・onReadブロードキャストとBleSharedBridgeの連携を検証します。</p>
+
+  <button id="run_btn">テスト実行</button>
+  <div id="summary" class="summary" style="display:none"></div>
+  <pre id="results"></pre>
+
+  <script src="../../js/float16.min.js"></script>
+  <script src="../../js/quaternion.js"></script>
+  <script src="../../js/BleSharedBridge.js"></script>
+  <script src="../../js/ORPHE-CORE.js"></script>
+
+  <script>
+    const DEVICE_ID = 77;
+    const resultsEl = document.getElementById('results');
+    const summaryEl = document.getElementById('summary');
+    let passed = 0, failed = 0;
+
+    function log(msg, cls='info') {
+      const l = document.createElement('div');
+      l.className = cls;
+      l.textContent = msg;
+      resultsEl.appendChild(l);
+    }
+    const head = (m) => log(m, 'head');
+    const assert = (c, m) => {
+      if (c) { log('  ✓ ' + m, 'pass'); passed++; }
+      else   { log('  ✗ ' + m, 'fail'); failed++; }
+    };
+    const wait = (ms) => new Promise(r => setTimeout(r, ms));
+
+    async function runAll() {
+      resultsEl.innerHTML = '';
+      summaryEl.style.display = 'none';
+      passed = 0; failed = 0;
+      try { await runTests(); }
+      catch (err) { log('実行エラー: ' + err.message + '\n' + err.stack, 'fail'); failed++; }
+
+      const marker = document.createElement('div');
+      marker.id = 'test_complete_marker';
+      marker.setAttribute('data-passed', String(passed));
+      marker.setAttribute('data-failed', String(failed));
+      document.body.appendChild(marker);
+      document.title = failed === 0 ? `PASS ${passed}/${passed}` : `FAIL ${failed}/${passed+failed}`;
+
+      summaryEl.style.display = 'block';
+      if (failed === 0) {
+        summaryEl.className = 'summary ok';
+        summaryEl.textContent = `✓ 全 ${passed} テストがパスしました`;
+      } else {
+        summaryEl.className = 'summary ng';
+        summaryEl.textContent = `✗ ${passed} passed / ${failed} failed`;
+      }
+    }
+
+    async function runTests() {
+      head('■ テスト1: OrpheクラスのBridge関連プロパティ初期化');
+      const ble = new Orphe(DEVICE_ID);
+      assert(ble._bridge === null, '初期状態で_bridge = null');
+      assert(ble._isBridgeSecondary === false, '初期状態で_isBridgeSecondary = false');
+      assert(typeof ble._notifyBridge === 'function', '_notifyBridgeメソッドが存在');
+      assert(typeof ble._notifyBridgeBatch === 'function', '_notifyBridgeBatchメソッドが存在');
+      assert(typeof ble._beginAsSecondary === 'function', '_beginAsSecondaryメソッドが存在');
+      assert(typeof ble._handlePrimaryLost === 'function', '_handlePrimaryLostメソッドが存在');
+
+      head('■ テスト2: Secondary自動判定 (Primaryが存在する場合)');
+      // 別タブが Primary である状態を localStorage に偽装
+      const fakePrimary = {
+        timestamp: Date.now(),
+        tabId: 'FAKE_PRIMARY_TAB_' + Math.random().toString(36).slice(2),
+      };
+      localStorage.setItem(`orphe_bridge_primary_${DEVICE_ID}`, JSON.stringify(fakePrimary));
+
+      // Orpheのbegin()はBLE接続せずSecondaryとして起動するはず
+      const ble2 = new Orphe(DEVICE_ID);
+      const result = await ble2.begin('STEP_ANALYSIS');
+      assert(typeof result === 'string' && result.includes('BRIDGE SECONDARY'),
+        'begin()が"BRIDGE SECONDARY"を返す (actual: ' + result + ')');
+      assert(ble2._isBridgeSecondary === true, 'Secondary モードフラグがtrue');
+      assert(ble2._bridge !== null, '_bridge にインスタンスが設定される');
+      assert(ble2.bluetoothDevice === null, 'BLE接続は行われない (bluetoothDevice === null)');
+
+      head('■ テスト3: Secondaryがブロードキャストを受信してコールバック発火');
+      let receivedAcc = null, receivedGait = null;
+      ble2.gotAcc = function(acc) { receivedAcc = acc; };
+      ble2.gotGait = function(gait) { receivedGait = gait; };
+
+      // 別タブの Primary がブロードキャストする動作を iframe で再現
+      const iframe = document.createElement('iframe');
+      iframe.src = 'test-frame.html';
+      iframe.style.display = 'none';
+      document.body.appendChild(iframe);
+      await new Promise(resolve => {
+        const h = (e) => {
+          if (e.source === iframe.contentWindow && e.data?.id === 'ready') {
+            window.removeEventListener('message', h);
+            resolve();
+          }
+        };
+        window.addEventListener('message', h);
+      });
+
+      let callId = 0;
+      async function iframeCall(action, args={}) {
+        const id = 'int_' + callId++;
+        return new Promise(resolve => {
+          const h = (e) => {
+            if (e.source === iframe.contentWindow && e.data?.id === id) {
+              window.removeEventListener('message', h);
+              resolve(e.data.result);
+            }
+          };
+          window.addEventListener('message', h);
+          iframe.contentWindow.postMessage({ id, action, args }, '*');
+        });
+      }
+
+      // 偽装していた localStorage を削除してから実在のPrimaryを作る
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      await iframeCall('create', { deviceId: DEVICE_ID });
+      await iframeCall('claimPrimary');
+      await wait(100);
+
+      await iframeCall('broadcastBatch', {
+        batch: {
+          gotAcc:  { x: 7.7, y: 8.8, z: 9.9 },
+          gotGait: { direction: 4, steps: 99 },
+        }
+      });
+      await wait(150);
+
+      assert(receivedAcc !== null && receivedAcc.x === 7.7, 'ble.gotAccが正しいデータで呼ばれる');
+      assert(receivedGait !== null && receivedGait.direction === 4, 'ble.gotGaitが正しいデータで呼ばれる');
+
+      head('■ テスト4: reset() でBridgeがリリースされる');
+      ble2.reset();
+      assert(ble2._bridge === null, 'reset後、_bridgeがnull');
+      assert(ble2._isBridgeSecondary === false, 'reset後、_isBridgeSecondary=false');
+
+      head('■ テスト5: Primary側の_notifyBridgeBatchが配信される');
+      // ble3 を Primary として直接セットアップ
+      await iframeCall('release');
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      await wait(50);
+
+      const ble3 = new Orphe(DEVICE_ID);
+      ble3._bridge = new BleSharedBridge(DEVICE_ID);
+      ble3._bridge.claimPrimary();
+      await wait(50);
+
+      // 別タブ(iframe)をSecondaryとして購読させる
+      await iframeCall('create', { deviceId: DEVICE_ID });
+      await iframeCall('subscribeAsSecondary');
+      await wait(100);
+      await iframeCall('clearReceived');
+
+      // Orpheの_notifyBridgeBatch呼び出しを再現
+      ble3._notifyBridgeBatch({
+        gotAcc: { x: 1, y: 2, z: 3 },
+        gotGyro: { x: 4, y: 5, z: 6 },
+      });
+      await wait(150);
+
+      const received = await iframeCall('getReceived');
+      assert(received.some(r => r.cb === 'gotAcc' && r.data.x === 1), 'Secondaryが gotAcc を受信');
+      // gotGyro は test-frame に登録していないので届かない想定だが、エラーにならない
+      assert(received.filter(r => r.cb === 'gotAcc').length === 1, '重複なく1回だけ受信');
+
+      head('■ テスト6: Primaryのbroadcastは自Secondary(同タブ内)には届かない');
+      // BroadcastChannelは自ページには送信しない仕様
+      // ble3 は Primary、同じタブに別の Orphe Secondary は作れないが、
+      // Primary自身が送ったデータは自分では受信しないことを間接的に確認
+      let selfLoopback = false;
+      const ble3OrigGotAcc = ble3.gotAcc;
+      ble3.gotAcc = function(d) { selfLoopback = true; if (ble3OrigGotAcc) ble3OrigGotAcc(d); };
+
+      ble3._notifyBridgeBatch({ gotAcc: { x: 99, y: 99, z: 99 } });
+      await wait(100);
+      assert(selfLoopback === false, 'Primaryは自身の送信したbroadcastで自gotAccを発火させない');
+
+      head('■ クリーンアップ');
+      ble3._bridge?.release();
+      ble3._bridge = null;
+      await iframeCall('release');
+      iframe.remove();
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      log('  OK');
+    }
+
+    document.getElementById('run_btn').addEventListener('click', async (e) => {
+      e.target.disabled = true;
+      await runAll();
+      e.target.disabled = false;
+    });
+
+    if (new URLSearchParams(location.search).has('autorun')) {
+      window.addEventListener('load', () => runAll());
+    }
+  </script>
+</body>
+</html>

--- a/examples/TEST-BRIDGE/integration-test.html
+++ b/examples/TEST-BRIDGE/integration-test.html
@@ -361,17 +361,61 @@
       assert(ble8.bluetoothDevice?.id === 'core-auto', 'scanで記憶済みidに一致するデバイスを選ぶ');
       assert(scanRequestDeviceCalled === false, '記憶済みデバイスがあればrequestDeviceを呼ばない');
 
-      head('■ テスト13: 記憶削除後のscanは手動選択へフォールバックする');
+      head('■ テスト13: 接続済みscanは追加のBLE選択を行わない');
+      ble8.requestDevice = async function() {
+        scanRequestDeviceCalled = true;
+        throw new Error('requestDevice should not be called');
+      };
+      scanRequestDeviceCalled = false;
+      await ble8.scan('DATE_TIME');
+      assert(scanRequestDeviceCalled === false, 'bluetoothDevice保持中はrequestDeviceを呼ばない');
+
+      head('■ テスト14: 記憶削除後のscanは手動選択へフォールバックする');
       ble8.bluetoothDevice = null;
       ble8.forgetLastBluetoothDevice();
       scanRequestDeviceCalled = false;
+      let scanGetDevicesCalled = false;
       ble8.requestDevice = async function() {
         scanRequestDeviceCalled = true;
         this.bluetoothDevice = { id: 'core-manual', name: 'CR-MANUAL', addEventListener: function() {} };
       };
+      Object.defineProperty(navigator, 'bluetooth', {
+        configurable: true,
+        value: {
+          getDevices: async function() {
+            scanGetDevicesCalled = true;
+            return [
+              { id: 'core-auto', name: 'CR-AUTO', addEventListener: function() {} },
+            ];
+          },
+        },
+      });
       await ble8.scan('DEVICE_INFORMATION');
       assert(scanRequestDeviceCalled === true, '記憶削除後はrequestDeviceを呼ぶ');
+      assert(scanGetDevicesCalled === false, '記憶がない初回接続ではgetDevicesを先に呼ばない');
       assert(ble8.bluetoothDevice?.id === 'core-manual', '手動選択したデバイスへ切り替えられる');
+
+      head('■ テスト15: selectBluetoothDeviceは接続中でも手動選択へ切り替える');
+      ble8._rememberBluetoothDevice({ id: 'core-manual', name: 'CR-MANUAL' });
+      ble8._bridge = new BleSharedBridge(DEVICE_ID);
+      ble8._bridge.claimPrimary();
+      ble8.bluetoothDevice = {
+        id: 'core-manual',
+        name: 'CR-MANUAL',
+        gatt: { connected: true, disconnect: function() { this.connected = false; } },
+        addEventListener: function() {},
+      };
+      let selectRequestDeviceCalled = false;
+      ble8.requestDevice = async function() {
+        selectRequestDeviceCalled = true;
+        this.bluetoothDevice = { id: 'core-switched', name: 'CR-SWITCHED', addEventListener: function() {} };
+      };
+      await ble8.selectBluetoothDevice('DEVICE_INFORMATION');
+      assert(selectRequestDeviceCalled === true, 'selectBluetoothDeviceはrequestDeviceを呼ぶ');
+      assert(ble8._bridge === null, 'selectBluetoothDeviceで既存Bridgeを解放');
+      assert(ble8._getLastBluetoothDeviceInfo() === null, 'selectBluetoothDeviceで古い記憶を削除');
+      assert(ble8.bluetoothDevice?.id === 'core-switched', 'selectBluetoothDeviceで選んだ別デバイスを保持');
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
 
       Math.random = originalRandom;
       if (hadBluetooth) {

--- a/examples/TEST-BRIDGE/physical-range-test.html
+++ b/examples/TEST-BRIDGE/physical-range-test.html
@@ -161,7 +161,6 @@
     const ble = new Orphe(0);
     let isTesting = false;
     let isReconnecting = false;
-    let reconnectTimer = null;
     let reconnectStartedAt = null;
     let reconnectAttempts = 0;
     let disconnectCount = 0;
@@ -196,6 +195,14 @@
       return Math.max(1, Number(document.getElementById('maxAttemptsInput').value) || 120);
     }
 
+    function reconnectOptions() {
+      return {
+        autoReconnect: true,
+        reconnectIntervalMs: retryIntervalMs(),
+        reconnectMaxAttempts: maxAttempts(),
+      };
+    }
+
     function updateStatus() {
       const badge = document.getElementById('statusBadge');
       if (isReconnecting) {
@@ -226,7 +233,7 @@
     }
 
     async function beginWithCurrentDevice() {
-      const result = await ble.begin(selectedNotification());
+      const result = await ble.begin(selectedNotification(), reconnectOptions());
       log(`begin() result: ${result}`, 'ok');
       return result;
     }
@@ -279,46 +286,7 @@
     }
 
     function stopReconnectLoop() {
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
       isReconnecting = false;
-    }
-
-    function scheduleReconnect() {
-      if (!isTesting || isReconnecting) return;
-      isReconnecting = true;
-      reconnectStartedAt = reconnectStartedAt || Date.now();
-      log(`reconnect loop started. interval=${retryIntervalMs() / 1000}s max=${maxAttempts()}`, 'warn');
-      runReconnectAttempt();
-    }
-
-    async function runReconnectAttempt() {
-      if (!isTesting || !isReconnecting) return;
-      if (reconnectAttempts >= maxAttempts()) {
-        isReconnecting = false;
-        log('reconnect failed: max attempts reached', 'error');
-        updateStatus();
-        return;
-      }
-
-      reconnectAttempts++;
-      updateStatus();
-      try {
-        log(`reconnect attempt #${reconnectAttempts}`, 'warn');
-        await beginWithCurrentDevice();
-        const recoveredIn = reconnectStartedAt ? Math.round((Date.now() - reconnectStartedAt) / 1000) : 0;
-        document.getElementById('recoveryValue').textContent = `${recoveredIn}s / ${reconnectAttempts} tries`;
-        isReconnecting = false;
-        reconnectStartedAt = null;
-        log(`reconnect success: ${recoveredIn}s, attempts=${reconnectAttempts}`, 'ok');
-      } catch (error) {
-        log(`reconnect attempt failed: ${error}`, 'error');
-        reconnectTimer = setTimeout(runReconnectAttempt, retryIntervalMs());
-      } finally {
-        updateStatus();
-      }
     }
 
     function formatVector(data, keys) {
@@ -352,11 +320,35 @@
       disconnectCount++;
       log('disconnect detected', 'error');
       updateStatus();
-      scheduleReconnect();
     };
 
     ble.onError = function(error) {
       log(`error: ${error}`, 'error');
+      updateStatus();
+    };
+
+    ble.onReconnectAttempt = function(info) {
+      if (!isTesting) return;
+      isReconnecting = true;
+      reconnectStartedAt = reconnectStartedAt || Date.now();
+      reconnectAttempts = info.attempt;
+      log(`reconnect attempt #${info.attempt} / ${info.maxAttempts}`, 'warn');
+      updateStatus();
+    };
+
+    ble.onReconnectSuccess = function(info) {
+      isReconnecting = false;
+      const recoveredIn = Math.round(info.elapsedMs / 1000);
+      document.getElementById('recoveryValue').textContent = `${recoveredIn}s / ${info.attempt} tries`;
+      reconnectStartedAt = null;
+      log(`reconnect success: ${recoveredIn}s, attempts=${info.attempt}`, 'ok');
+      updateStatus();
+    };
+
+    ble.onReconnectFailed = function(info) {
+      isReconnecting = false;
+      reconnectStartedAt = null;
+      log(`reconnect failed: ${info.error}`, 'error');
       updateStatus();
     };
 

--- a/examples/TEST-BRIDGE/physical-range-test.html
+++ b/examples/TEST-BRIDGE/physical-range-test.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ORPHE CORE BLE Range Reconnect Test</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="../../js/float16.min.js"></script>
+  <script src="../../js/quaternion.js"></script>
+  <script src="../../js/ORPHE-CORE.js"></script>
+  <script src="../../js/BleSharedBridge.js"></script>
+  <style>
+    body { background: #f6f7f9; color: #1f2933; padding: 16px; }
+    .wrap { max-width: 960px; margin: 0 auto; }
+    .panel { background: #fff; border: 1px solid #d8dee8; border-radius: 8px; padding: 14px; margin-bottom: 12px; }
+    .status { display: inline-flex; align-items: center; min-height: 30px; padding: 4px 12px; border-radius: 999px; font-weight: 700; font-size: 0.9rem; }
+    .offline { background: #e5e7eb; color: #374151; }
+    .connected { background: #d1e7dd; color: #0f5132; }
+    .reconnecting { background: #fff3cd; color: #664d03; }
+    .failed { background: #f8d7da; color: #842029; }
+    .metric { min-height: 72px; border: 1px solid #e5e7eb; border-radius: 8px; padding: 10px; background: #fbfcfe; }
+    .metric-label { color: #64748b; font-size: 0.78rem; }
+    .metric-value { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 1.05rem; }
+    #log { height: 280px; overflow-y: auto; background: #111827; color: #d1d5db; border-radius: 8px; padding: 10px; font-size: 0.82rem; }
+    button { white-space: nowrap; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
+      <h1 class="h4 m-0">ORPHE CORE BLE Range Reconnect Test</h1>
+      <span id="statusBadge" class="status offline">未接続</span>
+    </div>
+
+    <div class="panel">
+      <div class="d-flex flex-wrap gap-2">
+        <button id="selectStartBtn" class="btn btn-primary">デバイス選択して開始</button>
+        <button id="rememberedStartBtn" class="btn btn-outline-primary">前回デバイスで開始</button>
+        <button id="stopBtn" class="btn btn-outline-danger">停止</button>
+        <button id="clearLogBtn" class="btn btn-outline-secondary">ログ消去</button>
+      </div>
+      <div class="row g-2 mt-3">
+        <div class="col-md-4">
+          <label class="form-label small mb-1" for="retryIntervalInput">再接続間隔（秒）</label>
+          <input id="retryIntervalInput" class="form-control" type="number" value="3" min="1" max="30">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label small mb-1" for="maxAttemptsInput">最大試行回数</label>
+          <input id="maxAttemptsInput" class="form-control" type="number" value="120" min="1" max="999">
+        </div>
+        <div class="col-md-4">
+          <label class="form-label small mb-1" for="notificationSelect">通知タイプ</label>
+          <select id="notificationSelect" class="form-select">
+            <option value="STEP_ANALYSIS_AND_SENSOR_VALUES" selected>STEP + SENSOR</option>
+            <option value="STEP_ANALYSIS">STEP only</option>
+            <option value="SENSOR_VALUES">SENSOR only</option>
+          </select>
+        </div>
+      </div>
+      <div class="mt-3 small text-muted">
+        テスト開始後、ORPHE COREを持って離れてBLE切断を発生させ、数秒後に近づいてください。ページが自動再接続を試し続け、復帰時間を記録します。
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="row g-2">
+        <div class="col-md-6">
+          <div class="metric">
+            <div class="metric-label">接続デバイス</div>
+            <div id="deviceValue" class="metric-value">--</div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="metric">
+            <div class="metric-label">記憶済みデバイス</div>
+            <div id="rememberedValue" class="metric-value">--</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">切断回数</div>
+            <div id="disconnectsValue" class="metric-value">0</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">再接続試行</div>
+            <div id="attemptsValue" class="metric-value">0</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">最終復帰時間</div>
+            <div id="recoveryValue" class="metric-value">--</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">最終データ経過</div>
+            <div id="lastDataValue" class="metric-value">--</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="fw-bold mb-2">歩いて離れるテスト手順</div>
+      <ol class="mb-0">
+        <li>「デバイス選択して開始」を押してORPHE COREを選ぶ。</li>
+        <li>ステータスが「接続中」になり、センサーデータが流れていることを確認する。</li>
+        <li>ORPHE COREを持って離れ、ログに「切断検知」が出るまで待つ。</li>
+        <li>ページは自動で再接続を試し続けるので、ORPHE COREを近づける。</li>
+        <li>「再接続成功」と復帰時間が出ればOK。</li>
+      </ol>
+    </div>
+
+    <div class="panel">
+      <div class="fw-bold mb-2">イベントログ</div>
+      <div id="log"></div>
+    </div>
+  </div>
+
+  <script>
+    const ble = new Orphe(0);
+    let isTesting = false;
+    let isReconnecting = false;
+    let reconnectTimer = null;
+    let reconnectStartedAt = null;
+    let reconnectAttempts = 0;
+    let disconnectCount = 0;
+    let lastDataAt = null;
+
+    function now() {
+      return new Date().toLocaleTimeString();
+    }
+
+    function log(message, level = 'info') {
+      const color = level === 'error' ? '#fca5a5' : level === 'ok' ? '#86efac' : level === 'warn' ? '#fde68a' : '#d1d5db';
+      const line = `<div><span style="color:#93c5fd">[${now()}]</span> <span style="color:${color}">${message}</span></div>`;
+      const el = document.getElementById('log');
+      el.innerHTML = line + el.innerHTML;
+    }
+
+    function formatDevice(device) {
+      if (!device) return '--';
+      return `${device.name || '(no name)'} / ${device.id || '(no id)'}`;
+    }
+
+    function selectedNotification() {
+      return document.getElementById('notificationSelect').value;
+    }
+
+    function retryIntervalMs() {
+      return Math.max(1, Number(document.getElementById('retryIntervalInput').value) || 3) * 1000;
+    }
+
+    function maxAttempts() {
+      return Math.max(1, Number(document.getElementById('maxAttemptsInput').value) || 120);
+    }
+
+    function updateStatus() {
+      const badge = document.getElementById('statusBadge');
+      if (isReconnecting) {
+        badge.className = 'status reconnecting';
+        badge.textContent = '再接続中';
+      } else if (ble.bluetoothDevice?.gatt?.connected) {
+        badge.className = 'status connected';
+        badge.textContent = '接続中';
+      } else if (isTesting) {
+        badge.className = 'status failed';
+        badge.textContent = '切断中';
+      } else {
+        badge.className = 'status offline';
+        badge.textContent = '未接続';
+      }
+
+      const remembered = ble._getLastBluetoothDeviceInfo ? ble._getLastBluetoothDeviceInfo() : null;
+      document.getElementById('deviceValue').textContent = formatDevice(ble.bluetoothDevice);
+      document.getElementById('rememberedValue').textContent = remembered
+        ? `${remembered.bluetoothName || '(no name)'} / ${remembered.bluetoothId || '(no id)'}`
+        : '--';
+      document.getElementById('disconnectsValue').textContent = String(disconnectCount);
+      document.getElementById('attemptsValue').textContent = String(reconnectAttempts);
+      document.getElementById('lastDataValue').textContent = lastDataAt
+        ? `${Math.round((Date.now() - lastDataAt) / 1000)}s`
+        : '--';
+    }
+
+    async function beginWithCurrentDevice() {
+      const result = await ble.begin(selectedNotification());
+      log(`begin() result: ${result}`, 'ok');
+      return result;
+    }
+
+    async function startWithDeviceSelection() {
+      stopReconnectLoop();
+      isTesting = true;
+      try {
+        log('manual device selection start', 'warn');
+        await ble.selectBluetoothDevice('DEVICE_INFORMATION');
+        log(`selected: ${formatDevice(ble.bluetoothDevice)}`, 'ok');
+        reconnectAttempts = 0;
+        reconnectStartedAt = null;
+        await beginWithCurrentDevice();
+      } catch (error) {
+        log(`start failed: ${error}`, 'error');
+      } finally {
+        updateStatus();
+      }
+    }
+
+    async function startWithRememberedDevice() {
+      stopReconnectLoop();
+      isTesting = true;
+      try {
+        reconnectAttempts = 0;
+        reconnectStartedAt = null;
+        log('remembered device start', 'warn');
+        await beginWithCurrentDevice();
+      } catch (error) {
+        log(`remembered start failed: ${error}`, 'error');
+        if (ble._rememberedBluetoothDeviceUnavailable) {
+          log('remembered device is unavailable. Use manual selection once.', 'error');
+        }
+      } finally {
+        updateStatus();
+      }
+    }
+
+    function stopTest() {
+      stopReconnectLoop();
+      isTesting = false;
+      try {
+        ble.reset();
+      } catch (error) {
+        log(`stop reset error: ${error}`, 'error');
+      }
+      log('test stopped', 'warn');
+      updateStatus();
+    }
+
+    function stopReconnectLoop() {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      isReconnecting = false;
+    }
+
+    function scheduleReconnect() {
+      if (!isTesting || isReconnecting) return;
+      isReconnecting = true;
+      reconnectStartedAt = reconnectStartedAt || Date.now();
+      log(`reconnect loop started. interval=${retryIntervalMs() / 1000}s max=${maxAttempts()}`, 'warn');
+      runReconnectAttempt();
+    }
+
+    async function runReconnectAttempt() {
+      if (!isTesting || !isReconnecting) return;
+      if (reconnectAttempts >= maxAttempts()) {
+        isReconnecting = false;
+        log('reconnect failed: max attempts reached', 'error');
+        updateStatus();
+        return;
+      }
+
+      reconnectAttempts++;
+      updateStatus();
+      try {
+        log(`reconnect attempt #${reconnectAttempts}`, 'warn');
+        await beginWithCurrentDevice();
+        const recoveredIn = reconnectStartedAt ? Math.round((Date.now() - reconnectStartedAt) / 1000) : 0;
+        document.getElementById('recoveryValue').textContent = `${recoveredIn}s / ${reconnectAttempts} tries`;
+        isReconnecting = false;
+        reconnectStartedAt = null;
+        log(`reconnect success: ${recoveredIn}s, attempts=${reconnectAttempts}`, 'ok');
+      } catch (error) {
+        log(`reconnect attempt failed: ${error}`, 'error');
+        reconnectTimer = setTimeout(runReconnectAttempt, retryIntervalMs());
+      } finally {
+        updateStatus();
+      }
+    }
+
+    function markDataReceived() {
+      lastDataAt = Date.now();
+      updateStatus();
+    }
+
+    ble.setup();
+
+    ble.onScan = function(deviceName) {
+      log(`scan/select: ${deviceName || '(no name)'}`, 'ok');
+      updateStatus();
+    };
+
+    ble.onConnect = function(uuid) {
+      log(`connect: ${uuid}`, 'ok');
+      updateStatus();
+    };
+
+    ble.onStartNotify = function(uuid) {
+      log(`start notify: ${uuid}`, 'ok');
+      updateStatus();
+    };
+
+    ble.onDisconnect = function() {
+      disconnectCount++;
+      log('disconnect detected', 'error');
+      updateStatus();
+      scheduleReconnect();
+    };
+
+    ble.onError = function(error) {
+      log(`error: ${error}`, 'error');
+      updateStatus();
+    };
+
+    ble.gotBLEFrequency = function(freq) {
+      markDataReceived();
+    };
+
+    ble.gotStepsNumber = function() {
+      markDataReceived();
+    };
+
+    ble.gotAcc = function() {
+      markDataReceived();
+    };
+
+    ble.gotEuler = function() {
+      markDataReceived();
+    };
+
+    document.getElementById('selectStartBtn').addEventListener('click', startWithDeviceSelection);
+    document.getElementById('rememberedStartBtn').addEventListener('click', startWithRememberedDevice);
+    document.getElementById('stopBtn').addEventListener('click', stopTest);
+    document.getElementById('clearLogBtn').addEventListener('click', () => {
+      document.getElementById('log').innerHTML = '';
+    });
+
+    setInterval(updateStatus, 1000);
+    updateStatus();
+    log('ready');
+  </script>
+</body>
+</html>

--- a/examples/TEST-BRIDGE/physical-range-test.html
+++ b/examples/TEST-BRIDGE/physical-range-test.html
@@ -22,6 +22,10 @@
     .metric-label { color: #64748b; font-size: 0.78rem; }
     .metric-value { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 1.05rem; }
     #log { height: 280px; overflow-y: auto; background: #111827; color: #d1d5db; border-radius: 8px; padding: 10px; font-size: 0.82rem; }
+    .raw-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 10px; }
+    .raw-cell { border: 1px solid #e5e7eb; border-radius: 8px; padding: 10px; background: #fbfcfe; }
+    .raw-label { color: #64748b; font-size: 0.78rem; }
+    .raw-value { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.98rem; white-space: pre-wrap; }
     button { white-space: nowrap; }
   </style>
 </head>
@@ -104,6 +108,39 @@
     </div>
 
     <div class="panel">
+      <div class="d-flex align-items-center justify-content-between gap-2 mb-2">
+        <div class="fw-bold">リアルタイム生データ</div>
+        <div class="small text-muted">受信数 <span id="packetCountValue">0</span></div>
+      </div>
+      <div class="raw-grid">
+        <div class="raw-cell">
+          <div class="raw-label">加速度 acc</div>
+          <div id="rawAccValue" class="raw-value">--</div>
+        </div>
+        <div class="raw-cell">
+          <div class="raw-label">ジャイロ gyro</div>
+          <div id="rawGyroValue" class="raw-value">--</div>
+        </div>
+        <div class="raw-cell">
+          <div class="raw-label">クォータニオン quat</div>
+          <div id="rawQuatValue" class="raw-value">--</div>
+        </div>
+        <div class="raw-cell">
+          <div class="raw-label">Euler</div>
+          <div id="rawEulerValue" class="raw-value">--</div>
+        </div>
+        <div class="raw-cell">
+          <div class="raw-label">歩数 steps</div>
+          <div id="rawStepsValue" class="raw-value">--</div>
+        </div>
+        <div class="raw-cell">
+          <div class="raw-label">BLE周波数</div>
+          <div id="rawFreqValue" class="raw-value">--</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
       <div class="fw-bold mb-2">歩いて離れるテスト手順</div>
       <ol class="mb-0">
         <li>「デバイス選択して開始」を押してORPHE COREを選ぶ。</li>
@@ -129,6 +166,7 @@
     let reconnectAttempts = 0;
     let disconnectCount = 0;
     let lastDataAt = null;
+    let packetCount = 0;
 
     function now() {
       return new Date().toLocaleTimeString();
@@ -184,6 +222,7 @@
       document.getElementById('lastDataValue').textContent = lastDataAt
         ? `${Math.round((Date.now() - lastDataAt) / 1000)}s`
         : '--';
+      document.getElementById('packetCountValue').textContent = String(packetCount);
     }
 
     async function beginWithCurrentDevice() {
@@ -282,8 +321,13 @@
       }
     }
 
-    function markDataReceived() {
+    function formatVector(data, keys) {
+      return keys.map(key => `${key}:${Number(data?.[key] ?? 0).toFixed(3)}`).join(' ');
+    }
+
+    function markDataReceived(label) {
       lastDataAt = Date.now();
+      packetCount++;
       updateStatus();
     }
 
@@ -317,19 +361,33 @@
     };
 
     ble.gotBLEFrequency = function(freq) {
-      markDataReceived();
+      document.getElementById('rawFreqValue').textContent = `${Math.floor(freq)} Hz`;
+      markDataReceived('freq');
     };
 
-    ble.gotStepsNumber = function() {
-      markDataReceived();
+    ble.gotStepsNumber = function(steps) {
+      document.getElementById('rawStepsValue').textContent = JSON.stringify(steps);
+      markDataReceived('steps');
     };
 
-    ble.gotAcc = function() {
-      markDataReceived();
+    ble.gotAcc = function(acc) {
+      document.getElementById('rawAccValue').textContent = formatVector(acc, ['x', 'y', 'z']);
+      markDataReceived('acc');
     };
 
-    ble.gotEuler = function() {
-      markDataReceived();
+    ble.gotGyro = function(gyro) {
+      document.getElementById('rawGyroValue').textContent = formatVector(gyro, ['x', 'y', 'z']);
+      markDataReceived('gyro');
+    };
+
+    ble.gotQuat = function(quat) {
+      document.getElementById('rawQuatValue').textContent = formatVector(quat, ['w', 'x', 'y', 'z']);
+      markDataReceived('quat');
+    };
+
+    ble.gotEuler = function(euler) {
+      document.getElementById('rawEulerValue').textContent = formatVector(euler, ['pitch', 'roll', 'yaw']);
+      markDataReceived('euler');
     };
 
     document.getElementById('selectStartBtn').addEventListener('click', startWithDeviceSelection);

--- a/examples/TEST-BRIDGE/physical-reconnect-test.html
+++ b/examples/TEST-BRIDGE/physical-reconnect-test.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ORPHE CORE BLE Reconnect Test</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="../../js/float16.min.js"></script>
+  <script src="../../js/quaternion.js"></script>
+  <script src="../../js/ORPHE-CORE.js"></script>
+  <script src="../../js/BleSharedBridge.js"></script>
+  <style>
+    body { background: #f6f7f9; color: #1f2933; padding: 16px; }
+    .wrap { max-width: 880px; margin: 0 auto; }
+    .panel { background: #fff; border: 1px solid #d8dee8; border-radius: 8px; padding: 14px; margin-bottom: 12px; }
+    .status { display: inline-flex; align-items: center; min-height: 30px; padding: 4px 12px; border-radius: 999px; font-weight: 700; font-size: 0.9rem; }
+    .offline { background: #e5e7eb; color: #374151; }
+    .primary { background: #d1e7dd; color: #0f5132; }
+    .secondary { background: #cfe2ff; color: #084298; }
+    .warn { background: #fff3cd; color: #664d03; }
+    .metric { min-height: 68px; border: 1px solid #e5e7eb; border-radius: 8px; padding: 10px; background: #fbfcfe; }
+    .metric-label { color: #64748b; font-size: 0.78rem; }
+    .metric-value { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 1.05rem; }
+    #log { height: 220px; overflow-y: auto; background: #111827; color: #d1d5db; border-radius: 8px; padding: 10px; font-size: 0.82rem; }
+    .step-list li { margin-bottom: 6px; }
+    button { white-space: nowrap; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
+      <h1 class="h4 m-0">ORPHE CORE BLE Reconnect Test</h1>
+      <span id="modeBadge" class="status offline">未接続</span>
+    </div>
+
+    <div class="panel">
+      <div class="d-flex flex-wrap gap-2">
+        <button id="connectBtn" class="btn btn-primary">接続 / 再接続</button>
+        <button id="disconnectBtn" class="btn btn-outline-danger">切断</button>
+        <button id="forgetBtn" class="btn btn-outline-secondary">前回デバイスを忘れる</button>
+        <button id="devicesBtn" class="btn btn-outline-dark">許可済みBLE一覧</button>
+        <button id="clearLogBtn" class="btn btn-outline-secondary">ログ消去</button>
+      </div>
+      <div class="mt-3 small text-muted">
+        別デバイスへ切り替える時は「前回デバイスを忘れる」を押してから「接続 / 再接続」を押してください。
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="row g-2">
+        <div class="col-md-6">
+          <div class="metric">
+            <div class="metric-label">接続デバイス</div>
+            <div id="deviceValue" class="metric-value">--</div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="metric">
+            <div class="metric-label">記憶済みデバイス</div>
+            <div id="rememberedValue" class="metric-value">--</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">BLE Hz</div>
+            <div id="freqValue" class="metric-value">--</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">歩数</div>
+            <div id="stepsValue" class="metric-value">--</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">加速度</div>
+            <div id="accValue" class="metric-value">-- / -- / --</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="metric">
+            <div class="metric-label">Euler</div>
+            <div id="eulerValue" class="metric-value">-- / --</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="fw-bold mb-2">実機チェック手順</div>
+      <ol class="step-list mb-0">
+        <li>このページを2つのタブで開く。</li>
+        <li>Tab Aで「接続 / 再接続」を押し、BLE選択ダイアログからORPHE COREを選ぶ。</li>
+        <li>Tab Bで「接続 / 再接続」を押し、BLEダイアログなしでSecondaryになることを確認する。</li>
+        <li>Tab Aで「切断」を押し、Tab Bが同じORPHE COREへ自動再接続してPrimaryになることを確認する。</li>
+        <li>別のCOREへ切り替える時は「前回デバイスを忘れる」後に接続し直す。</li>
+      </ol>
+    </div>
+
+    <div class="panel">
+      <div class="fw-bold mb-2">イベントログ</div>
+      <div id="log"></div>
+    </div>
+  </div>
+
+  <script>
+    const ble = new Orphe(0);
+    const notificationType = 'STEP_ANALYSIS_AND_SENSOR_VALUES';
+
+    function now() {
+      return new Date().toLocaleTimeString();
+    }
+
+    function log(message, level = 'info') {
+      const color = level === 'error' ? '#fca5a5' : level === 'ok' ? '#86efac' : '#fde68a';
+      const line = `<div><span style="color:#93c5fd">[${now()}]</span> <span style="color:${color}">${message}</span></div>`;
+      const el = document.getElementById('log');
+      el.innerHTML = line + el.innerHTML;
+    }
+
+    function formatDevice(device) {
+      if (!device) return '--';
+      return `${device.name || '(no name)'} / ${device.id || '(no id)'}`;
+    }
+
+    function getRememberedInfo() {
+      return ble._getLastBluetoothDeviceInfo ? ble._getLastBluetoothDeviceInfo() : null;
+    }
+
+    function updateStatus() {
+      const badge = document.getElementById('modeBadge');
+      if (ble._isBridgeSecondary) {
+        badge.className = 'status secondary';
+        badge.textContent = 'Secondary: 共有受信中';
+      } else if (ble.bluetoothDevice?.gatt?.connected) {
+        badge.className = 'status primary';
+        badge.textContent = 'Primary: BLE接続中';
+      } else if (ble.bluetoothDevice) {
+        badge.className = 'status warn';
+        badge.textContent = 'デバイス保持 / GATT未接続';
+      } else {
+        badge.className = 'status offline';
+        badge.textContent = '未接続';
+      }
+
+      document.getElementById('deviceValue').textContent = formatDevice(ble.bluetoothDevice);
+      const remembered = getRememberedInfo();
+      document.getElementById('rememberedValue').textContent = remembered
+        ? `${remembered.bluetoothName || '(no name)'} / ${remembered.bluetoothId || '(no id)'}`
+        : '--';
+    }
+
+    async function connect() {
+      try {
+        log('begin() start');
+        const result = await ble.begin(notificationType);
+        log(`begin() result: ${result}`, 'ok');
+      } catch (error) {
+        log(`begin() exception: ${error}`, 'error');
+      } finally {
+        updateStatus();
+      }
+    }
+
+    function disconnect() {
+      try {
+        log('reset() start');
+        ble.reset();
+        log('reset() done', 'ok');
+      } catch (error) {
+        log(`reset() exception: ${error}`, 'error');
+      } finally {
+        updateStatus();
+      }
+    }
+
+    function forgetLastDevice() {
+      ble.forgetLastBluetoothDevice();
+      log('forgot last Bluetooth device', 'ok');
+      updateStatus();
+    }
+
+    async function showPermittedDevices() {
+      if (!navigator.bluetooth?.getDevices) {
+        log('navigator.bluetooth.getDevices() is unavailable', 'error');
+        return;
+      }
+      try {
+        const devices = await navigator.bluetooth.getDevices();
+        if (devices.length === 0) {
+          log('permitted devices: 0');
+          return;
+        }
+        log(`permitted devices: ${devices.map(formatDevice).join(' | ')}`);
+      } catch (error) {
+        log(`getDevices() error: ${error}`, 'error');
+      }
+    }
+
+    ble.setup();
+
+    ble.onScan = function(deviceName) {
+      log(`scan/select: ${deviceName || '(no name)'}`, 'ok');
+      updateStatus();
+    };
+
+    ble.onConnect = function(uuid) {
+      log(`connect: ${uuid}`, 'ok');
+      updateStatus();
+    };
+
+    ble.onStartNotify = function(uuid) {
+      log(`start notify: ${uuid}`, 'ok');
+      updateStatus();
+    };
+
+    ble.onDisconnect = function() {
+      log('disconnect detected');
+      updateStatus();
+    };
+
+    ble.onError = function(error) {
+      log(`error: ${error}`, 'error');
+      updateStatus();
+    };
+
+    ble.gotBLEFrequency = function(freq) {
+      document.getElementById('freqValue').textContent = `${Math.floor(freq)} Hz`;
+    };
+
+    ble.gotStepsNumber = function(steps) {
+      document.getElementById('stepsValue').textContent = steps.value;
+    };
+
+    ble.gotAcc = function(acc) {
+      document.getElementById('accValue').textContent =
+        `${acc.x.toFixed(2)} / ${acc.y.toFixed(2)} / ${acc.z.toFixed(2)}`;
+    };
+
+    ble.gotEuler = function(euler) {
+      document.getElementById('eulerValue').textContent =
+        `${(euler.pitch * 180 / Math.PI).toFixed(1)} / ${(euler.roll * 180 / Math.PI).toFixed(1)}`;
+    };
+
+    document.getElementById('connectBtn').addEventListener('click', connect);
+    document.getElementById('disconnectBtn').addEventListener('click', disconnect);
+    document.getElementById('forgetBtn').addEventListener('click', forgetLastDevice);
+    document.getElementById('devicesBtn').addEventListener('click', showPermittedDevices);
+    document.getElementById('clearLogBtn').addEventListener('click', () => {
+      document.getElementById('log').innerHTML = '';
+    });
+
+    setInterval(updateStatus, 1000);
+    updateStatus();
+    log('ready');
+  </script>
+</body>
+</html>

--- a/examples/TEST-BRIDGE/physical-reconnect-test.html
+++ b/examples/TEST-BRIDGE/physical-reconnect-test.html
@@ -163,6 +163,9 @@
         log(`begin() result: ${result}`, 'ok');
       } catch (error) {
         log(`begin() exception: ${error}`, 'error');
+        if (ble._rememberedBluetoothDeviceUnavailable) {
+          log('remembered device reconnect failed. Press connect again to choose manually.', 'error');
+        }
       } finally {
         updateStatus();
       }

--- a/examples/TEST-BRIDGE/physical-reconnect-test.html
+++ b/examples/TEST-BRIDGE/physical-reconnect-test.html
@@ -152,7 +152,8 @@
 
     async function connect() {
       try {
-        if (ble._isBridgeSecondary || ble.bluetoothDevice?.gatt?.connected) {
+        const hasHeldDisconnectedDevice = ble.bluetoothDevice && !ble.bluetoothDevice.gatt?.connected;
+        if (ble._isBridgeSecondary || ble.bluetoothDevice?.gatt?.connected || hasHeldDisconnectedDevice) {
           log('manual device switch start');
           await ble.selectBluetoothDevice('DEVICE_INFORMATION');
           log(`manual device selected: ${formatDevice(ble.bluetoothDevice)}`, 'ok');

--- a/examples/TEST-BRIDGE/physical-reconnect-test.html
+++ b/examples/TEST-BRIDGE/physical-reconnect-test.html
@@ -35,14 +35,13 @@
 
     <div class="panel">
       <div class="d-flex flex-wrap gap-2">
-        <button id="connectBtn" class="btn btn-primary">接続 / 再接続</button>
+        <button id="connectBtn" class="btn btn-primary">接続 / 再接続 / 切り替え</button>
         <button id="disconnectBtn" class="btn btn-outline-danger">切断</button>
-        <button id="forgetBtn" class="btn btn-outline-secondary">前回デバイスを忘れる</button>
         <button id="devicesBtn" class="btn btn-outline-dark">許可済みBLE一覧</button>
         <button id="clearLogBtn" class="btn btn-outline-secondary">ログ消去</button>
       </div>
       <div class="mt-3 small text-muted">
-        別デバイスへ切り替える時は「前回デバイスを忘れる」を押してから「接続 / 再接続」を押してください。
+        接続中に同じボタンを押すとBLE選択ダイアログを出し、別のCOREへ切り替えます。未接続時は前回のCOREへ自動再接続します。
       </div>
     </div>
 
@@ -91,10 +90,10 @@
       <div class="fw-bold mb-2">実機チェック手順</div>
       <ol class="step-list mb-0">
         <li>このページを2つのタブで開く。</li>
-        <li>Tab Aで「接続 / 再接続」を押し、BLE選択ダイアログからORPHE COREを選ぶ。</li>
-        <li>Tab Bで「接続 / 再接続」を押し、BLEダイアログなしでSecondaryになることを確認する。</li>
+        <li>Tab Aで「接続 / 再接続 / 切り替え」を押し、BLE選択ダイアログからORPHE COREを選ぶ。</li>
+        <li>Tab Bで「接続 / 再接続 / 切り替え」を押し、BLEダイアログなしでSecondaryになることを確認する。</li>
         <li>Tab Aで「切断」を押し、Tab Bが同じORPHE COREへ自動再接続してPrimaryになることを確認する。</li>
-        <li>別のCOREへ切り替える時は「前回デバイスを忘れる」後に接続し直す。</li>
+        <li>Primary接続中に同じボタンをもう一度押し、別のCOREを選ぶと記憶済みデバイスが更新されることを確認する。</li>
       </ol>
     </div>
 
@@ -153,6 +152,11 @@
 
     async function connect() {
       try {
+        if (ble._isBridgeSecondary || ble.bluetoothDevice?.gatt?.connected) {
+          log('manual device switch start');
+          await ble.selectBluetoothDevice('DEVICE_INFORMATION');
+          log(`manual device selected: ${formatDevice(ble.bluetoothDevice)}`, 'ok');
+        }
         log('begin() start');
         const result = await ble.begin(notificationType);
         log(`begin() result: ${result}`, 'ok');
@@ -173,12 +177,6 @@
       } finally {
         updateStatus();
       }
-    }
-
-    function forgetLastDevice() {
-      ble.forgetLastBluetoothDevice();
-      log('forgot last Bluetooth device', 'ok');
-      updateStatus();
     }
 
     async function showPermittedDevices() {
@@ -245,7 +243,6 @@
 
     document.getElementById('connectBtn').addEventListener('click', connect);
     document.getElementById('disconnectBtn').addEventListener('click', disconnect);
-    document.getElementById('forgetBtn').addEventListener('click', forgetLastDevice);
     document.getElementById('devicesBtn').addEventListener('click', showPermittedDevices);
     document.getElementById('clearLogBtn').addEventListener('click', () => {
       document.getElementById('log').innerHTML = '';

--- a/examples/TEST-BRIDGE/test-frame.html
+++ b/examples/TEST-BRIDGE/test-frame.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><script src="../../js/BleSharedBridge.js"></script></head>
+<body>
+<script>
+  let bridge = null;
+  const received = [];
+
+  window.addEventListener('message', (e) => {
+    const { id, action, args } = e.data || {};
+    if (!id) return;
+    let result = null;
+    try {
+      if (action === 'create') {
+        // 古いブリッジが残っているとチャネルが二重に購読されてしまうため必ず解放
+        if (bridge) { try { bridge.release(); } catch (_) {} }
+        bridge = new BleSharedBridge(args.deviceId);
+        result = 'ok';
+      }
+      else if (action === 'claimPrimary')             { bridge.claimPrimary(); result = 'ok'; }
+      else if (action === 'isRemotePrimaryAvailable') { result = bridge.isRemotePrimaryAvailable(); }
+      else if (action === 'broadcastBatch')           { bridge.broadcastBatch(args.batch); result = 'ok'; }
+      else if (action === 'broadcastDisconnect')      { bridge.broadcastDisconnect(); result = 'ok'; }
+      else if (action === 'subscribeAsSecondary') {
+        bridge.subscribeAsSecondary({
+          gotAcc:        (d) => received.push({ cb: 'gotAcc', data: d }),
+          gotGait:       (d) => received.push({ cb: 'gotGait', data: d }),
+          onPrimaryLost: ()  => received.push({ cb: 'onPrimaryLost' }),
+        });
+        result = 'ok';
+      }
+      else if (action === 'getReceived')      { result = received.slice(); }
+      else if (action === 'debugBridgeState') {
+        result = {
+          isPrimary: bridge?.isPrimary,
+          hasChannel: !!bridge?._channel,
+          hasCallbacks: Object.keys(bridge?._callbacks || {}),
+          channelName: bridge?._channelName,
+        };
+      }
+      else if (action === 'clearReceived')    { received.length = 0; result = 'ok'; }
+      else if (action === 'release')          { bridge.release(); result = 'ok'; }
+      else if (action === 'readStorageKey')   { result = localStorage.getItem('orphe_bridge_primary_' + args.deviceId); }
+    } catch (err) { result = { error: String(err) }; }
+    parent.postMessage({ id, result }, '*');
+  });
+
+  parent.postMessage({ id: 'ready' }, '*');
+</script>
+</body>
+</html>

--- a/examples/TEST-BRIDGE/unit-test.html
+++ b/examples/TEST-BRIDGE/unit-test.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>BleSharedBridge 単体テスト</title>
+  <style>
+    body { font-family: -apple-system, system-ui, sans-serif; padding: 20px; max-width: 900px; margin: 0 auto; background: #f8f9fa; }
+    h1 { font-size: 1.3em; }
+    #results { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; padding: 16px; font-family: "SF Mono", Menlo, monospace; font-size: 0.88em; }
+    .pass { color: #0f5132; }
+    .fail { color: #842029; font-weight: bold; }
+    .info { color: #6c757d; }
+    .head { color: #084298; font-weight: bold; margin-top: 10px; }
+    .summary { margin-top: 20px; padding: 12px; border-radius: 6px; }
+    .ok   { background: #d1e7dd; color: #0f5132; }
+    .ng   { background: #f8d7da; color: #842029; }
+    button { padding: 8px 20px; background: #0d6efd; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 1em; }
+    button:disabled { opacity: 0.5; }
+    iframe { display: none; }
+  </style>
+</head>
+<body>
+  <h1>🔬 BleSharedBridge 単体テスト</h1>
+  <p>BLE実機は不要です。<code>BroadcastChannel</code> と <code>localStorage</code> の動作を自動検証します。</p>
+
+  <button id="run_btn">テスト実行</button>
+
+  <div id="summary" class="summary" style="display:none"></div>
+  <pre id="results"></pre>
+
+  <script src="../../js/BleSharedBridge.js"></script>
+  <script>
+    const DEVICE_ID = 99; // テスト専用に 0/1 と衝突しないIDを使う
+    const resultsEl = document.getElementById('results');
+    const summaryEl = document.getElementById('summary');
+
+    let passed = 0, failed = 0;
+
+    function log(msg, cls = 'info') {
+      const line = document.createElement('div');
+      line.className = cls;
+      line.textContent = msg;
+      resultsEl.appendChild(line);
+    }
+    function head(msg)      { log(msg, 'head'); }
+    function assert(cond, msg) {
+      if (cond) { log('  ✓ ' + msg, 'pass'); passed++; }
+      else      { log('  ✗ ' + msg, 'fail'); failed++; }
+      return cond;
+    }
+    const wait = (ms) => new Promise(r => setTimeout(r, ms));
+
+    /**
+     * iframeを1つ作成し、その中でbridgeを扱える関数を返す。
+     * iframe内はメインページと別browsing contextなのでBroadcastChannelが
+     * 両者間で機能する。
+     */
+    async function createTabSimulator(label) {
+      const iframe = document.createElement('iframe');
+      // srcdoc だと opaque origin で BroadcastChannel が分離されるため
+      // 外部 HTML として読み込み、親と同一オリジンを保つ
+      iframe.src = 'test-frame.html';
+      document.body.appendChild(iframe);
+      await new Promise(resolve => {
+        const handler = (e) => {
+          if (e.source === iframe.contentWindow && e.data?.id === 'ready') {
+            window.removeEventListener('message', handler);
+            resolve();
+          }
+        };
+        window.addEventListener('message', handler);
+      });
+      let counter = 0;
+      async function call(action, args = {}) {
+        const id = `${label}_${counter++}`;
+        return new Promise(resolve => {
+          const handler = (e) => {
+            if (e.source === iframe.contentWindow && e.data?.id === id) {
+              window.removeEventListener('message', handler);
+              resolve(e.data.result);
+            }
+          };
+          window.addEventListener('message', handler);
+          iframe.contentWindow.postMessage({ id, action, args }, '*');
+        });
+      }
+      return { iframe, call, destroy: () => iframe.remove() };
+    }
+
+    async function runTests() {
+      // クリーンアップ
+      try { localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`); } catch (_) {}
+
+      head('■ セットアップ: 2つのタブをシミュレート');
+      const tabA = await createTabSimulator('A');
+      const tabB = await createTabSimulator('B');
+      log(`  iframe A / B ready`);
+
+      head('■ テスト1: Primary検出');
+      await tabA.call('create', { deviceId: DEVICE_ID });
+      await tabB.call('create', { deviceId: DEVICE_ID });
+
+      const initialCheck = await tabB.call('isRemotePrimaryAvailable');
+      assert(initialCheck === false, 'Primaryが存在しない初期状態でfalseを返す');
+
+      await tabA.call('claimPrimary');
+      await wait(50);
+
+      const afterClaimCheck = await tabB.call('isRemotePrimaryAvailable');
+      assert(afterClaimCheck === true, 'Primary確立後、別タブからtrueを返す');
+
+      const selfCheck = await tabA.call('isRemotePrimaryAvailable');
+      assert(selfCheck === false, '自タブは"他タブのPrimary"とはみなさない');
+
+      const storageEntry = await tabA.call('readStorageKey', { deviceId: DEVICE_ID });
+      assert(storageEntry !== null, 'claimPrimaryでlocalStorageにエントリが書き込まれる');
+      const parsed = JSON.parse(storageEntry);
+      assert(typeof parsed.timestamp === 'number', '  └ timestampが数値');
+      assert(typeof parsed.tabId === 'string',      '  └ tabIdが文字列');
+
+      head('■ テスト2: Secondary購読 & バッチブロードキャスト');
+      await tabB.call('subscribeAsSecondary');
+      await wait(100);
+
+      await tabB.call('clearReceived');
+      await tabA.call('broadcastBatch', {
+        batch: {
+          gotAcc:  { x: 1.1, y: 2.2, z: 3.3 },
+          gotGait: { direction: 2, steps: 42 },
+        }
+      });
+      await wait(100);
+
+      const recv = await tabB.call('getReceived');
+      assert(recv.length === 2, `バッチ1回で2コールバックが発火 (actual: ${recv.length})`);
+      const accMsg  = recv.find(r => r.cb === 'gotAcc');
+      const gaitMsg = recv.find(r => r.cb === 'gotGait');
+      assert(accMsg && accMsg.data.x === 1.1,        'gotAccデータが正しく伝搬');
+      assert(gaitMsg && gaitMsg.data.direction === 2, 'gotGaitデータが正しく伝搬');
+
+      head('■ テスト3: 複数バッチの連続送信');
+      await tabB.call('clearReceived');
+      for (let i = 0; i < 10; i++) {
+        await tabA.call('broadcastBatch', { batch: { gotAcc: { x: i, y: 0, z: 0 } } });
+      }
+      await wait(300);
+      const recvMulti = await tabB.call('getReceived');
+      assert(recvMulti.length === 10, `連続10バッチが全て到達 (actual: ${recvMulti.length})`);
+      const xs = recvMulti.map(r => r.data.x);
+      assert(JSON.stringify(xs) === JSON.stringify([0,1,2,3,4,5,6,7,8,9]), '順序が保持される');
+
+      head('■ テスト4: broadcastDisconnectで即時通知');
+      await tabB.call('clearReceived');
+      await tabA.call('broadcastDisconnect');
+      await wait(100);
+      const recvDisc = await tabB.call('getReceived');
+      const hasLost = recvDisc.some(r => r.cb === 'onPrimaryLost');
+      assert(hasLost, 'disconnectedメッセージでonPrimaryLostが発火');
+
+      const storageAfterDisc = await tabA.call('readStorageKey', { deviceId: DEVICE_ID });
+      assert(storageAfterDisc === null, 'broadcastDisconnectでlocalStorageがクリーンアップされる');
+
+      head('■ テスト5: release時の自エントリ保護');
+      await tabA.call('create', { deviceId: DEVICE_ID });
+      await tabA.call('claimPrimary');
+      await wait(50);
+
+      // 故意に別タブIDで上書き（他タブが Primary を奪った状況を再現）
+      localStorage.setItem(`orphe_bridge_primary_${DEVICE_ID}`,
+        JSON.stringify({ timestamp: Date.now(), tabId: 'FAKE_OTHER_TAB' }));
+
+      await tabA.call('release');
+      await wait(50);
+
+      const rawAfterRelease = localStorage.getItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      const parsedOther = JSON.parse(rawAfterRelease);
+      assert(parsedOther?.tabId === 'FAKE_OTHER_TAB',
+        '他タブの Primary エントリは release で破壊されない（自タブIDのみ削除）');
+
+      head('■ テスト6: heartbeat タイムアウトでの無効判定');
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      // タイムアウト超過のheartbeatを偽装
+      localStorage.setItem(`orphe_bridge_primary_${DEVICE_ID}`,
+        JSON.stringify({ timestamp: Date.now() - 10000, tabId: 'STALE_TAB' }));
+
+      await tabB.call('create', { deviceId: DEVICE_ID });
+      const staleCheck = await tabB.call('isRemotePrimaryAvailable');
+      assert(staleCheck === false, 'HEARTBEAT_TIMEOUT_MS(5s)を超えたエントリは無効扱い');
+
+      head('■ テスト7: 複数Secondaryへの同時配信');
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      const tabC = await createTabSimulator('C');
+      await tabA.call('create', { deviceId: DEVICE_ID });
+      await tabB.call('create', { deviceId: DEVICE_ID });
+      await tabC.call('create', { deviceId: DEVICE_ID });
+
+      await tabA.call('claimPrimary');
+      await tabB.call('subscribeAsSecondary');
+      await tabC.call('subscribeAsSecondary');
+      await wait(100);
+
+      await tabB.call('clearReceived');
+      await tabC.call('clearReceived');
+      await tabA.call('broadcastBatch', { batch: { gotAcc: { x: 9.9, y: 0, z: 0 } } });
+      await wait(100);
+
+      const recvB = await tabB.call('getReceived');
+      const recvC = await tabC.call('getReceived');
+      assert(recvB.length === 1 && recvB[0].data.x === 9.9, 'Secondary B が受信');
+      assert(recvC.length === 1 && recvC[0].data.x === 9.9, 'Secondary C が同じデータを受信');
+
+      head('■ テスト8: Primary喪失→全Secondaryが onPrimaryLost 発火');
+      await tabB.call('clearReceived');
+      await tabC.call('clearReceived');
+      await tabA.call('release'); // Primary が消える
+      await wait(200);
+
+      const lostB = await tabB.call('getReceived');
+      const lostC = await tabC.call('getReceived');
+      assert(lostB.some(r => r.cb === 'onPrimaryLost'), 'Tab B が onPrimaryLost 検知');
+      assert(lostC.some(r => r.cb === 'onPrimaryLost'), 'Tab C が onPrimaryLost 検知');
+
+      head('■ テスト9: Secondary→新Primary昇格');
+      // 全タブをクリーンな状態にして再構築
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      await tabA.call('release');
+      await tabB.call('release');
+      await tabC.call('release');
+      await tabA.call('create', { deviceId: DEVICE_ID });
+      await tabB.call('create', { deviceId: DEVICE_ID });
+
+      // B は最初 Secondary ではなく、Primary 昇格を試みる
+      await tabA.call('claimPrimary');
+      await wait(50);
+      const bCheckBefore = await tabB.call('isRemotePrimaryAvailable');
+      assert(bCheckBefore === true, 'B は A が Primary であると認識');
+
+      // A が消え、B が Primary を奪取
+      await tabA.call('release');
+      await wait(100);
+      const bCheckAfter = await tabB.call('isRemotePrimaryAvailable');
+      assert(bCheckAfter === false, 'A 喪失後、B は他の Primary を認識しない');
+
+      await tabB.call('claimPrimary');
+      await wait(50);
+      const bStorageEntry = await tabB.call('readStorageKey', { deviceId: DEVICE_ID });
+      assert(bStorageEntry !== null, 'B が新 Primary として localStorage に登録される');
+      const bParsed = JSON.parse(bStorageEntry);
+      assert(typeof bParsed.tabId === 'string' && bParsed.tabId !== '', '  └ B の tabId が記録される');
+
+      head('■ テスト10: 不正メッセージの耐性');
+      await tabB.call('release');
+      await tabA.call('release');
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      await tabA.call('create', { deviceId: DEVICE_ID });
+      await tabB.call('create', { deviceId: DEVICE_ID });
+      await tabA.call('claimPrimary');
+      await tabB.call('subscribeAsSecondary');
+      await wait(100);
+      await tabB.call('clearReceived');
+
+      // 不正データをチャネルに流しても Secondary がクラッシュしないことを確認
+      await tabA.call('broadcastBatch', { batch: { nonexistent_callback: { foo: 1 } } });
+      await wait(100);
+      // エラーにならずここまで到達したら OK
+      const afterBadMsg = await tabB.call('getReceived');
+      assert(afterBadMsg.length === 0, '未登録コールバックは静かに無視される');
+
+      head('■ テスト11: deviceId分離（干渉しない）');
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      await tabA.call('create', { deviceId: DEVICE_ID });     // device 99
+      await tabB.call('create', { deviceId: DEVICE_ID + 1 }); // device 100
+
+      await tabA.call('claimPrimary');
+      await wait(50);
+
+      const crossCheck = await tabB.call('isRemotePrimaryAvailable');
+      assert(crossCheck === false, 'device 99のPrimaryはdevice 100から見えない');
+
+      head('■ クリーンアップ');
+      await tabA.call('release');
+      await tabB.call('release');
+      try { await tabC.call('release'); } catch (_) {}
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID}`);
+      localStorage.removeItem(`orphe_bridge_primary_${DEVICE_ID + 1}`);
+      tabA.destroy();
+      tabB.destroy();
+      try { tabC.destroy(); } catch (_) {}
+      log('  OK');
+
+      // サマリ
+      summaryEl.style.display = 'block';
+      if (failed === 0) {
+        summaryEl.className = 'summary ok';
+        summaryEl.textContent = `✓ 全 ${passed} テストがパスしました`;
+      } else {
+        summaryEl.className = 'summary ng';
+        summaryEl.textContent = `✗ ${passed} passed / ${failed} failed`;
+      }
+    }
+
+    async function runAll() {
+      resultsEl.innerHTML = '';
+      summaryEl.style.display = 'none';
+      passed = 0; failed = 0;
+      try { await runTests(); }
+      catch (err) { log('実行エラー: ' + err.message + '\n' + err.stack, 'fail'); }
+      // ヘッドレステスト用にDOMにマーカーを置く
+      const marker = document.createElement('div');
+      marker.id = 'test_complete_marker';
+      marker.setAttribute('data-passed', String(passed));
+      marker.setAttribute('data-failed', String(failed));
+      document.body.appendChild(marker);
+      document.title = failed === 0 ? `PASS ${passed}/${passed}` : `FAIL ${failed}/${passed+failed}`;
+    }
+
+    document.getElementById('run_btn').addEventListener('click', async (e) => {
+      e.target.disabled = true;
+      await runAll();
+      e.target.disabled = false;
+    });
+
+    // ?autorun=1 で自動実行（ヘッドレステスト用）
+    if (new URLSearchParams(location.search).has('autorun')) {
+      window.addEventListener('load', () => runAll());
+    }
+  </script>
+</body>
+</html>

--- a/js/BleSharedBridge.js
+++ b/js/BleSharedBridge.js
@@ -1,0 +1,222 @@
+var bleSharedBridge_version_date = `
+Last modified: 2026-04-19
+`;
+
+/**
+ * BleSharedBridge
+ *
+ * 複数のブラウザタブ間でORPHE COREのBLE接続を共有するブリッジモジュール。
+ *
+ * 動作原理:
+ *   - Primary tab : BLE接続を保持し、センサーデータをBroadcastChannelで全タブに配信する
+ *   - Secondary tab: BLE接続不要。BroadcastChannelを購読してデータを受信し、
+ *                    通常の got* コールバックをそのまま利用できる
+ *
+ * Primary検出:
+ *   localStorage にハートビートを書き込み、3秒以内に更新されているタブを
+ *   Primary とみなす。Primaryが閉じると heartbeat が途絶え、Secondary が
+ *   navigator.bluetooth.getDevices() を使って自動再接続を試みる。
+ *
+ * 使い方:
+ *   ORPHE-CORE.js と CoreToolkit.js が自動的に利用するため、
+ *   ユーザが直接インスタンスを生成する必要はない。
+ */
+class BleSharedBridge {
+  /**
+   * @param {number} deviceId - Orphe インスタンスの id (0 または 1)
+   */
+  constructor(deviceId) {
+    this.deviceId = deviceId;
+    this._storageKey = `orphe_bridge_primary_${deviceId}`;
+    this._channelName = `orphe-ble-bridge-${deviceId}`;
+    this._tabId = `tab_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+    this.isPrimary = false;
+    this._channel = null;
+    this._heartbeatInterval = null;
+    this._watchInterval = null;
+    this._callbacks = {};
+    this.onPrimaryLost = null; // Secondary が Primary 喪失を検知したときのコールバック
+  }
+
+  // ─── Primary 検出 ───────────────────────────────────────────
+
+  /**
+   * 別タブに有効な Primary が存在するか確認する
+   * @returns {boolean}
+   */
+  isRemotePrimaryAvailable() {
+    try {
+      const raw = localStorage.getItem(this._storageKey);
+      if (!raw) return false;
+      const { timestamp, tabId } = JSON.parse(raw);
+      // 自分自身は除外、3秒以内に更新されていれば有効
+      return tabId !== this._tabId && (Date.now() - timestamp < 3000);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  // ─── Primary モード ──────────────────────────────────────────
+
+  /**
+   * このタブを Primary として登録し、BroadcastChannel を開く
+   */
+  claimPrimary() {
+    this.isPrimary = true;
+    this._openChannel();
+    this._updateHeartbeat();
+    this._heartbeatInterval = setInterval(() => this._updateHeartbeat(), 1000);
+
+    // 他のタブに接続完了を通知
+    this._send({ type: 'primary_connected', deviceId: this.deviceId });
+  }
+
+  /**
+   * センサーデータを他タブへブロードキャストする（Primary のみ使用）
+   * @param {string} callbackName - 'gotAcc' など got* のメソッド名
+   * @param {Object} data - コールバックに渡すデータオブジェクト
+   */
+  broadcast(callbackName, data) {
+    if (!this.isPrimary || !this._channel) return;
+    this._send({
+      type: 'sensor_data',
+      deviceId: this.deviceId,
+      callbackName,
+      data,
+    });
+  }
+
+  /**
+   * 切断を全タブへ通知し、Primary リソースを解放する
+   */
+  broadcastDisconnect() {
+    this._send({ type: 'disconnected', deviceId: this.deviceId });
+    this.release();
+  }
+
+  // ─── Secondary モード ────────────────────────────────────────
+
+  /**
+   * このタブを Secondary として BroadcastChannel を購読する
+   * @param {Object} callbacks
+   * @param {Function} callbacks.onPrimaryConnected  - Primary が接続したとき
+   * @param {Function} callbacks.onDisconnect        - Primary が切断されたとき
+   * @param {Function} callbacks.onReconnectNeeded   - 自動再接続が必要なとき
+   * @param {Function} [callbacks.gotAcc]            - 各センサーコールバック
+   */
+  subscribeAsSecondary(callbacks) {
+    this.isPrimary = false;
+    this._callbacks = callbacks;
+    this._openChannel();
+    this._channel.onmessage = (event) => this._handleMessage(event.data);
+
+    // Primary の heartbeat を監視し、途絶えたら再接続を促す
+    this._watchInterval = setInterval(() => {
+      if (!this.isRemotePrimaryAvailable()) {
+        this._onPrimaryLost();
+      }
+    }, 2000);
+  }
+
+  // ─── Fast Reconnect ──────────────────────────────────────────
+
+  /**
+   * ペアリング済みデバイスを取得し、再接続ダイアログなしで接続できるデバイスを返す
+   * navigator.bluetooth.getDevices() が利用可能な Chrome でのみ動作する
+   * @returns {Promise<BluetoothDevice|null>}
+   */
+  async getPairedDevice() {
+    if (!navigator.bluetooth?.getDevices) return null;
+    try {
+      const devices = await navigator.bluetooth.getDevices();
+      return devices.length > 0 ? devices[0] : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ─── 共通 ────────────────────────────────────────────────────
+
+  /**
+   * リソースをすべて解放する
+   */
+  release() {
+    if (this._heartbeatInterval) {
+      clearInterval(this._heartbeatInterval);
+      this._heartbeatInterval = null;
+    }
+    if (this._watchInterval) {
+      clearInterval(this._watchInterval);
+      this._watchInterval = null;
+    }
+    if (this.isPrimary) {
+      try { localStorage.removeItem(this._storageKey); } catch (_) {}
+    }
+    if (this._channel) {
+      this._channel.close();
+      this._channel = null;
+    }
+    this.isPrimary = false;
+  }
+
+  // ─── 内部メソッド ─────────────────────────────────────────────
+
+  _openChannel() {
+    if (this._channel) return;
+    try {
+      this._channel = new BroadcastChannel(this._channelName);
+    } catch (e) {
+      console.warn('[BleSharedBridge] BroadcastChannel が利用できません:', e);
+    }
+  }
+
+  _send(msg) {
+    try {
+      if (this._channel) this._channel.postMessage(msg);
+    } catch (_) {}
+  }
+
+  _updateHeartbeat() {
+    try {
+      localStorage.setItem(this._storageKey, JSON.stringify({
+        timestamp: Date.now(),
+        tabId: this._tabId,
+      }));
+    } catch (_) {}
+  }
+
+  _handleMessage(msg) {
+    if (msg.deviceId !== this.deviceId) return;
+
+    if (msg.type === 'sensor_data') {
+      const cb = this._callbacks[msg.callbackName];
+      if (typeof cb === 'function') cb(msg.data);
+
+    } else if (msg.type === 'disconnected') {
+      clearInterval(this._watchInterval);
+      this._watchInterval = null;
+      if (typeof this._callbacks.onDisconnect === 'function') {
+        this._callbacks.onDisconnect();
+      }
+      // 自動再接続のトリガー
+      if (typeof this._callbacks.onReconnectNeeded === 'function') {
+        this._callbacks.onReconnectNeeded();
+      }
+
+    } else if (msg.type === 'primary_connected') {
+      if (typeof this._callbacks.onPrimaryConnected === 'function') {
+        this._callbacks.onPrimaryConnected();
+      }
+    }
+  }
+
+  _onPrimaryLost() {
+    // watchInterval を止めてループしない
+    clearInterval(this._watchInterval);
+    this._watchInterval = null;
+
+    if (typeof this._callbacks.onReconnectNeeded === 'function') {
+      this._callbacks.onReconnectNeeded();
+    }
+  }
+}

--- a/js/BleSharedBridge.js
+++ b/js/BleSharedBridge.js
@@ -1,25 +1,26 @@
-var bleSharedBridge_version_date = `
-Last modified: 2026-04-19
-`;
+var bleSharedBridge_version_date = `2026-04-19`;
 
 /**
  * BleSharedBridge
  *
- * 複数のブラウザタブ間でORPHE COREのBLE接続を共有するブリッジモジュール。
+ * 複数のブラウザタブ間で ORPHE CORE の BLE 接続を共有するブリッジモジュール。
  *
- * 動作原理:
- *   - Primary tab : BLE接続を保持し、センサーデータをBroadcastChannelで全タブに配信する
- *   - Secondary tab: BLE接続不要。BroadcastChannelを購読してデータを受信し、
- *                    通常の got* コールバックをそのまま利用できる
+ * 仕組み:
+ *   - Primary tab   : BLE接続を保持し、センサーデータを BroadcastChannel で配信
+ *   - Secondary tab : BLE接続不要。チャネルを購読してデータを受信し、通常の
+ *                     got* コールバックをそのまま利用できる
  *
  * Primary検出:
- *   localStorage にハートビートを書き込み、3秒以内に更新されているタブを
- *   Primary とみなす。Primaryが閉じると heartbeat が途絶え、Secondary が
- *   navigator.bluetooth.getDevices() を使って自動再接続を試みる。
+ *   - localStorage にハートビート（1秒毎）を書き込む
+ *   - `storage` イベントで他タブの変更を即時検知（ポーリング不要）
+ *   - `pagehide` でタブ閉じ時にクリーン通知
+ *   - 上記が抜けたケースに備えて 2秒ポーリングでフォールバック
  *
- * 使い方:
- *   ORPHE-CORE.js と CoreToolkit.js が自動的に利用するため、
- *   ユーザが直接インスタンスを生成する必要はない。
+ * Primary喪失時:
+ *   - 各 Secondary がランダム遅延（0〜1500ms）後に再接続を試みる
+ *   - 遅延後に再度 localStorage を確認し、他タブが先に Primary になっていれば
+ *     Secondary に戻る（暗黙的なリーダー選出）
+ *   - Fast Reconnect: navigator.bluetooth.getDevices() でダイアログ不要の再接続
  */
 class BleSharedBridge {
   /**
@@ -29,17 +30,26 @@ class BleSharedBridge {
     this.deviceId = deviceId;
     this._storageKey = `orphe_bridge_primary_${deviceId}`;
     this._channelName = `orphe-ble-bridge-${deviceId}`;
-    this._tabId = `tab_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+    this._tabId = `tab_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
     this.isPrimary = false;
     this._channel = null;
     this._heartbeatInterval = null;
     this._watchInterval = null;
+    this._storageListener = null;
+    this._pagehideListener = null;
     this._callbacks = {};
-    this.onPrimaryLost = null; // Secondary が Primary 喪失を検知したときのコールバック
   }
 
-  // ─── Primary 検出 ───────────────────────────────────────────
+  // ─── タイミング定数 ──────────────────────────────────────────
+  // バックグラウンドタブで setInterval が throttle されても誤検知しないよう
+  // タイムアウトには十分な余裕を持たせる。
+  static get HEARTBEAT_INTERVAL_MS() { return 1000; }
+  static get HEARTBEAT_TIMEOUT_MS()  { return 5000; }
+  static get WATCH_INTERVAL_MS()     { return 2000; }
+  static get ELECTION_MAX_DELAY_MS() { return 1500; }
 
+  // ─── Primary 検出 ───────────────────────────────────────────
   /**
    * 別タブに有効な Primary が存在するか確認する
    * @returns {boolean}
@@ -49,15 +59,14 @@ class BleSharedBridge {
       const raw = localStorage.getItem(this._storageKey);
       if (!raw) return false;
       const { timestamp, tabId } = JSON.parse(raw);
-      // 自分自身は除外、3秒以内に更新されていれば有効
-      return tabId !== this._tabId && (Date.now() - timestamp < 3000);
+      return tabId !== this._tabId &&
+        (Date.now() - timestamp < BleSharedBridge.HEARTBEAT_TIMEOUT_MS);
     } catch (_) {
       return false;
     }
   }
 
   // ─── Primary モード ──────────────────────────────────────────
-
   /**
    * このタブを Primary として登録し、BroadcastChannel を開く
    */
@@ -65,25 +74,33 @@ class BleSharedBridge {
     this.isPrimary = true;
     this._openChannel();
     this._updateHeartbeat();
-    this._heartbeatInterval = setInterval(() => this._updateHeartbeat(), 1000);
+    this._heartbeatInterval = setInterval(
+      () => this._updateHeartbeat(),
+      BleSharedBridge.HEARTBEAT_INTERVAL_MS
+    );
 
-    // 他のタブに接続完了を通知
-    this._send({ type: 'primary_connected', deviceId: this.deviceId });
+    // タブが閉じられたときに自分のエントリを即時除去する
+    this._pagehideListener = () => {
+      this._cleanupOwnPrimaryEntry();
+      this._send({ type: 'disconnected', deviceId: this.deviceId });
+    };
+    window.addEventListener('pagehide', this._pagehideListener);
   }
 
   /**
-   * センサーデータを他タブへブロードキャストする（Primary のみ使用）
-   * @param {string} callbackName - 'gotAcc' など got* のメソッド名
-   * @param {Object} data - コールバックに渡すデータオブジェクト
+   * 複数のコールバック呼び出しを1メッセージにまとめてブロードキャストする
+   * @param {Object<string, any>} batch - 例: { gotAcc: {...}, gotQuat: {...} }
+   */
+  broadcastBatch(batch) {
+    if (!this.isPrimary || !this._channel) return;
+    this._send({ type: 'batch', deviceId: this.deviceId, batch });
+  }
+
+  /**
+   * 単一コールバックをブロードキャストする（互換API）
    */
   broadcast(callbackName, data) {
-    if (!this.isPrimary || !this._channel) return;
-    this._send({
-      type: 'sensor_data',
-      deviceId: this.deviceId,
-      callbackName,
-      data,
-    });
+    this.broadcastBatch({ [callbackName]: data });
   }
 
   /**
@@ -95,50 +112,36 @@ class BleSharedBridge {
   }
 
   // ─── Secondary モード ────────────────────────────────────────
-
   /**
    * このタブを Secondary として BroadcastChannel を購読する
    * @param {Object} callbacks
-   * @param {Function} callbacks.onPrimaryConnected  - Primary が接続したとき
-   * @param {Function} callbacks.onDisconnect        - Primary が切断されたとき
-   * @param {Function} callbacks.onReconnectNeeded   - 自動再接続が必要なとき
-   * @param {Function} [callbacks.gotAcc]            - 各センサーコールバック
+   * @param {Function} callbacks.onPrimaryLost - Primary が喪失/切断されたとき
+   * @param {Function} [callbacks.gotAcc]      - 各センサーコールバック
    */
   subscribeAsSecondary(callbacks) {
     this.isPrimary = false;
     this._callbacks = callbacks;
     this._openChannel();
-    this._channel.onmessage = (event) => this._handleMessage(event.data);
-
-    // Primary の heartbeat を監視し、途絶えたら再接続を促す
-    this._watchInterval = setInterval(() => {
-      if (!this.isRemotePrimaryAvailable()) {
-        this._onPrimaryLost();
-      }
-    }, 2000);
-  }
-
-  // ─── Fast Reconnect ──────────────────────────────────────────
-
-  /**
-   * ペアリング済みデバイスを取得し、再接続ダイアログなしで接続できるデバイスを返す
-   * navigator.bluetooth.getDevices() が利用可能な Chrome でのみ動作する
-   * @returns {Promise<BluetoothDevice|null>}
-   */
-  async getPairedDevice() {
-    if (!navigator.bluetooth?.getDevices) return null;
-    try {
-      const devices = await navigator.bluetooth.getDevices();
-      return devices.length > 0 ? devices[0] : null;
-    } catch (_) {
-      return null;
+    if (this._channel) {
+      this._channel.onmessage = (event) => this._handleMessage(event.data);
     }
+
+    // storage イベントは同一オリジンの他タブの localStorage 変更を即時検知する
+    this._storageListener = (e) => {
+      if (e.key !== this._storageKey) return;
+      if (e.newValue === null) this._firePrimaryLost();
+    };
+    window.addEventListener('storage', this._storageListener);
+
+    // フォールバックポーリング（heartbeat タイムアウト用）
+    this._watchInterval = setInterval(() => {
+      if (!this.isRemotePrimaryAvailable()) this._firePrimaryLost();
+    }, BleSharedBridge.WATCH_INTERVAL_MS);
   }
 
   // ─── 共通 ────────────────────────────────────────────────────
-
   /**
-   * リソースをすべて解放する
+   * すべてのリソースを解放する
    */
   release() {
     if (this._heartbeatInterval) {
@@ -149,31 +152,34 @@ class BleSharedBridge {
       clearInterval(this._watchInterval);
       this._watchInterval = null;
     }
-    if (this.isPrimary) {
-      try { localStorage.removeItem(this._storageKey); } catch (_) {}
+    if (this._storageListener) {
+      window.removeEventListener('storage', this._storageListener);
+      this._storageListener = null;
     }
+    if (this._pagehideListener) {
+      window.removeEventListener('pagehide', this._pagehideListener);
+      this._pagehideListener = null;
+    }
+    if (this.isPrimary) this._cleanupOwnPrimaryEntry();
     if (this._channel) {
-      this._channel.close();
+      try { this._channel.close(); } catch (_) {}
       this._channel = null;
     }
     this.isPrimary = false;
   }
 
   // ─── 内部メソッド ─────────────────────────────────────────────
-
   _openChannel() {
     if (this._channel) return;
     try {
       this._channel = new BroadcastChannel(this._channelName);
     } catch (e) {
-      console.warn('[BleSharedBridge] BroadcastChannel が利用できません:', e);
+      console.warn('[BleSharedBridge] BroadcastChannel unavailable:', e);
     }
   }
 
   _send(msg) {
-    try {
-      if (this._channel) this._channel.postMessage(msg);
-    } catch (_) {}
+    try { this._channel?.postMessage(msg); } catch (_) {}
   }
 
   _updateHeartbeat() {
@@ -185,38 +191,46 @@ class BleSharedBridge {
     } catch (_) {}
   }
 
+  /**
+   * localStorage から自分の Primary エントリのみを削除する
+   * （他タブが既に Primary を奪取している場合は何もしない）
+   */
+  _cleanupOwnPrimaryEntry() {
+    try {
+      const raw = localStorage.getItem(this._storageKey);
+      if (!raw) return;
+      const { tabId } = JSON.parse(raw);
+      if (tabId === this._tabId) localStorage.removeItem(this._storageKey);
+    } catch (_) {}
+  }
+
   _handleMessage(msg) {
-    if (msg.deviceId !== this.deviceId) return;
+    if (!msg || msg.deviceId !== this.deviceId) return;
 
-    if (msg.type === 'sensor_data') {
-      const cb = this._callbacks[msg.callbackName];
-      if (typeof cb === 'function') cb(msg.data);
-
+    if (msg.type === 'batch' && msg.batch) {
+      for (const name in msg.batch) {
+        const cb = this._callbacks[name];
+        if (typeof cb === 'function') cb(msg.batch[name]);
+      }
     } else if (msg.type === 'disconnected') {
-      clearInterval(this._watchInterval);
-      this._watchInterval = null;
-      if (typeof this._callbacks.onDisconnect === 'function') {
-        this._callbacks.onDisconnect();
-      }
-      // 自動再接続のトリガー
-      if (typeof this._callbacks.onReconnectNeeded === 'function') {
-        this._callbacks.onReconnectNeeded();
-      }
-
-    } else if (msg.type === 'primary_connected') {
-      if (typeof this._callbacks.onPrimaryConnected === 'function') {
-        this._callbacks.onPrimaryConnected();
-      }
+      this._firePrimaryLost();
     }
   }
 
-  _onPrimaryLost() {
-    // watchInterval を止めてループしない
-    clearInterval(this._watchInterval);
-    this._watchInterval = null;
+  /**
+   * onPrimaryLost を1回だけ発火する（重複検知してもループしない）
+   */
+  _firePrimaryLost() {
+    if (this._primaryLostFired) return;
+    this._primaryLostFired = true;
 
-    if (typeof this._callbacks.onReconnectNeeded === 'function') {
-      this._callbacks.onReconnectNeeded();
+    // Secondary の監視はもう不要
+    if (this._watchInterval) {
+      clearInterval(this._watchInterval);
+      this._watchInterval = null;
     }
+
+    const cb = this._callbacks.onPrimaryLost;
+    if (typeof cb === 'function') cb();
   }
 }

--- a/js/CoreToolkit.js
+++ b/js/CoreToolkit.js
@@ -197,11 +197,14 @@ async function toggleCoreModule(dom, options = {}) {
                 </i>`;
                 freqEl.title = '別タブのBLE接続を共有中';
             }
-            // Primary が切れたら自動でトグルをリセット
+            // Primary が切れたら UI をリセット（ユーザ設定の onDisconnect は保持）
+            const userOnDisconnect = ble.onDisconnect;
             ble.onDisconnect = function () {
+                if (typeof userOnDisconnect === 'function') userOnDisconnect.call(this);
                 const sw = document.querySelector(`#switch_ble${number}`);
                 if (sw) sw.checked = false;
-                document.querySelector(`#ui${number}`).style.visibility = 'hidden';
+                const uiEl = document.querySelector(`#ui${number}`);
+                if (uiEl) uiEl.style.visibility = 'hidden';
             };
         } else {
             ble.gotBLEFrequency = function (freq) {

--- a/js/CoreToolkit.js
+++ b/js/CoreToolkit.js
@@ -157,13 +157,21 @@ function buildCoreToolkit(parent_element, title, core_id = 0, notification = 'ST
   <div class="d-grid gap-2 col-10 mx-auto mt-4">
   <button class="btn btn-warning text-white" type="button" onclick="resetCoreModule(${core_id});">Reset
     Attitude & Gait Analysis</button>
-</div>`, 'modal-body', '', div_modal_content);
+  <button class="btn btn-outline-primary" type="button" id="button_switch_device${core_id}">Select another CORE</button>
+	</div>`, 'modal-body', '', div_modal_content);
 
     // div_modal_bodyにある notificationセレクタを設定値にあわせる
     let select_notify = div_modal_body.querySelector(`#select_notify${core_id}`);
     if (notification == 'STEP_ANALYSIS') select_notify.options[0].selected = true;
     else if (notification == 'SENSOR_VALUES') select_notify.options[1].selected = true;
     else if (notification == 'STEP_ANALYSIS_AND_SENSOR_VALURS') select_notify.options[2].selected = true;
+
+    const switchDeviceButton = div_modal_body.querySelector(`#button_switch_device${core_id}`);
+    if (switchDeviceButton) {
+        switchDeviceButton.addEventListener('click', function () {
+            switchCoreBluetoothDevice(core_id, options);
+        });
+    }
 }
 
 /**
@@ -215,6 +223,30 @@ async function toggleCoreModule(dom, options = {}) {
     else {
         ble.reset();
         document.querySelector(`#ui${number}`).style.visibility = 'hidden';
+    }
+}
+
+/**
+ * CoreToolkitから別のBluetoothデバイスを手動選択して接続し直す。
+ * @param {number} no - core_id(0,1)
+ * @param {object} options
+ */
+async function switchCoreBluetoothDevice(no, options = {}) {
+    const ble = bles[no];
+    const sw = document.querySelector(`#switch_ble${no}`);
+    const uiEl = document.querySelector(`#ui${no}`);
+    const notification = sw?.getAttribute('notification') || 'STEP_ANALYSIS_AND_SENSOR_VALUES';
+
+    try {
+        if (uiEl) uiEl.style.visibility = 'hidden';
+        await ble.selectBluetoothDevice('DEVICE_INFORMATION');
+        const ret = await ble.begin(notification, options);
+        if (sw) sw.checked = !!ret;
+        if (ret && uiEl) uiEl.style.visibility = 'visible';
+    } catch (error) {
+        if (sw) sw.checked = false;
+        if (uiEl) uiEl.style.visibility = 'hidden';
+        ble.onError(error);
     }
 }
 

--- a/js/CoreToolkit.js
+++ b/js/CoreToolkit.js
@@ -24,6 +24,8 @@ var cores = bles;
 function buildCoreToolkit(parent_element, title, core_id = 0, notification = 'STEP_ANALYSIS_AND_SENSOR_VALUES', options = {}) {
     // デフォルト値を設定
     options.range = options.range || { acc: -1, gyro: -1 };
+    if (typeof options.autoReconnect === 'undefined') options.autoReconnect = true;
+    bles[core_id]._coreToolkitOptions = options;
 
     // console.log(options)
     if (options.range && options.range.acc != -1 && options.range.gyro != -1) {
@@ -259,17 +261,18 @@ async function switchCoreBluetoothDevice(no, options = {}) {
  * @param {dom} dom  - notificationのセレクタ
  */
 function changeNotify(no, dom) {
+    const options = bles[no]._coreToolkitOptions || {};
     if (bles[no].notification_type == 'STEP_ANALYSIS') {
         bles[no].stopNotify('STEP_ANALYSIS').then(() => {
             setTimeout(function () {
-                bles[no].begin(dom.value);
+                bles[no].begin(dom.value, options);
             }, 500);
         });
     }
     else if (bles[no].notification_type == 'SENSOR_VALUES') {
         bles[no].stopNotify('SENSOR_VALUES').then(() => {
             setTimeout(function () {
-                bles[no].begin(dom.value);
+                bles[no].begin(dom.value, options);
             }, 500);
         });
     }
@@ -277,7 +280,7 @@ function changeNotify(no, dom) {
         bles[no].stopNotify('STEP_ANALYSIS').then(() => {
             bles[no].stopNotify('SENSOR_VALUES').then(() => {
                 setTimeout(function () {
-                    bles[no].begin(dom.value);
+                    bles[no].begin(dom.value, options);
                 }, 500);
             });
         });

--- a/js/CoreToolkit.js
+++ b/js/CoreToolkit.js
@@ -173,7 +173,6 @@ function buildCoreToolkit(parent_element, title, core_id = 0, notification = 'ST
  * 
  */
 async function toggleCoreModule(dom, options = {}) {
-    // console.log("toggleCoreModule", options);
     let checked = dom.checked;
     let number = parseInt(dom.value);
     let ble = bles[number];
@@ -186,14 +185,33 @@ async function toggleCoreModule(dom, options = {}) {
         }
 
         document.querySelector(`#ui${number}`).style.visibility = 'visible';
-        ble.gotBLEFrequency = function (freq) {
-            document.querySelector(`#freq${this.id} `).innerHTML = `${Math.floor(freq)} Hz`;
-        };
+
+        // BleSharedBridge: Secondary モードの場合は「共有接続中」を表示
+        if (ble._isBridgeSecondary) {
+            const freqEl = document.querySelector(`#icon_bluetooth${number}`);
+            if (freqEl) {
+                freqEl.innerHTML = `<i class="bi bi-broadcast position-relative">
+                  <span class="position-absolute top-0 start-50 translate-middle badge text-muted" style="font-size:0.2em;" id="freq${number}">
+                    共有
+                  </span>
+                </i>`;
+                freqEl.title = '別タブのBLE接続を共有中';
+            }
+            // Primary が切れたら自動でトグルをリセット
+            ble.onDisconnect = function () {
+                const sw = document.querySelector(`#switch_ble${number}`);
+                if (sw) sw.checked = false;
+                document.querySelector(`#ui${number}`).style.visibility = 'hidden';
+            };
+        } else {
+            ble.gotBLEFrequency = function (freq) {
+                document.querySelector(`#freq${this.id} `).innerHTML = `${Math.floor(freq)} Hz`;
+            };
+        }
     }
     else {
         ble.reset();
         document.querySelector(`#ui${number}`).style.visibility = 'hidden';
-        //setHeaderStatusOffline(ble.id);
     }
 }
 

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -587,7 +587,13 @@ class Orphe {
     this.steps_number = 0;
   }
   scan(uuid, options = {}) {
-    return (this.bluetoothDevice ? Promise.resolve() : this.requestDevice(uuid))
+    return (this.bluetoothDevice ? Promise.resolve() : this._requestRememberedBluetoothDevice())
+      .then(device => {
+        if (!device) return this.requestDevice(uuid);
+        this.bluetoothDevice = device;
+        this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
+        this.onScan(this.bluetoothDevice.name);
+      })
       .catch(error => {
         this.onError(error);
       });
@@ -669,6 +675,16 @@ class Orphe {
     }
 
     return null;
+  }
+
+  async _requestRememberedBluetoothDevice() {
+    if (!navigator.bluetooth?.getDevices) return null;
+    try {
+      const devices = await navigator.bluetooth.getDevices();
+      return this._findLastBluetoothDevice(devices);
+    } catch (_) {
+      return null;
+    }
   }
 
   /**

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -477,6 +477,17 @@ class Orphe {
           this._bridge = new BleSharedBridge(this.id);
           this._isBridgeSecondary = false;
           this._bridge.claimPrimary();
+
+          // Primary の BLE が予期せず切断された場合、他タブへ通知する
+          if (this.bluetoothDevice && !this._bridgeBleDisconnectHooked) {
+            this._bridgeBleDisconnectHooked = true;
+            this.bluetoothDevice.addEventListener('gattserverdisconnected', () => {
+              if (this._bridge && this._bridge.isPrimary) {
+                this._bridge.broadcastDisconnect();
+                this._bridge = null;
+              }
+            });
+          }
         }
         return result;
       })
@@ -841,84 +852,80 @@ class Orphe {
   }
 
   /**
-   * Secondary モードとして begin する内部メソッド（BleSharedBridge 用）
+   * Secondary として begin する（BleSharedBridge 用内部メソッド）
    * @param {BleSharedBridge} bridge
-   * @param {string} str_type - notification type
+   * @param {string} str_type
    * @returns {Promise<string>}
    */
   _beginAsSecondary(bridge, str_type) {
     this._bridge = bridge;
     this._isBridgeSecondary = true;
 
-    const self = this;
-    bridge.subscribeAsSecondary({
-      gotAcc:                    (d) => self.gotAcc(d),
-      gotGyro:                   (d) => self.gotGyro(d),
-      gotQuat:                   (d) => self.gotQuat(d),
-      gotEuler:                  (d) => self.gotEuler(d),
-      gotConvertedAcc:           (d) => self.gotConvertedAcc(d),
-      gotConvertedGyro:          (d) => self.gotConvertedGyro(d),
-      gotDelta:                  (d) => self.gotDelta(d),
-      gotGait:                   (d) => self.gotGait(d),
-      gotType:                   (d) => self.gotType(d),
-      gotDirection:              (d) => self.gotDirection(d),
-      gotDistance:               (d) => self.gotDistance(d),
-      gotCalorie:                (d) => self.gotCalorie(d),
-      gotStandingPhaseDuration:  (d) => self.gotStandingPhaseDuration(d),
-      gotSwingPhaseDuration:     (d) => self.gotSwingPhaseDuration(d),
-      gotStride:                 (d) => self.gotStride(d),
-      gotFootAngle:              (d) => self.gotFootAngle(d),
-      gotPronation:              (d) => self.gotPronation(d),
-      gotLandingImpact:          (d) => self.gotLandingImpact(d),
-      gotStepsNumber:            (d) => self.gotStepsNumber(d),
-      gotBLEFrequency:           (d) => self.gotBLEFrequency(d),
+    // Primary から受信するコールバック名の一覧。
+    // onRead() 内で発火するものをすべて列挙する。
+    const BRIDGE_CALLBACK_NAMES = [
+      'gotAcc', 'gotGyro', 'gotQuat', 'gotEuler',
+      'gotConvertedAcc', 'gotConvertedGyro', 'gotDelta',
+      'gotGait', 'gotType', 'gotDirection', 'gotDistance', 'gotCalorie',
+      'gotStandingPhaseDuration', 'gotSwingPhaseDuration',
+      'gotStride', 'gotFootAngle',
+      'gotPronation', 'gotLandingImpact',
+      'gotStepsNumber', 'gotBLEFrequency',
+    ];
+    const callbacks = {};
+    for (const name of BRIDGE_CALLBACK_NAMES) {
+      callbacks[name] = (d) => this[name](d);
+    }
+    callbacks.onPrimaryLost = () => this._handlePrimaryLost(str_type);
 
-      onPrimaryConnected: () => {
-        self.onConnect('BRIDGE_SECONDARY');
-      },
-      onDisconnect: () => {
-        self._isBridgeSecondary = false;
-        self.onDisconnect();
-      },
-      onReconnectNeeded: () => {
-        // Primary が消えた → Fast Reconnect を試みる
-        self._tryBridgeReconnect(str_type);
-      },
-    });
-
+    bridge.subscribeAsSecondary(callbacks);
     this.onConnect('BRIDGE_SECONDARY');
     return Promise.resolve('done begin(); BRIDGE SECONDARY');
   }
 
   /**
-   * Primary タブが閉じた際に自動再接続を試みる
-   * navigator.bluetooth.getDevices() でペアリング済みデバイスがあればダイアログ不要で接続
+   * Primary 喪失時の処理。ランダム遅延を挟んでリーダー選出を行い、
+   * - 他タブが先に Primary になった → Secondary に戻る
+   * - 自分が先着 → Fast Reconnect で BLE 接続
+   * - Fast Reconnect 不可 → 手動接続を促す
    * @param {string} str_type
    */
-  async _tryBridgeReconnect(str_type) {
+  async _handlePrimaryLost(str_type) {
+    // 多重発火ガード
+    if (!this._isBridgeSecondary) return;
+    this._isBridgeSecondary = false;
+
     if (this._bridge) {
       this._bridge.release();
       this._bridge = null;
-      this._isBridgeSecondary = false;
     }
     this.onDisconnect();
 
-    // Fast Reconnect: ペアリング済みデバイスがあればダイアログなしで再接続
+    // 全 Secondary が同時に再接続するのを避けるためランダム遅延
+    const delay = Math.random() * BleSharedBridge.ELECTION_MAX_DELAY_MS;
+    await new Promise(r => setTimeout(r, delay));
+
+    // 遅延中に他タブが Primary を取っていれば Secondary として再購読
+    const probe = new BleSharedBridge(this.id);
+    if (probe.isRemotePrimaryAvailable()) {
+      await this._beginAsSecondary(probe, str_type);
+      return;
+    }
+
+    // Fast Reconnect: ペアリング済みデバイスならダイアログなしで接続
     if (navigator.bluetooth?.getDevices) {
       try {
         const devices = await navigator.bluetooth.getDevices();
         if (devices.length > 0) {
           this.bluetoothDevice = devices[0];
           this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
-          // 直接 GATT 接続（requestDevice 不要）
           await this.begin(str_type);
           return;
         }
       } catch (_) {}
     }
 
-    // Fast Reconnect 不可 → UI 側で手動接続を促す
-    this.onError('Primary tab closed. Please reconnect.');
+    this.onError('Primary tab closed. Please reconnect manually.');
   }
 
 
@@ -926,13 +933,23 @@ class Orphe {
 
 
   /**
-   * BleSharedBridge 用: Primary タブからセンサーデータをブロードキャストする
+   * BleSharedBridge 用: 単一コールバックのデータを配信
    * @param {string} callbackName
    * @param {Object} data
    */
   _notifyBridge(callbackName, data) {
     if (this._bridge && this._bridge.isPrimary) {
       this._bridge.broadcast(callbackName, data);
+    }
+  }
+
+  /**
+   * BleSharedBridge 用: 複数コールバックをまとめて配信（メッセージ数を削減）
+   * @param {Object<string, Object>} batch
+   */
+  _notifyBridgeBatch(batch) {
+    if (this._bridge && this._bridge.isPrimary) {
+      this._bridge.broadcastBatch(batch);
     }
   }
 
@@ -1074,13 +1091,15 @@ class Orphe {
         this.gotCalorie({ value: this.gait.calorie });
         this.gotStandingPhaseDuration({ value: this.gait.standing_phase_duration });
         this.gotSwingPhaseDuration({ value: this.gait.swing_phase_duration });
-        this._notifyBridge('gotGait', this.gait);
-        this._notifyBridge('gotType', { value: this.gait.type });
-        this._notifyBridge('gotDistance', { value: this.gait.distance });
-        this._notifyBridge('gotDirection', { value: this.gait.direction });
-        this._notifyBridge('gotCalorie', { value: this.gait.calorie });
-        this._notifyBridge('gotStandingPhaseDuration', { value: this.gait.standing_phase_duration });
-        this._notifyBridge('gotSwingPhaseDuration', { value: this.gait.swing_phase_duration });
+        this._notifyBridgeBatch({
+          gotGait: this.gait,
+          gotType: { value: this.gait.type },
+          gotDistance: { value: this.gait.distance },
+          gotDirection: { value: this.gait.direction },
+          gotCalorie: { value: this.gait.calorie },
+          gotStandingPhaseDuration: { value: this.gait.standing_phase_duration },
+          gotSwingPhaseDuration: { value: this.gait.swing_phase_duration },
+        });
       }
       // Stride
       else if (data.getUint8(1) == 1 && steps_now > this.stride.steps) {
@@ -1096,8 +1115,10 @@ class Orphe {
           z: this.stride.z,
           steps_number: this.stride.steps
         });
-        this._notifyBridge('gotFootAngle', { value: this.stride.foot_angle });
-        this._notifyBridge('gotStride', { x: this.stride.x, y: this.stride.y, z: this.stride.z, steps_number: this.stride.steps });
+        this._notifyBridgeBatch({
+          gotFootAngle: { value: this.stride.foot_angle },
+          gotStride: { x: this.stride.x, y: this.stride.y, z: this.stride.z, steps_number: this.stride.steps },
+        });
       }
       // Pronation
       else if (data.getUint8(1) == 2 && steps_now > this.pronation.steps) {
@@ -1112,8 +1133,10 @@ class Orphe {
           z: this.pronation.z
         });
         this.gotLandingImpact({ value: this.pronation.landing_impact });
-        this._notifyBridge('gotPronation', { x: this.pronation.x, y: this.pronation.y, z: this.pronation.z });
-        this._notifyBridge('gotLandingImpact', { value: this.pronation.landing_impact });
+        this._notifyBridgeBatch({
+          gotPronation: { x: this.pronation.x, y: this.pronation.y, z: this.pronation.z },
+          gotLandingImpact: { value: this.pronation.landing_impact },
+        });
 
       }
       // Stride Attitude -- Not implemented
@@ -1140,9 +1163,11 @@ class Orphe {
         this.gotQuat(this.quat);
         this.gotDelta(this.delta);
         this.gotEuler(this.euler);
-        this._notifyBridge('gotQuat', this.quat);
-        this._notifyBridge('gotDelta', this.delta);
-        this._notifyBridge('gotEuler', this.euler);
+        this._notifyBridgeBatch({
+          gotQuat: this.quat,
+          gotDelta: this.delta,
+          gotEuler: this.euler,
+        });
       }
       // Sensor test
       else if (data.getUint8(1) == 5) {
@@ -1286,12 +1311,14 @@ class Orphe {
           let q = new Quaternion(this.quat.w, this.quat.x, this.quat.y, this.quat.z);
           this.euler = q.toEuler();
           this.gotEuler(this.euler);
-          this._notifyBridge('gotAcc', this.acc);
-          this._notifyBridge('gotQuat', this.quat);
-          this._notifyBridge('gotGyro', this.gyro);
-          this._notifyBridge('gotConvertedAcc', this.converted_acc);
-          this._notifyBridge('gotConvertedGyro', this.converted_gyro);
-          this._notifyBridge('gotEuler', this.euler);
+          this._notifyBridgeBatch({
+            gotAcc: this.acc,
+            gotQuat: this.quat,
+            gotGyro: this.gyro,
+            gotConvertedAcc: this.converted_acc,
+            gotConvertedGyro: this.converted_gyro,
+            gotEuler: this.euler,
+          });
         }
 
       }
@@ -1347,12 +1374,14 @@ class Orphe {
         let q = new Quaternion(this.quat.w, this.quat.x, this.quat.y, this.quat.z);
         this.euler = q.toEuler();
         this.gotEuler(this.euler);
-        this._notifyBridge('gotAcc', this.acc);
-        this._notifyBridge('gotQuat', this.quat);
-        this._notifyBridge('gotGyro', this.gyro);
-        this._notifyBridge('gotConvertedAcc', this.converted_acc);
-        this._notifyBridge('gotConvertedGyro', this.converted_gyro);
-        this._notifyBridge('gotEuler', this.euler);
+        this._notifyBridgeBatch({
+          gotAcc: this.acc,
+          gotQuat: this.quat,
+          gotGyro: this.gyro,
+          gotConvertedAcc: this.converted_acc,
+          gotConvertedGyro: this.converted_gyro,
+          gotEuler: this.euler,
+        });
       }
     }
   }

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -132,6 +132,10 @@ class Orphe {
     this.hashUUID = {}; // UUIDを保持するハッシュ
     this.hashUUID_lastConnected; // 最後に接続したUUIDを保持する
     this.id = id;
+
+    // BleSharedBridge: 複数タブ間接続共有
+    this._bridge = null;
+    this._isBridgeSecondary = false;
     this.array_device_information = new DataView(new ArrayBuffer(20));// device information用の配列
 
     /**
@@ -412,6 +416,15 @@ class Orphe {
     } = options;
     this.notification_type = str_type;
 
+    // ── BleSharedBridge: 別タブに Primary が存在するか確認 ──────────────
+    if (typeof BleSharedBridge !== 'undefined') {
+      const bridge = new BleSharedBridge(this.id);
+      if (bridge.isRemotePrimaryAvailable()) {
+        return this._beginAsSecondary(bridge, str_type);
+      }
+    }
+    // ────────────────────────────────────────────────────────────────────
+
     let obj = await this.getDeviceInformation();
 
     if (range.acc == 16) obj.range.acc = 3;
@@ -458,8 +471,13 @@ class Orphe {
         });
       }
     })
-      .then(async (result) => {  // この関数をasyncで宣言
-        // ここにresolveされたときに実行する共通のコードを書く
+      .then(async (result) => {
+        // BleSharedBridge: BLE接続成功後にこのタブを Primary として登録
+        if (typeof BleSharedBridge !== 'undefined' && result) {
+          this._bridge = new BleSharedBridge(this.id);
+          this._isBridgeSecondary = false;
+          this._bridge.claimPrimary();
+        }
         return result;
       })
       .catch(error => {  // ダイアログのキャンセルはそのまま閉じる
@@ -810,14 +828,113 @@ class Orphe {
    * reset(disconnect & clear)
    */
   reset() {
+    // BleSharedBridge: 切断を他タブに通知してリソース解放
+    if (this._bridge) {
+      if (this._bridge.isPrimary) this._bridge.broadcastDisconnect();
+      else this._bridge.release();
+      this._bridge = null;
+      this._isBridgeSecondary = false;
+    }
     this.disconnect(); //disconnect() is not Promise Object
     this.clear();
     this.onReset();
   }
 
+  /**
+   * Secondary モードとして begin する内部メソッド（BleSharedBridge 用）
+   * @param {BleSharedBridge} bridge
+   * @param {string} str_type - notification type
+   * @returns {Promise<string>}
+   */
+  _beginAsSecondary(bridge, str_type) {
+    this._bridge = bridge;
+    this._isBridgeSecondary = true;
+
+    const self = this;
+    bridge.subscribeAsSecondary({
+      gotAcc:                    (d) => self.gotAcc(d),
+      gotGyro:                   (d) => self.gotGyro(d),
+      gotQuat:                   (d) => self.gotQuat(d),
+      gotEuler:                  (d) => self.gotEuler(d),
+      gotConvertedAcc:           (d) => self.gotConvertedAcc(d),
+      gotConvertedGyro:          (d) => self.gotConvertedGyro(d),
+      gotDelta:                  (d) => self.gotDelta(d),
+      gotGait:                   (d) => self.gotGait(d),
+      gotType:                   (d) => self.gotType(d),
+      gotDirection:              (d) => self.gotDirection(d),
+      gotDistance:               (d) => self.gotDistance(d),
+      gotCalorie:                (d) => self.gotCalorie(d),
+      gotStandingPhaseDuration:  (d) => self.gotStandingPhaseDuration(d),
+      gotSwingPhaseDuration:     (d) => self.gotSwingPhaseDuration(d),
+      gotStride:                 (d) => self.gotStride(d),
+      gotFootAngle:              (d) => self.gotFootAngle(d),
+      gotPronation:              (d) => self.gotPronation(d),
+      gotLandingImpact:          (d) => self.gotLandingImpact(d),
+      gotStepsNumber:            (d) => self.gotStepsNumber(d),
+      gotBLEFrequency:           (d) => self.gotBLEFrequency(d),
+
+      onPrimaryConnected: () => {
+        self.onConnect('BRIDGE_SECONDARY');
+      },
+      onDisconnect: () => {
+        self._isBridgeSecondary = false;
+        self.onDisconnect();
+      },
+      onReconnectNeeded: () => {
+        // Primary が消えた → Fast Reconnect を試みる
+        self._tryBridgeReconnect(str_type);
+      },
+    });
+
+    this.onConnect('BRIDGE_SECONDARY');
+    return Promise.resolve('done begin(); BRIDGE SECONDARY');
+  }
+
+  /**
+   * Primary タブが閉じた際に自動再接続を試みる
+   * navigator.bluetooth.getDevices() でペアリング済みデバイスがあればダイアログ不要で接続
+   * @param {string} str_type
+   */
+  async _tryBridgeReconnect(str_type) {
+    if (this._bridge) {
+      this._bridge.release();
+      this._bridge = null;
+      this._isBridgeSecondary = false;
+    }
+    this.onDisconnect();
+
+    // Fast Reconnect: ペアリング済みデバイスがあればダイアログなしで再接続
+    if (navigator.bluetooth?.getDevices) {
+      try {
+        const devices = await navigator.bluetooth.getDevices();
+        if (devices.length > 0) {
+          this.bluetoothDevice = devices[0];
+          this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
+          // 直接 GATT 接続（requestDevice 不要）
+          await this.begin(str_type);
+          return;
+        }
+      } catch (_) {}
+    }
+
+    // Fast Reconnect 不可 → UI 側で手動接続を促す
+    this.onError('Primary tab closed. Please reconnect.');
+  }
 
 
 
+
+
+  /**
+   * BleSharedBridge 用: Primary タブからセンサーデータをブロードキャストする
+   * @param {string} callbackName
+   * @param {Object} data
+   */
+  _notifyBridge(callbackName, data) {
+    if (this._bridge && this._bridge.isPrimary) {
+      this._bridge.broadcast(callbackName, data);
+    }
+  }
 
   // Readコールバック
   /**
@@ -929,6 +1046,7 @@ class Orphe {
       const steps_now = data.getUint16(2);
       if ((0 <= header && header <= 2) && steps_now > this.steps_number) {
         this.gotStepsNumber({ value: steps_now });
+        this._notifyBridge('gotStepsNumber', { value: steps_now });
         this.steps_number = steps_now;
       }
 
@@ -956,6 +1074,13 @@ class Orphe {
         this.gotCalorie({ value: this.gait.calorie });
         this.gotStandingPhaseDuration({ value: this.gait.standing_phase_duration });
         this.gotSwingPhaseDuration({ value: this.gait.swing_phase_duration });
+        this._notifyBridge('gotGait', this.gait);
+        this._notifyBridge('gotType', { value: this.gait.type });
+        this._notifyBridge('gotDistance', { value: this.gait.distance });
+        this._notifyBridge('gotDirection', { value: this.gait.direction });
+        this._notifyBridge('gotCalorie', { value: this.gait.calorie });
+        this._notifyBridge('gotStandingPhaseDuration', { value: this.gait.standing_phase_duration });
+        this._notifyBridge('gotSwingPhaseDuration', { value: this.gait.swing_phase_duration });
       }
       // Stride
       else if (data.getUint8(1) == 1 && steps_now > this.stride.steps) {
@@ -971,6 +1096,8 @@ class Orphe {
           z: this.stride.z,
           steps_number: this.stride.steps
         });
+        this._notifyBridge('gotFootAngle', { value: this.stride.foot_angle });
+        this._notifyBridge('gotStride', { x: this.stride.x, y: this.stride.y, z: this.stride.z, steps_number: this.stride.steps });
       }
       // Pronation
       else if (data.getUint8(1) == 2 && steps_now > this.pronation.steps) {
@@ -984,7 +1111,9 @@ class Orphe {
           y: this.pronation.y,
           z: this.pronation.z
         });
-        this.gotLandingImpact({ value: this.pronation.landing_impact })
+        this.gotLandingImpact({ value: this.pronation.landing_impact });
+        this._notifyBridge('gotPronation', { x: this.pronation.x, y: this.pronation.y, z: this.pronation.z });
+        this._notifyBridge('gotLandingImpact', { value: this.pronation.landing_impact });
 
       }
       // Stride Attitude -- Not implemented
@@ -1011,6 +1140,9 @@ class Orphe {
         this.gotQuat(this.quat);
         this.gotDelta(this.delta);
         this.gotEuler(this.euler);
+        this._notifyBridge('gotQuat', this.quat);
+        this._notifyBridge('gotDelta', this.delta);
+        this._notifyBridge('gotEuler', this.euler);
       }
       // Sensor test
       else if (data.getUint8(1) == 5) {
@@ -1154,6 +1286,12 @@ class Orphe {
           let q = new Quaternion(this.quat.w, this.quat.x, this.quat.y, this.quat.z);
           this.euler = q.toEuler();
           this.gotEuler(this.euler);
+          this._notifyBridge('gotAcc', this.acc);
+          this._notifyBridge('gotQuat', this.quat);
+          this._notifyBridge('gotGyro', this.gyro);
+          this._notifyBridge('gotConvertedAcc', this.converted_acc);
+          this._notifyBridge('gotConvertedGyro', this.converted_gyro);
+          this._notifyBridge('gotEuler', this.euler);
         }
 
       }
@@ -1209,6 +1347,12 @@ class Orphe {
         let q = new Quaternion(this.quat.w, this.quat.x, this.quat.y, this.quat.z);
         this.euler = q.toEuler();
         this.gotEuler(this.euler);
+        this._notifyBridge('gotAcc', this.acc);
+        this._notifyBridge('gotQuat', this.quat);
+        this._notifyBridge('gotGyro', this.gyro);
+        this._notifyBridge('gotConvertedAcc', this.converted_acc);
+        this._notifyBridge('gotConvertedGyro', this.converted_gyro);
+        this._notifyBridge('gotEuler', this.euler);
       }
     }
   }

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -970,7 +970,7 @@ class Orphe {
       this._isBridgeSecondary = false;
     }
 
-    if (!wasBridgeSecondary) {
+    if (!wasBridgeSecondary && this.bluetoothDevice?.gatt?.connected) {
       this.disconnect(); //disconnect() is not Promise Object
     }
     this.clear();

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -587,7 +587,10 @@ class Orphe {
     this.steps_number = 0;
   }
   scan(uuid, options = {}) {
-    return (this.bluetoothDevice ? Promise.resolve() : this._requestRememberedBluetoothDevice())
+    if (this.bluetoothDevice) return Promise.resolve();
+
+    const useRememberedDevice = !options.forceDeviceSelection && this._getLastBluetoothDeviceInfo();
+    return (useRememberedDevice ? this._requestRememberedBluetoothDevice() : Promise.resolve(null))
       .then(device => {
         if (!device) return this.requestDevice(uuid);
         this.bluetoothDevice = device;
@@ -626,6 +629,27 @@ class Orphe {
         this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
         this.onScan(this.bluetoothDevice.name);
       });
+  }
+
+  /**
+   * 前回デバイスの記憶を使わず、必ずブラウザのBLE選択ダイアログを表示する。
+   * 接続済みCOREから別COREへ手動で切り替える場合に利用する。
+   * @param {string} uuid
+   */
+  selectBluetoothDevice(uuid = 'DEVICE_INFORMATION') {
+    this.forgetLastBluetoothDevice();
+    if (this._bridge) {
+      if (this._bridge.isPrimary) this._bridge.broadcastDisconnect();
+      else this._bridge.release();
+      this._bridge = null;
+      this._isBridgeSecondary = false;
+    }
+    if (this.bluetoothDevice?.gatt?.connected) {
+      try { this.bluetoothDevice.gatt.disconnect(); } catch (_) {}
+    }
+    this.bluetoothDevice = null;
+    this.dataCharacteristic = null;
+    return this.requestDevice(uuid);
   }
 
   /**

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -599,6 +599,7 @@ class Orphe {
       })
       .catch(error => {
         this.onError(error);
+        throw error;
       });
   }
   /**
@@ -720,7 +721,7 @@ class Orphe {
     if (!this.bluetoothDevice) {
       var error = "No Bluetooth Device";
       this.onError(error);
-      return;
+      return Promise.reject(error);
     }
     if (this.bluetoothDevice.gatt.connected && this.dataCharacteristic) {
       if (this.hashUUID_lastConnected == uuid)
@@ -742,6 +743,7 @@ class Orphe {
       })
       .catch(error => {
         this.onError(error);
+        throw error;
       });
   }
   /**
@@ -770,6 +772,7 @@ class Orphe {
       })
       .catch(error => {
         this.onError(error);
+        throw error;
       });
   }
   /**
@@ -792,6 +795,7 @@ class Orphe {
       })
       .catch(error => {
         this.onError(error);
+        throw error;
       });
   }
   /**
@@ -811,6 +815,7 @@ class Orphe {
       .catch(error => {
         console.error('startNotify: Error : ' + error);
         this.onError(error);
+        throw error;
       });
   }
   /**
@@ -844,6 +849,7 @@ class Orphe {
       })
       .catch(error => {
         this.onError(error);
+        throw error;
       });
 
   }

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -139,6 +139,14 @@ class Orphe {
     this._lastBluetoothDeviceStorageKey = `orphe_last_bluetooth_device_${id}`;
     this._usingRememberedBluetoothDevice = false;
     this._rememberedBluetoothDeviceUnavailable = false;
+    this._autoReconnectEnabled = false;
+    this._autoReconnectInProgress = false;
+    this._autoReconnectNotificationType = 'STEP_ANALYSIS';
+    this._autoReconnectOptions = {};
+    this._autoReconnectDevice = null;
+    this._autoReconnectDisconnectHandler = (event) => this._handleAutoReconnectDisconnect(event);
+    this._suppressAutoReconnectErrors = false;
+    this._lastAutoReconnectError = null;
     this.array_device_information = new DataView(new ArrayBuffer(20));// device information用の配列
 
     /**
@@ -415,9 +423,15 @@ class Orphe {
 
 
     const {
-      range = { acc: -1, gyro: -1 }
+      range = { acc: -1, gyro: -1 },
+      autoReconnect = false
     } = options;
     this.notification_type = str_type;
+    if (autoReconnect) {
+      this._enableAutoReconnect(str_type, options);
+    } else if (!this._autoReconnectInProgress) {
+      this._disableAutoReconnect();
+    }
 
     if (this._bridge) {
       this._bridge.release();
@@ -479,11 +493,15 @@ class Orphe {
           });
         });
       }
-    })
+      })
       .then(async (result) => {
+        if (result && this.bluetoothDevice) {
+          this._rememberBluetoothDevice(this.bluetoothDevice);
+          this._attachAutoReconnectDisconnectHandler(this.bluetoothDevice);
+        }
+
         // BleSharedBridge: BLE接続成功後にこのタブを Primary として登録
         if (typeof BleSharedBridge !== 'undefined' && result) {
-          this._rememberBluetoothDevice(this.bluetoothDevice);
           this._bridge = new BleSharedBridge(this.id);
           this._isBridgeSecondary = false;
           this._bridge.claimPrimary();
@@ -502,10 +520,126 @@ class Orphe {
         return result;
       })
       .catch(error => {  // ダイアログのキャンセルはそのまま閉じる
-        this.onError(error);
+        this._reportError(error);
         return;
       });
 
+  }
+
+
+  _reportError(error) {
+    if (this._suppressAutoReconnectErrors) {
+      this._lastAutoReconnectError = error;
+      return;
+    }
+    this.onError(error);
+  }
+
+  _enableAutoReconnect(str_type, options = {}) {
+    this._autoReconnectEnabled = true;
+    this._autoReconnectNotificationType = str_type;
+    this._autoReconnectOptions = Object.assign({}, options, { autoReconnect: true });
+  }
+
+  _disableAutoReconnect() {
+    this._autoReconnectEnabled = false;
+    this._autoReconnectInProgress = false;
+    this._suppressAutoReconnectErrors = false;
+  }
+
+  _autoReconnectIntervalMs() {
+    const interval = Number(this._autoReconnectOptions.reconnectIntervalMs);
+    return Number.isFinite(interval) && interval >= 0 ? interval : 3000;
+  }
+
+  _autoReconnectMaxAttempts() {
+    const attempts = Number(this._autoReconnectOptions.reconnectMaxAttempts);
+    return Number.isFinite(attempts) && attempts > 0 ? attempts : 120;
+  }
+
+  _autoReconnectWait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  _attachAutoReconnectDisconnectHandler(device) {
+    if (!device?.addEventListener) return;
+    if (this._autoReconnectDevice === device) return;
+    if (this._autoReconnectDevice?.removeEventListener) {
+      try {
+        this._autoReconnectDevice.removeEventListener('gattserverdisconnected', this._autoReconnectDisconnectHandler);
+      } catch (_) {}
+    }
+    this._autoReconnectDevice = device;
+    device.addEventListener('gattserverdisconnected', this._autoReconnectDisconnectHandler);
+  }
+
+  async _restoreAutoReconnectDevice() {
+    if (this.bluetoothDevice) return true;
+    const rememberedDevice = await this._requestRememberedBluetoothDevice();
+    if (!rememberedDevice) return false;
+    this.bluetoothDevice = rememberedDevice;
+    this._usingRememberedBluetoothDevice = true;
+    this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
+    this._attachAutoReconnectDisconnectHandler(this.bluetoothDevice);
+    this.onScan(this.bluetoothDevice.name);
+    return true;
+  }
+
+  _handleAutoReconnectDisconnect() {
+    if (!this._autoReconnectEnabled || this._autoReconnectInProgress) return;
+    if (this._bridge && this._bridge.isPrimary) {
+      this._bridge.broadcastDisconnect();
+      this._bridge = null;
+    }
+    this._startAutoReconnect();
+  }
+
+  async _startAutoReconnect() {
+    if (!this._autoReconnectEnabled || this._autoReconnectInProgress) return;
+
+    this._autoReconnectInProgress = true;
+    const startedAt = Date.now();
+    const maxAttempts = this._autoReconnectMaxAttempts();
+    const intervalMs = this._autoReconnectIntervalMs();
+    let lastError = null;
+
+    for (let attempt = 1; this._autoReconnectEnabled && attempt <= maxAttempts; attempt++) {
+      this.onReconnectAttempt({ attempt, maxAttempts, intervalMs });
+
+      try {
+        const hasDevice = await this._restoreAutoReconnectDevice();
+        if (!hasDevice) throw new Error('Last connected Bluetooth device not found. Please reconnect manually.');
+
+        this._lastAutoReconnectError = null;
+        this._suppressAutoReconnectErrors = true;
+        const result = await this.begin(this._autoReconnectNotificationType, this._autoReconnectOptions);
+        this._suppressAutoReconnectErrors = false;
+
+        if (result) {
+          this._autoReconnectInProgress = false;
+          this.onReconnectSuccess({
+            attempt,
+            maxAttempts,
+            elapsedMs: Date.now() - startedAt,
+            result,
+          });
+          return;
+        }
+
+        lastError = this._lastAutoReconnectError || new Error('Auto reconnect attempt failed.');
+      } catch (error) {
+        this._suppressAutoReconnectErrors = false;
+        lastError = error;
+      }
+
+      if (!this._autoReconnectEnabled || attempt >= maxAttempts) break;
+      await this._autoReconnectWait(intervalMs);
+    }
+
+    this._autoReconnectInProgress = false;
+    const error = lastError || new Error('Auto reconnect failed.');
+    this.onReconnectFailed({ maxAttempts, elapsedMs: Date.now() - startedAt, error });
+    this._reportError(error);
   }
 
 
@@ -603,7 +737,7 @@ class Orphe {
         this.onScan(this.bluetoothDevice.name);
       })
       .catch(error => {
-        this.onError(error);
+        this._reportError(error);
         throw error;
       });
   }
@@ -645,6 +779,7 @@ class Orphe {
    * @param {string} uuid
    */
   selectBluetoothDevice(uuid = 'DEVICE_INFORMATION') {
+    this._disableAutoReconnect();
     this.forgetLastBluetoothDevice();
     if (this._bridge) {
       if (this._bridge.isPrimary) this._bridge.broadcastDisconnect();
@@ -731,7 +866,7 @@ class Orphe {
   connectGATT(uuid) {
     if (!this.bluetoothDevice) {
       var error = "No Bluetooth Device";
-      this.onError(error);
+      this._reportError(error);
       return Promise.reject(error);
     }
     if (this.bluetoothDevice.gatt.connected && this.dataCharacteristic) {
@@ -753,7 +888,7 @@ class Orphe {
         this.onConnect(uuid);
       })
       .catch(error => {
-        this.onError(error);
+        this._reportError(error);
         if (this._usingRememberedBluetoothDevice) {
           this._rememberedBluetoothDeviceUnavailable = true;
           this._usingRememberedBluetoothDevice = false;
@@ -788,7 +923,7 @@ class Orphe {
         return this.dataCharacteristic.readValue();
       })
       .catch(error => {
-        this.onError(error);
+        this._reportError(error);
         throw error;
       });
   }
@@ -811,7 +946,7 @@ class Orphe {
         this.onWrite(uuid);
       })
       .catch(error => {
-        this.onError(error);
+        this._reportError(error);
         throw error;
       });
   }
@@ -831,7 +966,7 @@ class Orphe {
       })
       .catch(error => {
         console.error('startNotify: Error : ' + error);
-        this.onError(error);
+        this._reportError(error);
         throw error;
       });
   }
@@ -865,7 +1000,7 @@ class Orphe {
         this.onStopNotify(uuid);
       })
       .catch(error => {
-        this.onError(error);
+        this._reportError(error);
         throw error;
       });
 
@@ -884,7 +1019,7 @@ class Orphe {
   disconnect() {
     if (!this.bluetoothDevice) {
       var error = "No Bluetooth Device";
-      this.onError(error);
+      this._reportError(error);
       return;
     }
 
@@ -892,7 +1027,7 @@ class Orphe {
       this.bluetoothDevice.gatt.disconnect();
     } else {
       var error = "Bluetooth Device is already disconnected";
-      this.onError(error);
+      this._reportError(error);
       return;
     }
   }
@@ -960,6 +1095,7 @@ class Orphe {
    * reset(disconnect & clear)
    */
   reset() {
+    this._disableAutoReconnect();
     const wasBridgeSecondary = this._isBridgeSecondary;
 
     // BleSharedBridge: 切断を他タブに通知してリソース解放
@@ -1058,17 +1194,17 @@ class Orphe {
           return;
         }
         if (lastDeviceInfo && devices.length > 0) {
-          this.onError('Last connected Bluetooth device not found. Please reconnect manually.');
+          this._reportError('Last connected Bluetooth device not found. Please reconnect manually.');
           return;
         }
         if (devices.length > 1) {
-          this.onError('Multiple paired devices found. Please reconnect manually.');
+          this._reportError('Multiple paired devices found. Please reconnect manually.');
           return;
         }
       } catch (_) {}
     }
 
-    this.onError('Primary tab closed. Please reconnect manually.');
+    this._reportError('Primary tab closed. Please reconnect manually.');
   }
 
 
@@ -1564,7 +1700,7 @@ class Orphe {
         resolve(this.date_time);
       }).catch(error => {  // ダイアログのキャンセルはそのまま閉じる
         console.log('Error: ' + error);
-        this.onError(error);
+        this._reportError(error);
         reject(error);
       });
     });
@@ -1604,7 +1740,7 @@ class Orphe {
         resolve(this.device_information);
       }).catch(error => {  // ダイアログのキャンセルはそのまま閉じる
         console.log('Error: ' + error);
-        this.onError(error);
+        this._reportError(error);
         reject(error);
       });
     });
@@ -1734,6 +1870,9 @@ class Orphe {
   onStartNotify(uuid) { console.log("onStartNotify", uuid); }
   onStopNotify(uuid) { console.log("onStopNotify", uuid); }
   onDisconnect() { console.log("onDisconnect"); }
+  onReconnectAttempt(info) { }
+  onReconnectSuccess(info) { }
+  onReconnectFailed(info) { }
 
   /**
    * notification frequencyの実測値を取得する

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -833,15 +833,21 @@ class Orphe {
 
   _findLastBluetoothDevice(devices) {
     const info = this._getLastBluetoothDeviceInfo();
-    if (!info || !Array.isArray(devices)) return null;
+    return this._findBluetoothDevice(devices, info);
+  }
 
-    if (info.bluetoothId) {
-      const matchedById = devices.find(device => device.id === info.bluetoothId);
+  _findBluetoothDevice(devices, info) {
+    if (!info || !Array.isArray(devices)) return null;
+    const bluetoothId = info.bluetoothId || info.id || '';
+    const bluetoothName = info.bluetoothName || info.name || '';
+
+    if (bluetoothId) {
+      const matchedById = devices.find(device => device.id === bluetoothId);
       if (matchedById) return matchedById;
     }
 
-    if (info.bluetoothName) {
-      const matchedByName = devices.filter(device => device.name === info.bluetoothName);
+    if (bluetoothName) {
+      const matchedByName = devices.filter(device => device.name === bluetoothName);
       if (matchedByName.length === 1) return matchedByName[0];
     }
 
@@ -1180,6 +1186,13 @@ class Orphe {
       try {
         const devices = await navigator.bluetooth.getDevices();
         const lastDeviceInfo = this._getLastBluetoothDeviceInfo();
+        const selectedDevice = this._findBluetoothDevice(devices, this.bluetoothDevice);
+        if (selectedDevice) {
+          this.bluetoothDevice = selectedDevice;
+          this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
+          await this.begin(str_type);
+          return;
+        }
         const rememberedDevice = this._findLastBluetoothDevice(devices);
         if (rememberedDevice) {
           this.bluetoothDevice = rememberedDevice;

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -416,6 +416,12 @@ class Orphe {
     } = options;
     this.notification_type = str_type;
 
+    if (this._bridge) {
+      this._bridge.release();
+      this._bridge = null;
+      this._isBridgeSecondary = false;
+    }
+
     // ── BleSharedBridge: 別タブに Primary が存在するか確認 ──────────────
     if (typeof BleSharedBridge !== 'undefined') {
       const bridge = new BleSharedBridge(this.id);
@@ -839,6 +845,8 @@ class Orphe {
    * reset(disconnect & clear)
    */
   reset() {
+    const wasBridgeSecondary = this._isBridgeSecondary;
+
     // BleSharedBridge: 切断を他タブに通知してリソース解放
     if (this._bridge) {
       if (this._bridge.isPrimary) this._bridge.broadcastDisconnect();
@@ -846,7 +854,10 @@ class Orphe {
       this._bridge = null;
       this._isBridgeSecondary = false;
     }
-    this.disconnect(); //disconnect() is not Promise Object
+
+    if (!wasBridgeSecondary) {
+      this.disconnect(); //disconnect() is not Promise Object
+    }
     this.clear();
     this.onReset();
   }
@@ -858,6 +869,7 @@ class Orphe {
    * @returns {Promise<string>}
    */
   _beginAsSecondary(bridge, str_type) {
+    if (this._bridge && this._bridge !== bridge) this._bridge.release();
     this._bridge = bridge;
     this._isBridgeSecondary = true;
 
@@ -916,10 +928,14 @@ class Orphe {
     if (navigator.bluetooth?.getDevices) {
       try {
         const devices = await navigator.bluetooth.getDevices();
-        if (devices.length > 0) {
+        if (devices.length === 1) {
           this.bluetoothDevice = devices[0];
           this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
           await this.begin(str_type);
+          return;
+        }
+        if (devices.length > 1) {
+          this.onError('Multiple paired devices found. Please reconnect manually.');
           return;
         }
       } catch (_) {}

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -136,6 +136,7 @@ class Orphe {
     // BleSharedBridge: 複数タブ間接続共有
     this._bridge = null;
     this._isBridgeSecondary = false;
+    this._lastBluetoothDeviceStorageKey = `orphe_last_bluetooth_device_${id}`;
     this.array_device_information = new DataView(new ArrayBuffer(20));// device information用の配列
 
     /**
@@ -480,6 +481,7 @@ class Orphe {
       .then(async (result) => {
         // BleSharedBridge: BLE接続成功後にこのタブを Primary として登録
         if (typeof BleSharedBridge !== 'undefined' && result) {
+          this._rememberBluetoothDevice(this.bluetoothDevice);
           this._bridge = new BleSharedBridge(this.id);
           this._isBridgeSecondary = false;
           this._bridge.claimPrimary();
@@ -619,6 +621,56 @@ class Orphe {
         this.onScan(this.bluetoothDevice.name);
       });
   }
+
+  /**
+   * 最後に接続成功した Bluetooth デバイス情報を忘れる。
+   * 次回 begin() 時に手動選択ダイアログから別デバイスへ切り替えたい場合に利用する。
+   */
+  forgetLastBluetoothDevice() {
+    try { localStorage.removeItem(this._lastBluetoothDeviceStorageKey); } catch (_) {}
+  }
+
+  _rememberBluetoothDevice(device) {
+    if (!device) return;
+    try {
+      localStorage.setItem(this._lastBluetoothDeviceStorageKey, JSON.stringify({
+        deviceId: this.id,
+        bluetoothId: device.id || '',
+        bluetoothName: device.name || '',
+        lastConnectedAt: Date.now(),
+      }));
+    } catch (_) {}
+  }
+
+  _getLastBluetoothDeviceInfo() {
+    try {
+      const raw = localStorage.getItem(this._lastBluetoothDeviceStorageKey);
+      if (!raw) return null;
+      const info = JSON.parse(raw);
+      if (!info || (!info.bluetoothId && !info.bluetoothName)) return null;
+      return info;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  _findLastBluetoothDevice(devices) {
+    const info = this._getLastBluetoothDeviceInfo();
+    if (!info || !Array.isArray(devices)) return null;
+
+    if (info.bluetoothId) {
+      const matchedById = devices.find(device => device.id === info.bluetoothId);
+      if (matchedById) return matchedById;
+    }
+
+    if (info.bluetoothName) {
+      const matchedByName = devices.filter(device => device.name === info.bluetoothName);
+      if (matchedByName.length === 1) return matchedByName[0];
+    }
+
+    return null;
+  }
+
   /**
    * GATT通信を始めるための関数。read, write, startNotify, stopNotifyが呼び出されるとscanと一緒に呼び出されます。
    * @param {string} uuid 
@@ -928,10 +980,22 @@ class Orphe {
     if (navigator.bluetooth?.getDevices) {
       try {
         const devices = await navigator.bluetooth.getDevices();
-        if (devices.length === 1) {
+        const lastDeviceInfo = this._getLastBluetoothDeviceInfo();
+        const rememberedDevice = this._findLastBluetoothDevice(devices);
+        if (rememberedDevice) {
+          this.bluetoothDevice = rememberedDevice;
+          this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
+          await this.begin(str_type);
+          return;
+        }
+        if (!lastDeviceInfo && devices.length === 1) {
           this.bluetoothDevice = devices[0];
           this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
           await this.begin(str_type);
+          return;
+        }
+        if (lastDeviceInfo && devices.length > 0) {
+          this.onError('Last connected Bluetooth device not found. Please reconnect manually.');
           return;
         }
         if (devices.length > 1) {

--- a/js/ORPHE-CORE.js
+++ b/js/ORPHE-CORE.js
@@ -137,6 +137,8 @@ class Orphe {
     this._bridge = null;
     this._isBridgeSecondary = false;
     this._lastBluetoothDeviceStorageKey = `orphe_last_bluetooth_device_${id}`;
+    this._usingRememberedBluetoothDevice = false;
+    this._rememberedBluetoothDeviceUnavailable = false;
     this.array_device_information = new DataView(new ArrayBuffer(20));// device information用の配列
 
     /**
@@ -589,11 +591,14 @@ class Orphe {
   scan(uuid, options = {}) {
     if (this.bluetoothDevice) return Promise.resolve();
 
-    const useRememberedDevice = !options.forceDeviceSelection && this._getLastBluetoothDeviceInfo();
+    const useRememberedDevice = !options.forceDeviceSelection &&
+      !this._rememberedBluetoothDeviceUnavailable &&
+      this._getLastBluetoothDeviceInfo();
     return (useRememberedDevice ? this._requestRememberedBluetoothDevice() : Promise.resolve(null))
       .then(device => {
         if (!device) return this.requestDevice(uuid);
         this.bluetoothDevice = device;
+        this._usingRememberedBluetoothDevice = true;
         this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
         this.onScan(this.bluetoothDevice.name);
       })
@@ -627,6 +632,8 @@ class Orphe {
     return navigator.bluetooth.requestDevice(options)
       .then(device => {
         this.bluetoothDevice = device;
+        this._usingRememberedBluetoothDevice = false;
+        this._rememberedBluetoothDeviceUnavailable = false;
         this.bluetoothDevice.addEventListener('gattserverdisconnected', this.onDisconnect);
         this.onScan(this.bluetoothDevice.name);
       });
@@ -650,6 +657,8 @@ class Orphe {
     }
     this.bluetoothDevice = null;
     this.dataCharacteristic = null;
+    this._usingRememberedBluetoothDevice = false;
+    this._rememberedBluetoothDeviceUnavailable = false;
     return this.requestDevice(uuid);
   }
 
@@ -658,11 +667,13 @@ class Orphe {
    * 次回 begin() 時に手動選択ダイアログから別デバイスへ切り替えたい場合に利用する。
    */
   forgetLastBluetoothDevice() {
+    this._rememberedBluetoothDeviceUnavailable = false;
     try { localStorage.removeItem(this._lastBluetoothDeviceStorageKey); } catch (_) {}
   }
 
   _rememberBluetoothDevice(device) {
     if (!device) return;
+    this._rememberedBluetoothDeviceUnavailable = false;
     try {
       localStorage.setItem(this._lastBluetoothDeviceStorageKey, JSON.stringify({
         deviceId: this.id,
@@ -743,6 +754,12 @@ class Orphe {
       })
       .catch(error => {
         this.onError(error);
+        if (this._usingRememberedBluetoothDevice) {
+          this._rememberedBluetoothDeviceUnavailable = true;
+          this._usingRememberedBluetoothDevice = false;
+          this.bluetoothDevice = null;
+          this.dataCharacteristic = null;
+        }
         throw error;
       });
   }


### PR DESCRIPTION
## Summary
- Release any existing BleSharedBridge before beginning a new bridge session
- Avoid false BLE disconnect errors when resetting a Secondary bridge session or a stale disconnected device
- Remember the last successfully connected Bluetooth device id/name per Orphe core id
- During bridge takeover, auto-reconnect to the remembered device even when multiple paired devices are available
- During bridge takeover, prefer the device manually selected in the current tab before falling back to remembered-device or multi-candidate handling
- Add opt-in BLE `autoReconnect` support to Orphe.begin(), with reconnect attempt/success/failure callbacks
- Enable `autoReconnect` by default only for CoreToolkit, while direct `ble.begin()` examples keep their existing behavior unless they opt in
- If remembered-device reconnect fails, clear the stale held device and make the next user click fall back to manual BLE selection
- Normal scan reuses the remembered device only when memory exists, preserving requestDevice() user gesture for first-time manual selection
- CoreToolkit keeps the main switch as connect/disconnect to the remembered CORE, and adds Select another CORE in settings for explicit device switching
- Stop BLE read/connect failure paths before they continue into undefined DataView reads
- Add physical BLE reconnect/range test pages for real ORPHE CORE verification, including a live raw-data panel using the shared autoReconnect path
- Add integration coverage for bridge replacement, Secondary reset, multiple-device reconnect handling, selected-device takeover, remembered-device selection, scan reuse, manual switching, remembered-device failure fallback, forgetting remembered devices, and autoReconnect opt-in behavior

## Test
- node --check js/ORPHE-CORE.js
- node --check js/BleSharedBridge.js
- node --check js/CoreToolkit.js
- git diff --check
- Browser unit test: 25/25 passed locally
- Browser integration test: 58/58 passed locally
- Physical range test page HTML served successfully from SHA-fixed raw.githack URL
- Physical BLE range reconnect test with selected-device takeover fix: verified on real ORPHE CORE after d9b0bb2
- Secondary-to-Primary takeover with multiple paired devices: verified on real ORPHE CORE; no `Multiple paired devices found` fallback observed

## Latest device test URLs
- Physical BLE range reconnect: https://raw.githack.com/Orphe-OSS/ORPHE-CORE.js/d9b0bb2/examples/TEST-BRIDGE/physical-range-test.html
- Physical BLE reconnect/switching: https://raw.githack.com/Orphe-OSS/ORPHE-CORE.js/d9b0bb2/examples/TEST-BRIDGE/physical-reconnect-test.html
- TEST-BRIDGE index/CoreToolkit: https://raw.githack.com/Orphe-OSS/ORPHE-CORE.js/d9b0bb2/examples/TEST-BRIDGE/index.html
- Unit test: https://raw.githack.com/Orphe-OSS/ORPHE-CORE.js/d9b0bb2/examples/TEST-BRIDGE/unit-test.html?autorun=1
- Integration test: https://raw.githack.com/Orphe-OSS/ORPHE-CORE.js/d9b0bb2/examples/TEST-BRIDGE/integration-test.html?autorun=1