### PR TITLE
chore(examples): fill empty <title>s and rewrite stale ICC2022Sep README

### DIFF
--- a/examples/DTW/index.html
+++ b/examples/DTW/index.html
@@ -1,6 +1,8 @@
 <html>
 
 <head>
+    <meta charset="utf-8">
+    <title>DTW Time Series Match — ORPHE CORE</title>
     <link href="../../css/custom.css" rel="stylesheet">
     <link href="../../css/orphe_custom.css" rel="stylesheet">
 

--- a/examples/ICC2022Sep/README.md
+++ b/examples/ICC2022Sep/README.md
@@ -1,4 +1,12 @@
-# POSE
-POSE is an example to use MediaPipe Pose, p5js and ORPHE-CORE.js in a single project.
+# ICC2022Sep
 
-  * MediaPipe Pose: https://google.github.io/mediapipe/solutions/pose.html
+A pose + ORPHE CORE demo originally built for an event in September 2022. It combines MediaPipe Pose (camera-based body landmarks) with ORPHE CORE foot data, with a simple coin/effects layer driven by walking and jumping.
+
+This was previously a hybrid Electron + Web app; the Electron entry points (main.js / preload.js / package.json) were removed in PR #35 so the directory now runs purely in the browser.
+
+- MediaPipe Pose: <https://google.github.io/mediapipe/solutions/pose.html>
+- For a smaller pure-pose example, see [`examples/POSE/`](../POSE/).
+
+## Status
+
+`needs-review` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for context. The directory ships large vendored dependencies (p5.js / control_utils_3d.js / MediaPipe assets); treat it as an exhibition-style demo rather than a beginner-friendly sample.

--- a/examples/p5.ORPHE.FSR_visualise_0327_submit/index.html
+++ b/examples/p5.ORPHE.FSR_visualise_0327_submit/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
+    <title>ORPHE FSR / INSOLE Visualiser (p5.js)</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.1/p5.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.1/addons/p5.sound.min.js"></script>
     <!-- CSS only -->


### PR DESCRIPTION
catalog 監査 (`examples/catalog.json` の `audit_findings` セクション) で見つかった**メタデータ系の小さな誤り 3 件**をまとめて修正する PR。

## 修正内容

### 1. `examples/DTW/index.html` の `<title>` 空

`<title>` 要素が存在せずブラウザタブが URL だけの表示でした。
→ `DTW Time Series Match — ORPHE CORE` を設定。

### 2. `examples/p5.ORPHE.FSR_visualise_0327_submit/index.html` の `<title>` 空

同様に `<title>` 無し。
→ `ORPHE FSR / INSOLE Visualiser (p5.js)` を設定。
ディレクトリ名の `_0327_submit` (一回限りの submission suffix) のリネームはこの PR では扱わない (catalog で `needs-review` 扱い、別 PR で要相談)。

### 3. `examples/ICC2022Sep/README.md` が POSE の README をそのまま流用

L1 の `# POSE` を含めて `examples/POSE/README.md` の完全コピーで、ディレクトリの内容と一致しない状態でした。
→ ICC2022Sep 用の README に書き直し:
  - 2022 年 9 月のイベント向け Pose + ORPHE デモであること
  - PR #35 で Electron 資材は既に撤去され、現在はブラウザのみで動くこと
  - `examples/POSE/` がより軽量なポーズ単独サンプルであることを案内
  - catalog で `needs-review` 扱い (大きな同梱依存) を明記

## 動作変更ゼロ

HTML/JS は読み込み内容に変更なし。タイトル要素追加と README の文章だけ。

## Test plan

- [x] `grep -c '<title>' examples/DTW/index.html examples/p5.ORPHE.FSR_visualise_0327_submit/index.html` で title 存在確認
- [x] `examples/ICC2022Sep/README.md` の冒頭が `# ICC2022Sep` であることを確認
- [ ] (オプション) ローカルサーバで各ページを開きタブ表示が想定通りか確認