### PR TITLE
refactor(display-only): switch gotAcc → gotConvertedAcc in pure-display samples

### DIFF
--- a/examples/CORETOOLKIT-STARTER/sketch.js
+++ b/examples/CORETOOLKIT-STARTER/sketch.js
@@ -79,7 +79,9 @@ window.onload = function () {
             document.querySelector(`#svg${this.id}_z`).innerHTML = `${gyro.z.toFixed(3)}`;
         }
 
-        ble.gotAcc = function (acc) {
+        // gotConvertedAcc は実 G 値 (range 設定に応じて ±2/±4/±8/±16 G) を返す。
+        // テーブル表示用としては正規化値より直感的なのでこちらを使用。
+        ble.gotConvertedAcc = function (acc) {
             document.querySelector(`#sva${this.id}_x`).innerHTML = `${acc.x.toFixed(3)}`;
             document.querySelector(`#sva${this.id}_y`).innerHTML = `${acc.y.toFixed(3)}`;
             document.querySelector(`#sva${this.id}_z`).innerHTML = `${acc.z.toFixed(3)}`;

--- a/examples/CORE_TIME_SYNC/index.html
+++ b/examples/CORE_TIME_SYNC/index.html
@@ -41,7 +41,9 @@
         }
         function activateNotify() {
             core.begin("SENSOR_VALUES");
-            core.gotAcc = function (acc) {
+            // gotConvertedAcc は実 G 値 (±range G) を返す。
+            // 表示用なので正規化値より読みやすいこちらを使用。
+            core.gotConvertedAcc = function (acc) {
                 document.querySelector('#acc').innerText = `x:${acc.x}, y:${acc.y}, z:${acc.z}`;
             }
         }

--- a/examples/VIEW/sketch.js
+++ b/examples/VIEW/sketch.js
@@ -135,7 +135,9 @@ window.onload = function () {
             document.querySelector(`#svg${this.id}_z`).innerHTML = `${gyro.z.toFixed(3)}`;
         }
 
-        ble.gotAcc = function (acc) {
+        // gotConvertedAcc は実 G 値 (±range G) を返す。テーブル表示用に
+        // こちらを使うと正規化値より直感的に読める。
+        ble.gotConvertedAcc = function (acc) {
             document.querySelector(`#sva${this.id}_x`).innerHTML = `${acc.x.toFixed(3)}`;
             document.querySelector(`#sva${this.id}_y`).innerHTML = `${acc.y.toFixed(3)}`;
             document.querySelector(`#sva${this.id}_z`).innerHTML = `${acc.z.toFixed(3)}`;

--- a/starter-templates/ACCELEROMETER.html
+++ b/starter-templates/ACCELEROMETER.html
@@ -30,7 +30,11 @@
         window.onload = function () {
             // ORPHE CORE Init
             ble.setup();
-            ble.gotAcc = function (acc) {
+            // gotConvertedAcc は実 G 値 (range 設定に応じて ±2/±4/±8/±16 G) を返す。
+            // 「ACCELEROMETER」というファイル名から学習者が期待する「加速度センサ
+            // の生データ」に近いのは正規化値ではなく実 G 値なのでこちらを使う。
+            // 正規化値 (-1〜1) が欲しい場合は ble.gotAcc を直接上書きする。
+            ble.gotConvertedAcc = function (acc) {
                 document.querySelector('#x').innerHTML = acc.x;
                 document.querySelector('#y').innerHTML = acc.y;
                 document.querySelector('#z').innerHTML = acc.z;


### PR DESCRIPTION
`.claude/audit/EXAMPLES_AUDIT.md` 「`gotAcc` → `gotConvertedAcc` 置換」対応の **限定スコープ版**。

## なぜスコープを絞ったか

`gotAcc` は正規化値 (-1〜1) を返し、`gotConvertedAcc` は実 G 値 (range 設定に応じて ±2/±4/±8/±16 G) を返します。両者は値のスケールが異なるため、**閾値判定をしているコードを一律に置換すると動作が壊れます** (e.g. `if (mag > 0.7)` が「正規化値で 70%」だったのが「実 G 値で 0.7G」になり挙動激変)。

そこで本 PR では「**値を画面に表示するだけ**」のサンプルに限定して、gotAcc → gotConvertedAcc に切り替えます。学習者が「ACCELEROMETER」というラベルを見て期待するのは G 値の方なので、可読性が向上します。

## 変更対象 (4 ファイル)

| File | 役割 |
|---|---|
| `starter-templates/ACCELEROMETER.html` | 「加速度センサ最小例」公式 starter |
| `examples/CORETOOLKIT-STARTER/sketch.js` | センサモニタテーブル |
| `examples/VIEW/sketch.js` | センサモニタテーブル + 3D quaternion ビュー |
| `examples/CORE_TIME_SYNC/index.html` | 時刻同期検証用の acc 表示 |

## 意図的に **触っていない** ファイル (別 PR / 実機調整必要)

| File | 理由 |
|---|---|
| `examples/AIRWALKER/sketch.js` | 歩数判定閾値が正規化値スケールに依存 |
| `examples/FOOT ANGLE/sketch.js` | センサ表示 + 閾値視覚化が混在 |
| `examples/PRONATION/sketch.js` | 同上 |
| `examples/GAME-UDON / GAME-RHYTHM / GAME-SHOOTING / GAME-SHOOTING2 / GAME-MARIO / drum_test` | ゲームバランス調整済みの閾値 |
| `examples/GESTURE-DEMO/gesture-detector.js` | ジェスチャー認識閾値 |
| `examples/MOVEYOURFEET/scripts.js` | スコアリング閾値 |
| `examples/SENSOR-CALIBRATION/recorder.js` | 記録対象スケールはキャリブフロー側で決める |
| `starter-templates/ANALYSIS_AND_RAW.html` | ファイル名が「RAW」、正規化値が前提 |
| `examples/WORKSHOP_07/index.html` | FFT 振幅は scale-invariant、y 軸が変わるだけで教育的に意味なし |
| `examples/OH1/sketch.js` | 心拍計サンプル、acc は補助 |
| `tests/bridge/...`, `examples/drum_test/test.*` | 固定アサーションを壊す |

これらは「**実機を持ってその場で閾値を再調整**」する必要があり、example ごとの個別 PR にすべきです。

## Test plan

- [x] `node --check` が全 4 ファイルで通る
- [ ] (オプション) ローカルサーバで以下を開いて値表示が正常に動作することを確認:
  - http://localhost:8888/starter-templates/ACCELEROMETER.html
  - http://localhost:8888/examples/CORETOOLKIT-STARTER/
  - http://localhost:8888/examples/VIEW/
  - http://localhost:8888/examples/CORE_TIME_SYNC/