### PR TITLE
chore(ws/tmu2022): fill placeholder/missing <title> in two demos

### DIFF
--- a/ws/tmu2022/demos/LJ/index.html
+++ b/ws/tmu2022/demos/LJ/index.html
@@ -2,10 +2,11 @@
 <html lang="en">
 
 <head>
+    <meta charset="utf-8" />
+    <title>Long Jump Sonification — TMU 2022 Workshop</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css" />
-    <meta charset="utf-8" />
 </head>
 
 <body class="text-black">

--- a/ws/tmu2022/demos/orphe-ping/index.html
+++ b/ws/tmu2022/demos/orphe-ping/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>uoo</title>
+    <title>ORPHE Ping — TMU 2022 Workshop</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.2/font/bootstrap-icons.css">


### PR DESCRIPTION
## Summary

Static catalog audit (`examples/catalog.json` `audit_findings`) flagged two TMU 2022 workshop demos with placeholder / missing `<title>` metadata. Tab labels and bookmarks were unreadable.

## Changed files

- `ws/tmu2022/demos/orphe-ping/index.html` — `<title>uoo</title>` placeholder → `ORPHE Ping — TMU 2022 Workshop`.
- `ws/tmu2022/demos/LJ/index.html` — `<title>` was missing entirely. Added `Long Jump Sonification — TMU 2022 Workshop` (matches the existing `<h1>LONG JUMP sonification</h1>` on the page). Also moved `<meta charset="utf-8">` to the top of `<head>` while editing (markup ordering tidy; no script load order change).

## Validation

- `<title>` 要素が両ファイルに存在し、意味的な文字列であることを `grep` で確認
- HTML / JS の挙動 / script src は変更なし

## Assumptions

- `LJ` ディレクトリ名は "Long Jump" の略 (本文 `<h1>LONG JUMP sonification</h1>` から推測)
- `orphe-ping` は HP ゲージ + ボス + ターン UI を持つボス戦風ゲーム。タイトルとしてはディレクトリ名とイベント名の組合せで安全に命名
- 文字コード `<meta charset>` を head 先頭に持っていく順序変更は spec 推奨 ([HTML Living Standard 4.2.5.4](https://html.spec.whatwg.org/multipage/semantics.html#charset)) で安全と判断

## Questions

- `ws/tmu2025/index.html` L440 の `<a href="" target="_blank">` 空リンク (placehold.jp の `Sample B` 画像つき) は**まだ未実装の作品プレースホルダ**に見えました。実装されたら href を埋める想定なので、本 PR のスコープからは除外。要相談。

## Next PR 候補

- A. weak title 修正 (`examples/catalog.json` の `audit_findings.weak_titles` 15 件)
- F-2. `ws/tmu2025/index.html` L440 の空 href 解消 (該当作品の特定が要)