### PR TITLE
chore(examples): fix broken ../js/ paths in three test.html shims

### DIFF
--- a/examples/GAME-MARIO/index.html
+++ b/examples/GAME-MARIO/index.html
@@ -167,7 +167,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
   integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
   crossorigin="anonymous"></script>
-  <!-- <script src="../js/ORPHE-CORE.js"></script> -->
+  <!-- <script src="../../js/ORPHE-CORE.js"></script> -->
 
   <script>
     var bles = [new Orphe(0), new Orphe(1)];

--- a/examples/GAME-MARIO/test.html
+++ b/examples/GAME-MARIO/test.html
@@ -21,7 +21,7 @@
 
     <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
         type="text/javascript"></script> -->
-    <script src="../js/ORPHE-CORE.js"></script>
+    <script src="../../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"

--- a/examples/GAME-PINGPONG/index.html
+++ b/examples/GAME-PINGPONG/index.html
@@ -85,7 +85,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
   integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
   crossorigin="anonymous"></script>
-  <!-- <script src="../js/ORPHE-CORE.js"></script> -->
+  <!-- <script src="../../js/ORPHE-CORE.js"></script> -->
 
   <script>
     var bles = [new Orphe(0), new Orphe(1)];

--- a/examples/GAME-PINGPONG/test.html
+++ b/examples/GAME-PINGPONG/test.html
@@ -21,7 +21,7 @@
 
     <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
         type="text/javascript"></script> -->
-    <script src="../js/ORPHE-CORE.js"></script>
+    <script src="../../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"

--- a/examples/GAME-SHOOTING/test.html
+++ b/examples/GAME-SHOOTING/test.html
@@ -21,7 +21,7 @@
 
     <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
         type="text/javascript"></script> -->
-    <script src="../js/ORPHE-CORE.js"></script>
+    <script src="../../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"


### PR DESCRIPTION
`docs/examples-catalog.md` の **needs-fix** セクションで挙げられていた壊れた相対パス問題への対応です。

## 背景

`GAME-MARIO/test.html` / `GAME-PINGPONG/test.html` / `GAME-SHOOTING/test.html` は STEP_ANALYSIS 動作確認用のシンプルな shim ですが、SDK を `<script src="../js/ORPHE-CORE.js">` で参照しています。`examples/GAME-MARIO/` から見ると `../js/` は `examples/js/` を指すため**実ファイルが存在せず**、ブラウザで開くと `Orphe is not defined` でゼロから動きません。正しいパスは `../../js/ORPHE-CORE.js` (2 階層上 = リポジトリ直下の `/js/`)。

## 修正内容

実害のあった 3 箇所:

- `examples/GAME-MARIO/test.html:24`
- `examples/GAME-PINGPONG/test.html:24`
- `examples/GAME-SHOOTING/test.html:24`

加えて、コメントアウトされている 2 箇所も追従 (将来コメント解除した時に同じ罠に踏まないよう):

- `examples/GAME-MARIO/index.html:170` (コメント内)
- `examples/GAME-PINGPONG/index.html:88` (コメント内)

それ以外の動作変更なし。

## Test plan

- [x] grep で `../js/` 参照がレポジトリ全体から消えたことを確認
- [ ] (オプション) ローカルサーバで http://localhost:8888/examples/GAME-MARIO/test.html 等を開き、Console に `Orphe is not defined` が出ないことを確認 (実機 BLE 接続不要)