### PR TITLE
examples catalogに表示用フィールドを追加

### DIFF
--- a/docs/examples-catalog.md
+++ b/docs/examples-catalog.md
@@ -37,6 +37,23 @@ Each catalog entry uses these core fields:
 | `issues` | Known issues |
 | `next_actions` | Next work items |
 
+The catalog also carries display-oriented fields so the landing page, examples gallery, and validation scripts can consume the same data without guessing:
+
+| Field | Meaning |
+| --- | --- |
+| `category` | Primary gallery category: `getting-started`, `sensor-basics`, `gait-analysis`, `recording-analysis`, `playable-app`, `creative-coding`, `research-integration`, `workshop-archive`, `developer-tool`, or `internal-test`. |
+| `difficulty` | Beginner-facing level: `beginner`, `intermediate`, or `advanced`. This is about onboarding cost, not code quality. |
+| `featured` | Boolean shortcut for entries that should appear in the first public gallery row. |
+| `thumbnail` | Existing preview image path, or `null` when a thumbnail still needs to be prepared. |
+| `sort_order` | Stable display order for public navigation. Required for `featured` entries. |
+| `links` | Structured entry points such as `demo` and `source`. |
+| `requires_device` | Whether the entry needs ORPHE CORE or a compatible BLE device to be meaningful. |
+| `device_count` | Expected number of ORPHE CORE modules. This mirrors `devices` for display code. |
+| `needs_real_device_validation` | Whether physical ORPHE CORE verification is still needed. |
+| `public_navigation` | `featured`, `listed`, or `hidden`. This separates public value from first-screen priority. |
+
+Use `thumbnail: null` instead of omitting the field. Missing thumbnails are an explicit production task, not an accidental absence.
+
 ## Status Definitions
 
 | Status | Meaning |
@@ -47,6 +64,8 @@ Each catalog entry uses these core fields:
 | `needs-review` | Likely valuable, but purpose, audience, or device behavior needs review. |
 | `internal` | QA or maintenance tool. Not counted as a public example. |
 | `overlap` | Useful as part of a family, but confusing if presented as a separate top-level example. |
