### PR TITLE
chore(examples): rewrite generic <title> to per-example specific titles (23 files)

### DIFF
--- a/examples/AIRWALKER/index.html
+++ b/examples/AIRWALKER/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>ORPHE CORE JS DEMO</title>
+  <title>Air Walker — Step + Activity Dashboard (ORPHE CORE)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">

--- a/examples/CORETOOLKIT-STARTER/index.html
+++ b/examples/CORETOOLKIT-STARTER/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>ORPHE CORE JS</title>
+  <title>CoreToolkit Starter — ORPHE CORE</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">

--- a/examples/CORE_TIME_SYNC/index.html
+++ b/examples/CORE_TIME_SYNC/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>ORPHE CORE JS DEMO</title>
+    <title>Core Time Sync — ORPHE CORE</title>
 <script src="../../js/site-analytics.js"></script>
 </head>
 

--- a/examples/FOOT ANGLE/index.html
+++ b/examples/FOOT ANGLE/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>ORPHE CORE JS</title>
+  <title>Foot Angle Visualizer — ORPHE CORE</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">

--- a/examples/GAME-PINGPONG/index.html
+++ b/examples/GAME-PINGPONG/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>ping pong game</title>
+    <title>ORPHE Ping Pong (2P)</title>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">

--- a/examples/GAME-RHYTHM/index.html
+++ b/examples/GAME-RHYTHM/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>ORPHE CORE JS DEMO</title>
+    <title>ORPHE Rhythm Game</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.1/p5.js"></script>
   <script src="../../js/site-analytics.js"></script>
   </head>

--- a/examples/ICC2022Sep/index.html
+++ b/examples/ICC2022Sep/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>ORPHE CORE JS</title>
+  <title>Pose + ORPHE CORE Demo (ICC 2022)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">

--- a/examples/INFORMATION/index.html
+++ b/examples/INFORMATION/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>orphe.js</title>
+  <title>Device Information — ORPHE CORE</title>
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">

--- a/examples/OH1/index.html
+++ b/examples/OH1/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>ORPHE CORE JS</title>
+  <title>Polar OH1 + ORPHE CORE Heart Rate</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">

--- a/examples/POSE/index.html
+++ b/examples/POSE/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>ORPHE CORE JS</title>
+  <title>Pose + ORPHE CORE — MediaPipe Body Tracking</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">

--- a/examples/PRONATION/index.html
+++ b/examples/PRONATION/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>ORPHE CORE JS</title>
+  <title>Pronation Visualizer — ORPHE CORE</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">

--- a/examples/VIEW/index.html
+++ b/examples/VIEW/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>orphe.js</title>
+  <title>Sensor Viewer — ORPHE CORE</title>
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">

--- a/examples/VISUALIZE/index.html
+++ b/examples/VISUALIZE/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>orphe.js</title>
+  <title>Sensor Visualize (Chart.js) — ORPHE CORE</title>
   <link href="../../css/custom.css" rel="stylesheet">
   <link href="../../css/orphe_custom.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">

--- a/examples/WORKSHOP_07/index.html
+++ b/examples/WORKSHOP_07/index.html
@@ -15,7 +15,7 @@
 -->
 <head>
     <meta charset="utf-8">
-    <title>CoreToolkit.js</title>
+    <title>Workshop #7/#8 — DFT/FFT (ORPHE CORE)</title>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">

--- a/starter-templates/ACCELEROMETER.html
+++ b/starter-templates/ACCELEROMETER.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Accelerometer Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/ANALYSIS_AND_RAW.html
+++ b/starter-templates/ANALYSIS_AND_RAW.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Analysis + Sensor Values Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/EULER.html
+++ b/starter-templates/EULER.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Euler Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/GYRO.html
+++ b/starter-templates/GYRO.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Gyro Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/LIGHT.html
+++ b/starter-templates/LIGHT.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>LED Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/PRONATION.html
+++ b/starter-templates/PRONATION.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Pronation Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/QUATERNION.html
+++ b/starter-templates/QUATERNION.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Quaternion Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/STEPS.html
+++ b/starter-templates/STEPS.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Steps Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 

