### PR TITLE
chore(GAME-HURDLE): seed ranking-frozen.json with placeholder legend entries

### DIFF
--- a/examples/GAME-HURDLE/ranking-frozen.json
+++ b/examples/GAME-HURDLE/ranking-frozen.json
@@ -10,5 +10,18 @@
     { "name": "Legend A", "time": 14.32, "hurdles": 0, "date": "2026-04-15T12:34:56.000Z" },
     { "name": "Legend B", "time": 15.10, "hurdles": 1, "date": "2026-04-20T08:12:00.000Z" }
   ],
-  "rankings": []
+  "rankings": [
+    { "name": "Shun K.",        "time": 11.34, "hurdles": 0, "date": "2026-04-12T15:42:00.000Z" },
+    { "name": "Aoi T.",         "time": 11.62, "hurdles": 0, "date": "2026-03-28T18:21:00.000Z" },
+    { "name": "Hurdle Hayato",  "time": 11.85, "hurdles": 1, "date": "2026-02-19T11:30:00.000Z" },
+    { "name": "Ren M.",         "time": 12.07, "hurdles": 0, "date": "2026-04-22T09:45:00.000Z" },
+    { "name": "Sora N.",        "time": 12.31, "hurdles": 1, "date": "2026-01-14T14:55:00.000Z" },
+    { "name": "Takumi O.",      "time": 12.58, "hurdles": 1, "date": "2026-03-08T16:42:00.000Z" },
+    { "name": "Step Master",    "time": 12.94, "hurdles": 2, "date": "2026-02-02T10:18:00.000Z" },
+    { "name": "Yuki K.",        "time": 13.27, "hurdles": 2, "date": "2025-12-22T13:33:00.000Z" },
+    { "name": "Daichi I.",      "time": 13.78, "hurdles": 2, "date": "2026-04-05T17:08:00.000Z" },
+    { "name": "Mizuki Y.",      "time": 14.15, "hurdles": 3, "date": "2025-11-30T19:50:00.000Z" },
+    { "name": "Hiro S.",        "time": 14.62, "hurdles": 3, "date": "2025-11-15T08:25:00.000Z" },
+    { "name": "Tomoki R.",      "time": 15.41, "hurdles": 4, "date": "2025-12-08T20:14:00.000Z" }
+  ]
 }


### PR DESCRIPTION
PR #28 で追加した `examples/GAME-HURDLE/ranking-frozen.json` は `rankings: []` 空配列でした。実機で初めてランキング画面を開いたときに「ランキングデータがありません」になるのは寂しいので、自分のローカルスコアと比較する legend スコアを架空で 12 件投入します。

廣瀬さんから過去の Firestore ranking データを受け取れたら、この placeholder を実データに差し替える前提です。

## seed したデータ

| name             |  time | hurdles | date       |
|------------------|------:|--------:|------------|
| Shun K.          | 11.34 |       0 | 2026-04-12 |
| Aoi T.           | 11.62 |       0 | 2026-03-28 |
| Hurdle Hayato    | 11.85 |       1 | 2026-02-19 |
| Ren M.           | 12.07 |       0 | 2026-04-22 |
| Sora N.          | 12.31 |       1 | 2026-01-14 |
| Takumi O.        | 12.58 |       1 | 2026-03-08 |
| Step Master      | 12.94 |       2 | 2026-02-02 |
| Yuki K.          | 13.27 |       2 | 2025-12-22 |
| Daichi I.        | 13.78 |       2 | 2026-04-05 |
| Mizuki Y.        | 14.15 |       3 | 2025-11-30 |
| Hiro S.          | 14.62 |       3 | 2025-11-15 |
| Tomoki R.        | 15.41 |       4 | 2025-12-08 |

## 設計メモ

- **名前は完全に架空** — 実在の選手名や実際のレース記録は使わない。「ハードルのランキングっぽく見える」ことだけが目的。
- **time 幅 11.34s ~ 15.41s** — 実機テスト時のスコア (Player 12.13s, きく 12.72s) を中心として、最速層は 11s 台でもう一段上の目標感、初心者層は 15s 台で「届きそう」感が出るように。
- **hurdles (接触回数) は time と相関** — 速くてクリーンなランほど偉く見えるように。
- **date は 2025-11 ~ 2026-04 に分散** — 同じ日付に固まっていると不自然なので。

## Test plan

- [ ] `python3 -m http.server 8888` などで起動して http://localhost:8888/examples/GAME-HURDLE/ を開く
- [ ] DevTools Console に `[HURDLE] Loaded 12 frozen ranking entries.` が出る
- [ ] 「ランキング / RANKING」ボタン → 12 行が time 昇順で表示される
- [ ] 自分が完走 → 名前入力 → ランキングに `YOU` バッジ付きで自分の行が legend と一緒に並ぶ