### PR TITLE
chore: canonicalize legacy notification type strings ('RAW' / 'ANALYSIS' → public names)

### DIFF
--- a/examples/AIRWALKER/index.html
+++ b/examples/AIRWALKER/index.html
@@ -32,7 +32,7 @@
     </nav>
 
     <!-- <div class="col-12 mt-4">
-      <button class="btn btn-outline-primary" onclick="ble.begin('RAW');" hidden>connect</button>
+      <button class="btn btn-outline-primary" onclick="ble.begin('SENSOR_VALUES');" hidden>connect</button>
       <button class="btn btn-outline-primary" onclick="ble.stopNotify();" hidden>stop Notify</button>
       <button class="btn btn-outline-primary" onclick="ble.startNotify();" hidden>start Notify</button>
     </div> -->

--- a/examples/AIRWALKER/sketch.js
+++ b/examples/AIRWALKER/sketch.js
@@ -291,5 +291,5 @@ window.onload = function () {
 
   loadHistory();
   loadParameters();
-  buildCoreToolkit(document.querySelector('#CoreToolkit_placeholder'), '01', 0, 'RAW');
+  buildCoreToolkit(document.querySelector('#CoreToolkit_placeholder'), '01', 0, 'SENSOR_VALUES');
 }

--- a/examples/DTW/sketch.js
+++ b/examples/DTW/sketch.js
@@ -36,7 +36,7 @@ window.addEventListener('DOMContentLoaded', function () {
     let ble = bles[0];
     buildCoreToolkit(
         document.querySelector('#toolkit_placeholder'),
-        'ORPHE CORE01', ble.id, 'ANALYSIS_AND_RAW'
+        'ORPHE CORE01', ble.id, 'STEP_ANALYSIS_AND_SENSOR_VALUES'
     );
 })
 

--- a/examples/FOOT ANGLE/sketch.js
+++ b/examples/FOOT ANGLE/sketch.js
@@ -207,9 +207,9 @@ window.onload = function () {
       console.log('onDisconnect');
     }
 
-    buildCoreToolkit(document.querySelector('#toolkit_placeholder'),  
-    `0${ble.id + 1}`,  
-    ble.id, 'ANALYSIS_AND_RAW');
+    buildCoreToolkit(document.querySelector('#toolkit_placeholder'),
+    `0${ble.id + 1}`,
+    ble.id, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
 
     ble.onConnectGATT = function (uuid) {
       console.log('> connected GATT!');

--- a/examples/GAME-DDR/ARCHITECTURE.md
+++ b/examples/GAME-DDR/ARCHITECTURE.md
@@ -235,12 +235,12 @@ GAME INPUT HANDLER
         ├─> Setup device 1
         │      │
         │      ├─> bles[0].setup()
-        │      └─> buildCoreToolkit('#toolkit_placeholder1', '01', 0, 'ANALYSIS')
+        │      └─> buildCoreToolkit('#toolkit_placeholder1', '01', 0, 'STEP_ANALYSIS')
         │
         ├─> Setup device 2
         │      │
         │      ├─> bles[1].setup()
-        │      └─> buildCoreToolkit('#toolkit_placeholder2', '02', 1, 'ANALYSIS')
+        │      └─> buildCoreToolkit('#toolkit_placeholder2', '02', 1, 'STEP_ANALYSIS')
         │
         └─> Register callbacks
                │

--- a/examples/GAME-DDR/FIXES_APPLIED.md
+++ b/examples/GAME-DDR/FIXES_APPLIED.md
@@ -35,9 +35,9 @@ let bles = [new Orphe(0), new Orphe(1)];  // ← ORPHE-CORE.jsが読み込まれ
     // Initialize ORPHE devices
     var bles = [new Orphe(0), new Orphe(1)];
     bles[0].setup();
-    buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'ANALYSIS');
+    buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'STEP_ANALYSIS');
     bles[1].setup();
-    buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'ANALYSIS');
+    buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'STEP_ANALYSIS');
     var connectedDevices = 0;
     
     console.log('🎮 ORPHE devices initialized:', bles);

--- a/examples/GAME-DDR/index.html
+++ b/examples/GAME-DDR/index.html
@@ -124,9 +124,9 @@
         // Initialize ORPHE devices
         var bles = [new Orphe(0), new Orphe(1)];
         bles[0].setup();
-        buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'ANALYSIS');
+        buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'STEP_ANALYSIS');
         bles[1].setup();
-        buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'ANALYSIS');
+        buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'STEP_ANALYSIS');
         var connectedDevices = 0;
         
         console.log('🎮 ORPHE devices initialized:', bles);

--- a/examples/GAME-UDON/scripts.js
+++ b/examples/GAME-UDON/scripts.js
@@ -6,9 +6,9 @@ var gamepar =0;
 let canReset = true; // リセット可能かどうかを追跡するフラグ
 
 bles[0].setup();
-buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'RAW');
+buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'SENSOR_VALUES');
 bles[1].setup();
-buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'RAW');
+buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'SENSOR_VALUES');
 for (let ble of bles) {
     ble.onConnect = function () {
         connectedDevices++;

--- a/examples/MOVEYOURFEET/scripts.js
+++ b/examples/MOVEYOURFEET/scripts.js
@@ -15,9 +15,9 @@ var timer_num;
 
 
 bles[0].setup();
-buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'RAW');
+buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'SENSOR_VALUES');
 bles[1].setup();
-buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'RAW');
+buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'SENSOR_VALUES');
 for (let ble of bles) {
     ble.onConnect = function () {
         connectedDevices++;

--- a/examples/POSE/sketch.js
+++ b/examples/POSE/sketch.js
@@ -305,7 +305,7 @@ async function toggleCoreModule(dom) {
   let ble = bles[number];
 
   if (checked == true) {
-    let ret = await ble.begin('ANALYSIS');
+    let ret = await ble.begin('STEP_ANALYSIS');
     console.log(number);
     setTimeout(async function () {
       var obj = await ble.getDeviceInformation();

--- a/examples/PRONATION/sketch.js
+++ b/examples/PRONATION/sketch.js
@@ -118,9 +118,9 @@ window.onload = function () {
       document.querySelector(`#status${ble.id}`).classList = 'bg-secondary text-white'
     }
 
-    buildCoreToolkit(document.querySelector('#toolkit_placeholder'),  
-    `0${ble.id + 1}`,  
-    ble.id, 'ANALYSIS_AND_RAW');
+    buildCoreToolkit(document.querySelector('#toolkit_placeholder'),
+    `0${ble.id + 1}`,
+    ble.id, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
 
     ble.onConnectGATT = function (uuid) {
       console.log('> connected GATT!');

--- a/examples/VIEW/index.html
+++ b/examples/VIEW/index.html
@@ -42,8 +42,8 @@
 
         <div class="input-group">
           <select class="form-select bg-dark text-white" id="char0" aria-label="Example select with button addon">
-            <option selected value="ANALYSIS">ANALYSIS( QUATERNION, EULER, STEPS, STRIDE, PRONATION, etc)</option>
-            <option value="RAW">RAW( GYRO, ACCELEROMETER )</option>
+            <option selected value="STEP_ANALYSIS">STEP_ANALYSIS (QUATERNION, EULER, STEPS, STRIDE, PRONATION, etc)</option>
+            <option value="SENSOR_VALUES">SENSOR_VALUES (GYRO, ACCELEROMETER)</option>
           </select>
           <div class="input-group-text">
             <input class="form-check-input mt-0" type="checkbox" value=0 onclick="toggleConnect(this);" role="switch">
@@ -199,8 +199,8 @@
       <div class="col-6">
         <div class="input-group">
           <select class="form-select bg-dark text-white" id="char1" aria-label="Example select with button addon">
-            <option selected value="ANALYSIS">ANALYSIS( QUATERNION, EULER, STEPS, STRIDE, PRONATION, etc)</option>
-            <option value="RAW">RAW( GYRO, ACCELEROMETER )</option>
+            <option selected value="STEP_ANALYSIS">STEP_ANALYSIS (QUATERNION, EULER, STEPS, STRIDE, PRONATION, etc)</option>
+            <option value="SENSOR_VALUES">SENSOR_VALUES (GYRO, ACCELEROMETER)</option>
           </select>
           <div class="input-group-text">
             <input class="form-check-input mt-0" type="checkbox" value=1 onclick="toggleConnect(this);" role="switch">

--- a/examples/VISUALIZE/index.html
+++ b/examples/VISUALIZE/index.html
@@ -38,7 +38,7 @@
         <div class="input-group">
           <label class="input-group-text" for="inputGroupSelect01">01</label>
           <select class="form-select bg-dark text-white" id="char0" aria-label="Example select with button addon">
-            <option selected value="RAW">RAW</option>
+            <option selected value="SENSOR_VALUES">SENSOR_VALUES</option>
           </select>
           <div class="input-group-text">
             <input class="form-check-input mt-0" type="checkbox" value=0 onclick="toggleConnect(this);" role="switch">
@@ -71,7 +71,7 @@
         <div class="input-group">
           <label class="input-group-text" for="inputGroupSelect01">02</label>
           <select class="form-select bg-dark text-white" id="char1" aria-label="Example select with button addon">
-            <option selected value="RAW">RAW</option>
+            <option selected value="SENSOR_VALUES">SENSOR_VALUES</option>
           </select>
           <div class="input-group-text">
             <input class="form-check-input mt-0" type="checkbox" value=1 onclick="toggleConnect(this);" role="switch">

--- a/examples/WORKSHOP_07/index.html
+++ b/examples/WORKSHOP_07/index.html
@@ -44,12 +44,12 @@
         window.onload = function () {
             // ORPHE CORE Init; bles[0] and bles[1] are used by CoreToolkit.js
             bles[0].setup();
-            buildCoreToolkit(document.querySelector('#toolkit_placeholder'), '01', 0, 'RAW');
-            // alternatibe begin function call
+            buildCoreToolkit(document.querySelector('#toolkit_placeholder'), '01', 0, 'SENSOR_VALUES');
+            // alternative begin function call
             // buildCoreToolkit(document.querySelector('#toolkit_placeholder'),
             //     '01', // name to be shown on the UI
             //     0, // index of bles array
-            //     'ANALYSIS', // ANALYSIS, RAW, ANALYSIS_AND_RAW
+            //     'STEP_ANALYSIS', // STEP_ANALYSIS, SENSOR_VALUES, STEP_ANALYSIS_AND_SENSOR_VALUES
             //     { range: { acc: 8, gyro: 1000 } } // sensor range
             // );
 

--- a/examples/WORKSHOP_08/index.html
+++ b/examples/WORKSHOP_08/index.html
@@ -44,12 +44,12 @@
         window.onload = function () {
             // ORPHE CORE Init; bles[0] and bles[1] are used by CoreToolkit.js
             bles[0].setup();
-            buildCoreToolkit(document.querySelector('#toolkit_placeholder'), '01', 0, 'RAW');
-            // alternatibe begin function call
+            buildCoreToolkit(document.querySelector('#toolkit_placeholder'), '01', 0, 'SENSOR_VALUES');
+            // alternative begin function call
             // buildCoreToolkit(document.querySelector('#toolkit_placeholder'),
             //     '01', // name to be shown on the UI
             //     0, // index of bles array
-            //     'ANALYSIS', // ANALYSIS, RAW, ANALYSIS_AND_RAW
+            //     'STEP_ANALYSIS', // STEP_ANALYSIS, SENSOR_VALUES, STEP_ANALYSIS_AND_SENSOR_VALUES
             //     { range: { acc: 8, gyro: 1000 } } // sensor range
             // );
 


### PR DESCRIPTION
`.claude/audit/EXAMPLES_AUDIT.md` 「`'RAW'` / `'ANALYSIS'` 等の旧通知タイプ表記揺れ統一」対応。

## 変更内容

旧 alias `'RAW'` / `'ANALYSIS'` / `'ANALYSIS_AND_RAW'` を CLAUDE.md で正式に文書化されている名前に統一:

| 旧 | 新 |
|---|---|
| `'RAW'` | `'SENSOR_VALUES'` |
| `'ANALYSIS'` | `'STEP_ANALYSIS'` |
| `'ANALYSIS_AND_RAW'` | `'STEP_ANALYSIS_AND_SENSOR_VALUES'` |

SDK (`js/ORPHE-CORE.js`) には alias 変換と deprecation warning のロジックが残っているため、**動作は変わりません**。学習者が examples を読むときに 2 つの語彙が混在する状況を解消するための純粋な命名統一です。

## Files touched (実コードのみ、15 ファイル)

- `examples/AIRWALKER/{index.html,sketch.js}`
- `examples/DTW/sketch.js`
- `examples/FOOT ANGLE/sketch.js`
- `examples/GAME-DDR/index.html`
- `examples/GAME-UDON/scripts.js`
- `examples/MOVEYOURFEET/scripts.js`
- `examples/POSE/sketch.js`
- `examples/PRONATION/sketch.js`
- `examples/VIEW/index.html` (option `value` + 表示テキスト両方)
- `examples/VISUALIZE/index.html` (同上)
- `examples/WORKSHOP_07/index.html` (実コード + コメント内の説明文)
- `examples/WORKSHOP_08/index.html` (同上)
- `examples/GAME-DDR/ARCHITECTURE.md`, `FIXES_APPLIED.md` (ドキュメント説明文)

## 意図的に触っていない

- `examples/GAME-RHYTHM/ORPHE-CORE.js` — SDK の古い frozen ローカルコピー。alias 変換コード内に旧名が残るのは正しい挙動。
- `examples/{GAME-PINGPONG,GAME-HURDLE*,GAME-MARIO,GAME-SHOOTING,GAME-SPRINT-100M-VS}/scripts.js` — どれも index.html から読み込まれていない dead file。後続の「HURDLE 系 dead files 一括削除」PR で削除予定なので、この PR では触らずに整合させる。

## Test plan

- [x] `node --check` が全 JS ファイルで通る
- [x] 旧キー名が live code から消えたことを grep で確認
- [ ] (オプション) ローカルサーバで各 example を開いて Console エラー / 通知タイプ表示が想定通りか確認