--- a/starter-templates/STRIDE.html
+++ b/starter-templates/STRIDE.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>orphe.js</title>
+    <title>Stride Starter — ORPHE CORE</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
 </head>
 


### PR DESCRIPTION
## Summary

Catalog audit (`examples/catalog.json` `audit_findings.weak_titles`) listed 14 examples + all 9 starter-templates as having a non-specific tab title (`orphe.js`, `ORPHE CORE JS DEMO`, `CoreToolkit.js`, etc.). Browser tabs and bookmarks could not distinguish different examples.

## Changed files (23, title-only)

### examples/ (14)
| Path | Old | New |
|---|---|---|
| AIRWALKER/index.html | `ORPHE CORE JS DEMO` | `Air Walker — Step + Activity Dashboard (ORPHE CORE)` |
| CORETOOLKIT-STARTER/index.html | `ORPHE CORE JS` | `CoreToolkit Starter — ORPHE CORE` |
| CORE_TIME_SYNC/index.html | `ORPHE CORE JS DEMO` | `Core Time Sync — ORPHE CORE` |
| FOOT ANGLE/index.html | `ORPHE CORE JS` | `Foot Angle Visualizer — ORPHE CORE` |
| GAME-PINGPONG/index.html | `ping pong game` | `ORPHE Ping Pong (2P)` |
| GAME-RHYTHM/index.html | `ORPHE CORE JS DEMO` | `ORPHE Rhythm Game` |
| ICC2022Sep/index.html | `ORPHE CORE JS` | `Pose + ORPHE CORE Demo (ICC 2022)` |
| INFORMATION/index.html | `orphe.js` | `Device Information — ORPHE CORE` |
| OH1/index.html | `ORPHE CORE JS` | `Polar OH1 + ORPHE CORE Heart Rate` |
| POSE/index.html | `ORPHE CORE JS` | `Pose + ORPHE CORE — MediaPipe Body Tracking` |
| PRONATION/index.html | `ORPHE CORE JS` | `Pronation Visualizer — ORPHE CORE` |
| VIEW/index.html | `orphe.js` | `Sensor Viewer — ORPHE CORE` |
| VISUALIZE/index.html | `orphe.js` | `Sensor Visualize (Chart.js) — ORPHE CORE` |
| WORKSHOP_07/index.html | `CoreToolkit.js` | `Workshop #7/#8 — DFT/FFT (ORPHE CORE)` |

### starter-templates/ (9)
全 9 ファイルが `orphe.js` だったのを `<sensor> Starter — ORPHE CORE` 形式に統一 (例: `Accelerometer Starter — ORPHE CORE`)。

## Naming Policy

- センサー / ユーティリティ系: `<example purpose> — ORPHE CORE`
- ゲーム: `ORPHE <name>` (ブランドが先に読まれる方が見つけやすい)
- starter-templates: `<sensor> Starter — ORPHE CORE`
- ICC2022Sep / WORKSHOP_07 のような期間限定教材は出典を括弧で

## Validation

- `grep -m 1 '<title>'` で全 23 ファイルの新タイトル文字列を確認
- HTML 構造 / JS / CSS / asset 参照は変更なし

## Assumptions

- linter race / em-dash 化等の自動整形が **<title> 内には影響しない** と仮定 (sed で直接置換、内容も英数 + ハイフン相当文字のみ)
- catalog.json の `audit_findings.weak_titles` リストの 15 件目 `starter-templates/*.html (all 9)` は実際の 9 ファイル個別を指していた
- ICC2022Sep / WORKSHOP_07 のリネーム (`POSE-COIN-WALK` 等) は別 PR で要相談 (catalog で `needs-review`/`legacy` 扱い)

## Questions

- INFORMATION / VIEW / VISUALIZE は古い "orphe.js" のブランディングが意図的に使われていた可能性。新タイトルで問題ないか実機テスターに確認したい
- starter-templates の `<title>` を統一フォーマットに揃えたが、初心者向けに「Hello World」「Step 1」のようなオンボーディング順位は付けたい (別 PR / 別タスク)

## Next PR 候補

- B. README 最小整備 (public / public-candidate で README 不在の examples)
- catalog.json の `audit_findings.weak_titles` を空にする refresh PR (Codex 側 schema 拡張に合わせた方が安全)