+
+`status` and `public_navigation` are intentionally separate. An entry can be `public-candidate` and still be `listed` when it is useful to show, while `needs-review` entries should normally stay `hidden` until a human confirms the purpose and device behavior.
 
 ## Current Broad Count
 

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": "0.1.0",
-  "updated": "2026-05-01",
+  "schema_version": "0.2.0",
+  "updated": "2026-05-02",
   "purpose": "Draft catalog for organizing existing ORPHE-CORE.js learning units before adding new examples.",
   "summary": {
     "examples_web_apps": 35,
@@ -41,7 +41,20 @@
       "topics": ["device-information", "setup"],
       "data": ["deviceInformation"],
       "devices": 1,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "getting-started",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": "examples/INFORMATION/teaser.gif",
+      "sort_order": 10,
+      "links": {
+        "demo": "examples/INFORMATION/index.html",
+        "source": "examples/INFORMATION/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "light",
@@ -54,7 +67,20 @@
       "topics": ["led", "connection"],
       "data": [],
       "devices": 1,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "getting-started",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": "examples/LIGHT/teaser.gif",
+      "sort_order": 20,
+      "links": {
+        "demo": "examples/LIGHT/index.html",
+        "source": "examples/LIGHT/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "coretoolkit-starter",
@@ -67,7 +93,20 @@
       "topics": ["CoreToolkit", "sensor-monitor", "two-devices"],
       "data": ["quat", "euler", "delta", "gyro", "convertedAcc", "gait", "stride", "footAngle", "pronation", "landingImpact"],
       "devices": 2,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "getting-started",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": null,
+      "sort_order": 30,
+      "links": {
+        "demo": "examples/CORETOOLKIT-STARTER/index.html",
+        "source": "examples/CORETOOLKIT-STARTER/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "view",
@@ -80,7 +119,20 @@
       "topics": ["visualization", "sensor-monitor"],
       "data": ["quat", "delta", "gyro", "convertedAcc", "euler", "gait", "stride", "footAngle", "pronation", "landingImpact"],
       "devices": 2,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "sensor-basics",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": "examples/VIEW/data-viewer.gif",
+      "sort_order": 40,
+      "links": {
+        "demo": "examples/VIEW/index.html",
+        "source": "examples/VIEW/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "visualize",
@@ -94,7 +146,20 @@
       "data": ["quat", "delta", "gyro", "euler"],
       "devices": 2,
       "validation": ["existing-public-link", "needs-device-verification"],
-      "issues": ["Name and README still use RAW wording in places"]
+      "issues": ["Name and README still use RAW wording in places"],
+      "category": "sensor-basics",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 50,
+      "links": {
+        "demo": "examples/VISUALIZE/index.html",
+        "source": "examples/VISUALIZE/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "foot-angle",
@@ -108,7 +173,20 @@
       "data": ["footAngle", "stride", "gait"],
       "devices": 1,
       "validation": ["existing-public-link", "needs-device-verification"],
-      "issues": ["Directory name contains a space"]
+      "issues": ["Directory name contains a space"],
+      "category": "gait-analysis",
+      "difficulty": "intermediate",
+      "featured": true,
+      "thumbnail": null,
+      "sort_order": 60,
+      "links": {
+        "demo": "examples/FOOT ANGLE/index.html",
+        "source": "examples/FOOT ANGLE/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "pronation",
@@ -121,7 +199,20 @@
       "topics": ["gait-analysis", "pronation", "landing-impact"],
       "data": ["pronation", "landingImpact", "gait"],
       "devices": 1,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "gait-analysis",
+      "difficulty": "intermediate",
+      "featured": true,
+      "thumbnail": null,
+      "sort_order": 70,
+      "links": {
+        "demo": "examples/PRONATION/index.html",
+        "source": "examples/PRONATION/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "airwalker",
@@ -134,7 +225,20 @@
       "topics": ["gait", "activity", "dashboard"],
       "data": ["convertedAcc", "stepsNumber"],
       "devices": 1,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "gait-analysis",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 80,
+      "links": {
+        "demo": "examples/AIRWALKER/index.html",
+        "source": "examples/AIRWALKER/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "pose",
@@ -148,7 +252,20 @@
       "data": ["stepsNumber", "quat"],
       "devices": 1,
       "validation": ["existing-public-link", "needs-browser-validation"],
-      "issues": ["Large vendored dependencies"]
+      "issues": ["Large vendored dependencies"],
+      "category": "creative-coding",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 90,
+      "links": {
+        "demo": "examples/POSE/index.html",
+        "source": "examples/POSE/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "listed"
     },
     {
       "id": "oh1",
@@ -162,7 +279,20 @@
       "data": ["acc", "quat", "stride"],
       "devices": 1,
       "validation": ["existing-public-link", "needs-device-verification"],
-      "issues": ["Not an ORPHE-only example"]
+      "issues": ["Not an ORPHE-only example"],
+      "category": "research-integration",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 100,
+      "links": {
+        "demo": "examples/OH1/index.html",
+        "source": "examples/OH1/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "sensor-calibration",
@@ -175,7 +305,20 @@
       "topics": ["recording", "calibration", "analysis"],
       "data": ["convertedAcc", "gyro", "euler", "gait"],
       "devices": 1,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "recording-analysis",
+      "difficulty": "intermediate",
+      "featured": true,
+      "thumbnail": null,
+      "sort_order": 110,
+      "links": {
+        "demo": "examples/SENSOR-CALIBRATION/index.html",
+        "source": "examples/SENSOR-CALIBRATION/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "gesture-demo",
@@ -188,7 +331,20 @@
       "topics": ["gesture", "recognition"],
       "data": ["euler", "acc", "gyro"],
       "devices": 1,
-      "validation": ["existing-public-link", "needs-device-verification"]
+      "validation": ["existing-public-link", "needs-device-verification"],
+      "category": "sensor-basics",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 120,
+      "links": {
+        "demo": "examples/GESTURE-DEMO/index.html",
+        "source": "examples/GESTURE-DEMO/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "game-hurdle",
@@ -201,7 +357,20 @@
       "topics": ["game", "running", "gait"],
       "data": ["convertedAcc", "euler", "gait"],
       "devices": 2,
-      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"]
+      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"],
+      "category": "playable-app",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": "examples/_thumbnails/hurdle-110m.png",
+      "sort_order": 200,
+      "links": {
+        "demo": "examples/GAME-HURDLE/index.html",
+        "source": "examples/GAME-HURDLE/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "game-udon",
@@ -214,7 +383,20 @@
       "topics": ["game", "creative-coding"],
       "data": ["convertedAcc"],
       "devices": 2,
-      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"]
+      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"],
+      "category": "playable-app",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": "examples/_thumbnails/udon.png",
+      "sort_order": 210,
+      "links": {
+        "demo": "examples/GAME-UDON/index.html",
+        "source": "examples/GAME-UDON/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "move-your-feet",
@@ -227,7 +409,20 @@
       "topics": ["game", "fitness", "sound"],
       "data": ["convertedAcc"],
       "devices": 2,
-      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"]
+      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"],
+      "category": "playable-app",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": "examples/_thumbnails/move-your-feet.png",
+      "sort_order": 220,
+      "links": {
+        "demo": "examples/MOVEYOURFEET/index.html",
+        "source": "examples/MOVEYOURFEET/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "game-pingpong",
@@ -241,7 +436,20 @@
       "data": ["euler", "convertedAcc"],
       "devices": 2,
       "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"],
-      "issues": ["test.html has a broken local SDK path; fix is proposed in PR #40"]
+      "issues": ["test.html has a broken local SDK path; fix is proposed in PR #40"],
+      "category": "playable-app",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": "examples/_thumbnails/pingpong.png",
+      "sort_order": 230,
+      "links": {
+        "demo": "examples/GAME-PINGPONG/index.html",
+        "source": "examples/GAME-PINGPONG/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "drum-test",
@@ -255,7 +463,20 @@
       "data": ["convertedAcc"],
       "devices": 2,
       "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"],
-      "issues": ["Directory name reads like a test rather than a public app"]
+      "issues": ["Directory name reads like a test rather than a public app"],
+      "category": "playable-app",
+      "difficulty": "beginner",
+      "featured": true,
+      "thumbnail": "examples/_thumbnails/drum.png",
+      "sort_order": 240,
+      "links": {
+        "demo": "examples/drum_test/index.html",
+        "source": "examples/drum_test/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "game-boxing",
@@ -268,7 +489,20 @@
       "topics": ["game", "action"],
       "data": ["convertedAcc"],
       "devices": 2,
-      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"]
+      "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": true,
+      "thumbnail": "examples/_thumbnails/boxing.png",
+      "sort_order": 250,
+      "links": {
+        "demo": "examples/GAME-BOXING/index.html",
+        "source": "examples/GAME-BOXING/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "game-ddr",
@@ -282,7 +516,20 @@
       "data": ["gait"],
       "devices": 2,
       "validation": ["existing-public-link", "thumbnail-exists", "needs-device-verification"],
-      "issues": ["Many internal docs may be too noisy for learners"]
+      "issues": ["Many internal docs may be too noisy for learners"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": true,
+      "thumbnail": "examples/_thumbnails/ddr.png",
+      "sort_order": 260,
+      "links": {
+        "demo": "examples/GAME-DDR/index.html",
+        "source": "examples/GAME-DDR/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "featured"
     },
     {
       "id": "core-time-sync",
@@ -295,7 +542,20 @@
       "topics": ["time-sync", "analysis", "debugging"],
       "data": ["convertedAcc"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "recording-analysis",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": null,
+      "links": {
+        "demo": "examples/CORE_TIME_SYNC/index.html",
+        "source": "examples/CORE_TIME_SYNC/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "hidden"
     },
     {
       "id": "dtw",
@@ -308,7 +568,20 @@
       "topics": ["DTW", "gesture", "analysis"],
       "data": ["acc"],
       "devices": 1,
-      "validation": ["needs-browser-validation", "needs-device-verification"]
+      "validation": ["needs-browser-validation", "needs-device-verification"],
+      "category": "recording-analysis",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 300,
+      "links": {
+        "demo": "examples/DTW/index.html",
+        "source": "examples/DTW/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "game-fireball-mario",
@@ -321,7 +594,20 @@
       "topics": ["game", "jump", "kick"],
       "data": ["convertedAcc", "gait", "landingImpact"],
       "devices": 1,
-      "validation": ["needs-browser-validation", "needs-device-verification"]
+      "validation": ["needs-browser-validation", "needs-device-verification"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 310,
+      "links": {
+        "demo": "examples/GAME-FIREBALL-MARIO/index.html",
+        "source": "examples/GAME-FIREBALL-MARIO/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "game-mario",
@@ -335,7 +621,20 @@
       "data": ["convertedAcc", "euler"],
       "devices": 2,
       "validation": ["needs-device-verification"],
-      "issues": ["test.html broken local SDK path was fixed in PR #40"]
+      "issues": ["test.html broken local SDK path was fixed in PR #40"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 320,
+      "links": {
+        "demo": "examples/GAME-MARIO/index.html",
+        "source": "examples/GAME-MARIO/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "game-pk",
@@ -348,7 +647,20 @@
       "topics": ["game", "kick", "3d"],
       "data": ["convertedAcc", "euler"],
       "devices": 1,
-      "validation": ["needs-browser-validation", "needs-device-verification"]
+      "validation": ["needs-browser-validation", "needs-device-verification"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 330,
+      "links": {
+        "demo": "examples/GAME-PK/index.html",
+        "source": "examples/GAME-PK/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "game-rhythm",
@@ -362,7 +674,20 @@
       "data": ["unknown"],
       "devices": 1,
       "validation": ["needs-browser-validation", "needs-device-verification"],
-      "issues": ["Contains a frozen local ORPHE-CORE.js copy"]
+      "issues": ["Contains a frozen local ORPHE-CORE.js copy"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": null,
+      "links": {
+        "demo": "examples/GAME-RHYTHM/index.html",
+        "source": "examples/GAME-RHYTHM/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "hidden"
     },
     {
       "id": "game-shooting",
@@ -376,7 +701,20 @@
       "data": ["euler", "acc", "stepsNumber"],
       "devices": 2,
       "validation": ["needs-browser-validation", "needs-device-verification"],
-      "issues": ["test.html has a broken local SDK path; fix is proposed in PR #40", "Relationship with GAME-SHOOTING2 is still unclear"]
+      "issues": ["test.html has a broken local SDK path; fix is proposed in PR #40", "Relationship with GAME-SHOOTING2 is still unclear"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 340,
+      "links": {
+        "demo": "examples/GAME-SHOOTING/index.html",
+        "source": "examples/GAME-SHOOTING/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "game-shooting2",
@@ -389,7 +727,20 @@
       "topics": ["game", "shooting", "3d"],
       "data": ["unknown"],
       "devices": 2,
-      "validation": ["needs-browser-validation", "needs-device-verification"]
+      "validation": ["needs-browser-validation", "needs-device-verification"],
+      "category": "playable-app",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 350,
+      "links": {
+        "demo": "examples/GAME-SHOOTING2/index.html",
+        "source": "examples/GAME-SHOOTING2/"
+      },
+      "requires_device": true,
+      "device_count": 2,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "icc2022sep",
@@ -403,7 +754,20 @@
       "data": ["stepsNumber", "landingImpact", "pronation", "stride", "quat"],
       "devices": 1,
       "validation": ["needs-browser-validation", "needs-device-verification"],
-      "issues": ["Large vendored dependencies", "Possible duplicate p5 bundle"]
+      "issues": ["Large vendored dependencies", "Possible duplicate p5 bundle"],
+      "category": "creative-coding",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": null,
+      "links": {
+        "demo": "examples/ICC2022Sep/index.html",
+        "source": "examples/ICC2022Sep/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "hidden"
     },
     {
       "id": "workshop-07",
@@ -416,7 +780,20 @@
       "topics": ["Fourier", "DFT", "analysis"],
       "data": ["acc"],
       "devices": 1,
-      "validation": ["needs-browser-validation", "needs-device-verification"]
+      "validation": ["needs-browser-validation", "needs-device-verification"],
+      "category": "workshop-archive",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 400,
+      "links": {
+        "demo": "examples/WORKSHOP_07/index.html",
+        "source": "examples/WORKSHOP_07/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "fsr-visualise",
@@ -430,7 +807,20 @@
       "data": ["quat"],
       "devices": 1,
       "validation": ["needs-domain-review", "needs-device-verification"],
-      "issues": ["May be ORPHE INSOLE-specific rather than ORPHE CORE.js general"]
+      "issues": ["May be ORPHE INSOLE-specific rather than ORPHE CORE.js general"],
+      "category": "research-integration",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": null,
+      "links": {
+        "demo": "examples/p5.ORPHE.FSR_visualise_0327_submit/index.html",
+        "source": "examples/p5.ORPHE.FSR_visualise_0327_submit/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "hidden"
     },
     {
       "id": "starter-light",
@@ -443,7 +833,20 @@
       "topics": ["led"],
       "data": [],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "sensor-basics",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 630,
+      "links": {
+        "demo": "starter-templates/LIGHT.html",
+        "source": "starter-templates/LIGHT.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-accelerometer",
@@ -456,7 +859,20 @@
       "topics": ["accelerometer", "sensor-basics"],
       "data": ["convertedAcc"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "sensor-basics",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 631,
+      "links": {
+        "demo": "starter-templates/ACCELEROMETER.html",
+        "source": "starter-templates/ACCELEROMETER.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-gyro",
@@ -469,7 +885,20 @@
       "topics": ["gyro", "sensor-basics"],
       "data": ["gyro"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "sensor-basics",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 632,
+      "links": {
+        "demo": "starter-templates/GYRO.html",
+        "source": "starter-templates/GYRO.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-quaternion",
@@ -482,7 +911,20 @@
       "topics": ["quat", "orientation", "sensor-basics"],
       "data": ["quat"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "sensor-basics",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 633,
+      "links": {
+        "demo": "starter-templates/QUATERNION.html",
+        "source": "starter-templates/QUATERNION.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-euler",
@@ -495,7 +937,20 @@
       "topics": ["euler", "orientation", "sensor-basics"],
       "data": ["euler"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "sensor-basics",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 634,
+      "links": {
+        "demo": "starter-templates/EULER.html",
+        "source": "starter-templates/EULER.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-steps",
@@ -508,7 +963,20 @@
       "topics": ["steps", "gait-analysis"],
       "data": ["stepsNumber"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "gait-analysis",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 635,
+      "links": {
+        "demo": "starter-templates/STEPS.html",
+        "source": "starter-templates/STEPS.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-stride",
@@ -521,7 +989,20 @@
       "topics": ["stride", "gait-analysis"],
       "data": ["stride"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "gait-analysis",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 636,
+      "links": {
+        "demo": "starter-templates/STRIDE.html",
+        "source": "starter-templates/STRIDE.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-pronation",
@@ -534,7 +1015,20 @@
       "topics": ["pronation", "gait-analysis"],
       "data": ["pronation", "gait"],
       "devices": 1,
-      "validation": ["needs-device-verification"]
+      "validation": ["needs-device-verification"],
+      "category": "gait-analysis",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 637,
+      "links": {
+        "demo": "starter-templates/PRONATION.html",
+        "source": "starter-templates/PRONATION.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "starter-analysis-and-sensor-values",
@@ -548,7 +1042,20 @@
       "data": ["acc", "stepsNumber"],
       "devices": 1,
       "validation": ["needs-device-verification"],
-      "issues": ["Filename uses legacy RAW wording"]
+      "issues": ["Filename uses legacy RAW wording"],
+      "category": "gait-analysis",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 638,
+      "links": {
+        "demo": "starter-templates/ANALYSIS_AND_RAW.html",
+        "source": "starter-templates/ANALYSIS_AND_RAW.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "guide-p5",
@@ -561,7 +1068,20 @@
       "topics": ["p5.js", "creative-coding"],
       "data": [],
       "devices": 1,
-      "validation": ["browser-guide"]
+      "validation": ["browser-guide"],
+      "category": "creative-coding",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 739,
+      "links": {
+        "demo": "docs/getting-started-p5.html",
+        "source": "docs/getting-started-p5.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "listed"
     },
     {
       "id": "guide-vscode",
@@ -574,7 +1094,20 @@
       "topics": ["VSCode", "local-server"],
       "data": [],
       "devices": 1,
-      "validation": ["browser-guide"]
+      "validation": ["browser-guide"],
+      "category": "getting-started",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 740,
+      "links": {
+        "demo": "docs/getting-started-vscode.html",
+        "source": "docs/getting-started-vscode.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "listed"
     },
     {
       "id": "guide-led",
@@ -587,7 +1120,20 @@
       "topics": ["led"],
       "data": [],
       "devices": 1,
-      "validation": ["browser-guide"]
+      "validation": ["browser-guide"],
+      "category": "getting-started",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 741,
+      "links": {
+        "demo": "docs/getting-started-led.html",
+        "source": "docs/getting-started-led.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "listed"
     },
     {
       "id": "guide-coretoolkit",
@@ -600,7 +1146,20 @@
       "topics": ["CoreToolkit"],
       "data": ["acc"],
       "devices": 1,
-      "validation": ["browser-guide"]
+      "validation": ["browser-guide"],
+      "category": "getting-started",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 742,
+      "links": {
+        "demo": "docs/getting-started-coretoolkit.html",
+        "source": "docs/getting-started-coretoolkit.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "listed"
     },
     {
       "id": "guide-electron",
@@ -613,7 +1172,20 @@
       "topics": ["Electron", "desktop"],
       "data": [],
       "devices": 1,
-      "validation": ["browser-guide"]
+      "validation": ["browser-guide"],
+      "category": "developer-tool",
+      "difficulty": "beginner",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 743,
+      "links": {
+        "demo": "docs/getting-started-electron.html",
+        "source": "docs/getting-started-electron.html"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "listed"
     },
     {
       "id": "tests-bridge",
@@ -626,7 +1198,20 @@
       "topics": ["internal", "test", "BLE"],
       "data": ["gait", "sensor-values"],
       "devices": 1,
-      "validation": ["internal"]
+      "validation": ["internal"],
+      "category": "internal-test",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": null,
+      "links": {
+        "demo": "tests/bridge/index.html",
+        "source": "tests/bridge/"
+      },
+      "requires_device": false,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "hidden"
     },
     {
       "id": "ws-tmu2025",
@@ -640,7 +1225,20 @@
       "data": [],
       "devices": 1,
       "validation": ["existing-public-link", "needs-device-verification"],
-      "issues": ["index.html L440 has an empty <a href=\"\"> link to one of the gallery pieces"]
+      "issues": ["index.html L440 has an empty <a href=\"\"> link to one of the gallery pieces"],
+      "category": "workshop-archive",
+      "difficulty": "intermediate",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 410,
+      "links": {
+        "demo": "ws/tmu2025/index.html",
+        "source": "ws/tmu2025/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     },
     {
       "id": "ws-tmu2022",
@@ -654,7 +1252,20 @@
       "data": [],
       "devices": 1,
       "validation": ["needs-domain-review"],
-      "issues": ["demos/ripples.zip is shipped as an unexpanded zip", "demos/orphe-ping/index.html still has placeholder <title>uoo</title>", "demos/LJ/index.html is missing <title>"]
+      "issues": ["demos/ripples.zip is shipped as an unexpanded zip", "demos/orphe-ping/index.html still has placeholder <title>uoo</title>", "demos/LJ/index.html is missing <title>"],
+      "category": "workshop-archive",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": null,
+      "links": {
+        "demo": "ws/tmu2022/index.html",
+        "source": "ws/tmu2022/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": false,
+      "public_navigation": "hidden"
     },
     {
       "id": "app-orphe-terminal",
@@ -668,7 +1279,20 @@
       "data": ["acc", "gyro", "quat", "euler", "gait", "stride", "pronation"],
       "devices": 1,
       "validation": ["existing-public-link", "needs-device-verification"],
-      "issues": ["README.md is just one line"]
+      "issues": ["README.md is just one line"],
+      "category": "developer-tool",
+      "difficulty": "advanced",
+      "featured": false,
+      "thumbnail": null,
+      "sort_order": 500,
+      "links": {
+        "demo": "apps/ORPHE-TERMINAL/index.html",
+        "source": "apps/ORPHE-TERMINAL/"
+      },
+      "requires_device": true,
+      "device_count": 1,
+      "needs_real_device_validation": true,
+      "public_navigation": "listed"
     }
   ],
   "recipe_candidates": [
@@ -761,21 +1385,66 @@
     "missing_thumbnails_count": 29,
     "thumbnails_aggregated_in": "examples/_thumbnails/ (7 images: boxing, ddr, drum, hurdle-110m, move-your-feet, pingpong, udon)",
     "weak_titles": [
-      {"file": "examples/AIRWALKER/index.html", "title": "ORPHE CORE JS DEMO"},
-      {"file": "examples/CORETOOLKIT-STARTER/index.html", "title": "ORPHE CORE JS"},
-      {"file": "examples/CORE_TIME_SYNC/index.html", "title": "ORPHE CORE JS DEMO"},
-      {"file": "examples/FOOT ANGLE/index.html", "title": "ORPHE CORE JS"},
-      {"file": "examples/GAME-PINGPONG/index.html", "title": "ping pong game"},
-      {"file": "examples/GAME-RHYTHM/index.html", "title": "ORPHE CORE JS DEMO"},
-      {"file": "examples/ICC2022Sep/index.html", "title": "ORPHE CORE JS"},
-      {"file": "examples/INFORMATION/index.html", "title": "orphe.js"},
-      {"file": "examples/OH1/index.html", "title": "ORPHE CORE JS"},
-      {"file": "examples/POSE/index.html", "title": "ORPHE CORE JS"},
-      {"file": "examples/PRONATION/index.html", "title": "ORPHE CORE JS"},
-      {"file": "examples/VIEW/index.html", "title": "orphe.js"},
-      {"file": "examples/VISUALIZE/index.html", "title": "orphe.js"},
-      {"file": "examples/WORKSHOP_07/index.html", "title": "CoreToolkit.js"},
-      {"file": "starter-templates/*.html", "title": "orphe.js (all 9 files share this generic title)"}
+      {
+        "file": "examples/AIRWALKER/index.html",
+        "title": "ORPHE CORE JS DEMO"
+      },
+      {
+        "file": "examples/CORETOOLKIT-STARTER/index.html",
+        "title": "ORPHE CORE JS"
+      },
+      {
+        "file": "examples/CORE_TIME_SYNC/index.html",
+        "title": "ORPHE CORE JS DEMO"
+      },
+      {
+        "file": "examples/FOOT ANGLE/index.html",
+        "title": "ORPHE CORE JS"
+      },
+      {
+        "file": "examples/GAME-PINGPONG/index.html",
+        "title": "ping pong game"
+      },
+      {
+        "file": "examples/GAME-RHYTHM/index.html",
+        "title": "ORPHE CORE JS DEMO"
+      },
+      {
+        "file": "examples/ICC2022Sep/index.html",
+        "title": "ORPHE CORE JS"
+      },
+      {
+        "file": "examples/INFORMATION/index.html",
+        "title": "orphe.js"
+      },
+      {
+        "file": "examples/OH1/index.html",
+        "title": "ORPHE CORE JS"
+      },
+      {
+        "file": "examples/POSE/index.html",
+        "title": "ORPHE CORE JS"
+      },
+      {
+        "file": "examples/PRONATION/index.html",
+        "title": "ORPHE CORE JS"
+      },
+      {
+        "file": "examples/VIEW/index.html",
+        "title": "orphe.js"
+      },
+      {
+        "file": "examples/VISUALIZE/index.html",
+        "title": "orphe.js"
+      },
+      {
+        "file": "examples/WORKSHOP_07/index.html",
+        "title": "CoreToolkit.js"
+      },
+      {
+        "file": "starter-templates/*.html",
+        "title": "orphe.js (all 9 files share this generic title)"
+      }
     ],
     "internal_artifacts_in_public_examples": [
       {
@@ -791,17 +1460,7 @@
         "suggested_fix": "Move under docs/internal/game-ddr/."
       }
     ],
-    "summary_lines_for_release_notes": [
-      "AIRWALKER の dead chart/fft コードを削除済 (PR #31)",
-      "通知タイプ表記を公式名 (SENSOR_VALUES / STEP_ANALYSIS / STEP_ANALYSIS_AND_SENSOR_VALUES) に統一済 (PR #32)",
-      "WORKSHOP_07 と _08 を統合済 (PR #33)",
-      "TEST-BRIDGE を tests/bridge/ に移動済 (PR #34)",
-      "ICC2022Sep の Electron 資材を削除済 (PR #35)",
-      "HURDLE family の dead files を一括削除済 (PR #36)",
-      "GAME-PK の HTML 4 種を 1 つに集約 + DEBUG_MODE を opt-in 化済 (PR #37)",
-      "display-only example で gotAcc → gotConvertedAcc 切替済 (PR #39)",
-      "test.html 3 件の壊れた相対パス修正は PR #40 で提案中"
-    ]
+    "summary_lines_for_release_notes": ["AIRWALKER の dead chart/fft コードを削除済 (PR #31)", "通知タイプ表記を公式名 (SENSOR_VALUES / STEP_ANALYSIS / STEP_ANALYSIS_AND_SENSOR_VALUES) に統一済 (PR #32)", "WORKSHOP_07 と _08 を統合済 (PR #33)", "TEST-BRIDGE を tests/bridge/ に移動済 (PR #34)", "ICC2022Sep の Electron 資材を削除済 (PR #35)", "HURDLE family の dead files を一括削除済 (PR #36)", "GAME-PK の HTML 4 種を 1 つに集約 + DEBUG_MODE を opt-in 化済 (PR #37)", "display-only example で gotAcc → gotConvertedAcc 切替済 (PR #39)", "test.html 3 件の壊れた相対パス修正は PR #40 で提案中"]
   },
   "coverage_gaps": [
     {
@@ -819,5 +1478,16 @@
       "gap": "There are many games, but their sensor concepts are not consistently explained.",
       "timing": "Improve explanations before adding new game types."
     }
-  ]
+  ],
+  "display_schema": {
+    "category": ["getting-started", "sensor-basics", "gait-analysis", "recording-analysis", "playable-app", "creative-coding", "research-integration", "workshop-archive", "developer-tool", "internal-test"],
+    "difficulty": ["beginner", "intermediate", "advanced"],
+    "public_navigation": ["featured", "listed", "hidden"],
+    "thumbnail": "Path to an existing preview image, or null when one still needs to be prepared.",
+    "sort_order": "Integer used for stable public navigation ordering. Required when public_navigation is featured.",
+    "links": "Entry points for demos, source directories, docs, or API pages.",
+    "requires_device": "True when the example is only meaningful with ORPHE CORE hardware or a compatible BLE device.",
+    "device_count": "Expected number of ORPHE CORE modules. Mirrors devices while making display code explicit.",
+    "needs_real_device_validation": "True when the catalog entry still needs physical ORPHE CORE verification."
+  }
 }


### PR DESCRIPTION
## Summary
- examples/catalog.json を schema_version 0.2.0 に更新
- LP / Examples一覧で使うための category / difficulty / featured / thumbnail / sort_order / links / device_count / public_navigation などを各entryに追加
- 既存サムネイルがあるentryだけ thumbnail path を設定し、未準備のものは null として明示
- docs/examples-catalog.md に display field の定義と status/public_navigation の使い分けを追記

## Validation
- git diff --check
- node JSON parse OK
- catalog id重複なし
- category / difficulty / public_navigation の許可値チェック OK
- demo / source / thumbnail path existence check OK

## Assumptions
- public_navigation は featured / listed / hidden の3段階にしました
- 実機未確認のentryは needs_real_device_validation: true のままにしています
- thumbnail は新規作成せず、既存画像だけ設定しています

## Questions / Follow-ups
- featured の初期選定はLP上部に出す候補として仮置きです
- CoreToolkit / Gait系など thumbnail: null の主要entryは次PRで画像方針を決める必要があります

## Next PR候補
- catalog validation script追加
- catalog-driven gallery設計docs
- 100 examples roadmap docs