### PR TITLE
docs(examples): add minimal README scaffold to 17 public/candidate examples

### DIFF
--- a/examples/AIRWALKER/README.md
+++ b/examples/AIRWALKER/README.md
@@ -1,0 +1,34 @@
+# Air Walker
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Show steps, motion, and activity in a visual dashboard.
+
+## このexampleで学べること
+
+- Show steps, motion, and activity in a visual dashboard.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+- 歩数 (stepsNumber)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- クリエイティブコーダー・スポーツテック開発者
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- (関連 example なし — `docs/examples-catalog.md` の Overlap Families を参照)
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `airwalker` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/CORETOOLKIT-STARTER/README.md
+++ b/examples/CORETOOLKIT-STARTER/README.md
@@ -1,0 +1,42 @@
+# CoreToolkit Starter
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Use CoreToolkit.js to connect and monitor ORPHE CORE modules quickly.
+
+## このexampleで学べること
+
+- Use CoreToolkit.js to connect and monitor ORPHE CORE modules quickly.
+
+## 使うデータ
+
+- クォータニオン (quat)
+- オイラー角 (euler)
+- デルタ (delta)
+- ジャイロ (gyro)
+- 加速度 (gotConvertedAcc, 実Gスケール)
+- 歩行 (gait)
+- ストライド (stride)
+- 足角度 (footAngle)
+- プロネーション (pronation)
+- 接地衝撃 (landingImpact)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- 初学者・アプリ開発者
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- (関連 example なし — `docs/examples-catalog.md` の Overlap Families を参照)
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `coretoolkit-starter` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/FOOT ANGLE/README.md
+++ b/examples/FOOT ANGLE/README.md
@@ -1,0 +1,42 @@
+# Foot Angle
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Visualize foot angle from ORPHE gait analysis.
+
+## このexampleで学べること
+
+- Visualize foot angle from ORPHE gait analysis.
+
+## 使うデータ
+
+- 足角度 (footAngle)
+- ストライド (stride)
+- 歩行 (gait)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- 研究者・解析者・スポーツテック開発者
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 既知の課題
+
+- Directory name contains a space
+
+## 関連example
+
+- [`examples/VIEW/`](../VIEW/README.md) — Data Viewer
+- [`examples/VISUALIZE/`](../VISUALIZE/README.md) — Sensor Values Visualizer
+- [`examples/PRONATION/`](../PRONATION/README.md) — Pronation
+- [`examples/POSE/`](../POSE/README.md) — Pose
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `foot-angle` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/FOOT ANGLE/README.md
+++ b/examples/FOOT ANGLE/README.md
@@ -28,7 +28,7 @@ Visualize foot angle from ORPHE gait analysis.
 
 ## 既知の課題
 
-- Directory name contains a space
+- Directory name contains a space — Markdown links to this README must be wrapped in angle brackets (e.g. `[label](<../FOOT ANGLE/README.md>)`) or use `%20` to render correctly on GitHub
 
 ## 関連example
 

--- a/examples/GAME-FIREBALL-MARIO/README.md
+++ b/examples/GAME-FIREBALL-MARIO/README.md
@@ -1,0 +1,35 @@
+# Fireball Mario
+
+> **Status**: `public-candidate` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Action game using stepping, kicking, and jumping gestures.
+
+## このexampleで学べること
+
+- Action game using stepping, kicking, and jumping gestures.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+- 歩行 (gait)
+- 接地衝撃 (landingImpact)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- [`examples/GAME-PK/`](../GAME-PK/README.md) — Penalty Kick Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-fireball-mario` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GAME-HURDLE/README.md
+++ b/examples/GAME-HURDLE/README.md
@@ -1,0 +1,35 @@
+# 110m Hurdle Game
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Representative playable game using gait and motion input.
+
+## このexampleで学べること
+
+- Representative playable game using gait and motion input.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+- オイラー角 (euler)
+- 歩行 (gait)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- 初学者・ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- (関連 example なし — `docs/examples-catalog.md` の Overlap Families を参照)
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-hurdle` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GAME-MARIO/README.md
+++ b/examples/GAME-MARIO/README.md
@@ -1,0 +1,38 @@
+# 2D Action Game
+
+> **Status**: `public-candidate` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Playable 2D action game concept.
+
+## このexampleで学べること
+
+- Playable 2D action game concept.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+- オイラー角 (euler)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 既知の課題
+
+- test.html broken local SDK path was fixed in PR #40
+
+## 関連example
+
+- [`examples/GAME-BOXING/`](../GAME-BOXING/README.md) — Boxing Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-mario` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GAME-PINGPONG/README.md
+++ b/examples/GAME-PINGPONG/README.md
@@ -1,0 +1,38 @@
+# Ping Pong Game
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Simple competitive game concept using ORPHE input.
+
+## このexampleで学べること
+
+- Simple competitive game concept using ORPHE input.
+
+## 使うデータ
+
+- オイラー角 (euler)
+- 加速度 (gotConvertedAcc, 実Gスケール)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 既知の課題
+
+- test.html has a broken local SDK path; fix is proposed in PR #40
+
+## 関連example
+
+- (関連 example なし — `docs/examples-catalog.md` の Overlap Families を参照)
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-pingpong` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GAME-PINGPONG/README.md
+++ b/examples/GAME-PINGPONG/README.md
@@ -27,7 +27,7 @@ Simple competitive game concept using ORPHE input.
 
 ## 既知の課題
 
-- test.html has a broken local SDK path; fix is proposed in PR #40
+- test.html broken local SDK path was fixed in PR #40
 
 ## 関連example
 

--- a/examples/GAME-PK/README.md
+++ b/examples/GAME-PK/README.md
@@ -1,0 +1,35 @@
+# Penalty Kick Game
+
+> **Status**: `public-candidate` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Fun kick-accuracy game that can demonstrate acceleration and direction mapping.
+
+## このexampleで学べること
+
+- Fun kick-accuracy game that can demonstrate acceleration and direction mapping.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+- オイラー角 (euler)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- [`examples/GAME-FIREBALL-MARIO/`](../GAME-FIREBALL-MARIO/README.md) — Fireball Mario
+- [`examples/GAME-SHOOTING2/`](../GAME-SHOOTING2/README.md) — 3D Shooting Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-pk` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GAME-SHOOTING/README.md
+++ b/examples/GAME-SHOOTING/README.md
@@ -1,0 +1,40 @@
+# Shooting Game
+
+> **Status**: `public-candidate` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Shooting game concept.
+
+## このexampleで学べること
+
+- Shooting game concept.
+
+## 使うデータ
+
+- オイラー角 (euler)
+- 加速度 (acc, 正規化)
+- 歩数 (stepsNumber)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 既知の課題
+
+- test.html has a broken local SDK path; fix is proposed in PR #40
+- Relationship with GAME-SHOOTING2 is still unclear
+
+## 関連example
+
+- [`examples/GAME-SHOOTING2/`](../GAME-SHOOTING2/README.md) — 3D Shooting Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-shooting` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GAME-SHOOTING/README.md
+++ b/examples/GAME-SHOOTING/README.md
@@ -28,7 +28,7 @@ Shooting game concept.
 
 ## 既知の課題
 
-- test.html has a broken local SDK path; fix is proposed in PR #40
+- test.html broken local SDK path was fixed in PR #40
 - Relationship with GAME-SHOOTING2 is still unclear
 
 ## 関連example

--- a/examples/GAME-SHOOTING2/README.md
+++ b/examples/GAME-SHOOTING2/README.md
@@ -1,0 +1,34 @@
+# 3D Shooting Game
+
+> **Status**: `public-candidate` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+3D shooting-style game candidate.
+
+## このexampleで学べること
+
+- 3D shooting-style game candidate.
+
+## 使うデータ
+
+- (未調査)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- [`examples/GAME-PK/`](../GAME-PK/README.md) — Penalty Kick Game
+- [`examples/GAME-SHOOTING/`](../GAME-SHOOTING/README.md) — Shooting Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-shooting2` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GAME-UDON/README.md
+++ b/examples/GAME-UDON/README.md
@@ -1,0 +1,33 @@
+# Udon Kneading Game
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Playful body-motion game that is easy to understand visually.
+
+## このexampleで学べること
+
+- Playful body-motion game that is easy to understand visually.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- ゲームプレイヤー・クリエイティブコーダー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- [`examples/drum_test/`](../drum_test/README.md) — Drum Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `game-udon` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/GESTURE-DEMO/README.md
+++ b/examples/GESTURE-DEMO/README.md
@@ -1,0 +1,35 @@
+# Gesture Demo
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Starting point for gesture detection using ORPHE data.
+
+## このexampleで学べること
+
+- Starting point for gesture detection using ORPHE data.
+
+## 使うデータ
+
+- オイラー角 (euler)
+- 加速度 (acc, 正規化)
+- ジャイロ (gyro)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- アプリ開発者・クリエイティブコーダー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- (関連 example なし — `docs/examples-catalog.md` の Overlap Families を参照)
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `gesture-demo` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/MOVEYOURFEET/README.md
+++ b/examples/MOVEYOURFEET/README.md
@@ -1,0 +1,34 @@
+# Move Your Feet
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Exercise-style game using foot movement.
+
+## このexampleで学べること
+
+- Exercise-style game using foot movement.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- ゲームプレイヤー・フィットネス
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- [`examples/drum_test/`](../drum_test/README.md) — Drum Game
+- [`examples/GAME-RHYTHM/`](../GAME-RHYTHM/README.md) — Rhythm Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `move-your-feet` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/MOVEYOURFEET/README.md
+++ b/examples/MOVEYOURFEET/README.md
@@ -27,7 +27,7 @@ Exercise-style game using foot movement.
 ## 関連example
 
 - [`examples/drum_test/`](../drum_test/README.md) — Drum Game
-- [`examples/GAME-RHYTHM/`](../GAME-RHYTHM/README.md) — Rhythm Game
+- [`examples/GAME-DDR/`](../GAME-DDR/README.md) — DDR Game
 
 ## 元データ
 

--- a/examples/OH1/README.md
+++ b/examples/OH1/README.md
@@ -1,0 +1,39 @@
+# OH1 Heart Rate
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Demonstrate integration with an external BLE heart-rate sensor.
+
+## このexampleで学べること
+
+- Demonstrate integration with an external BLE heart-rate sensor.
+
+## 使うデータ
+
+- 加速度 (acc, 正規化)
+- クォータニオン (quat)
+- ストライド (stride)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- 研究者・解析者・BLE統合
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 既知の課題
+
+- Not an ORPHE-only example
+
+## 関連example
+
+- (関連 example なし — `docs/examples-catalog.md` の Overlap Families を参照)
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `oh1` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/PRONATION/README.md
+++ b/examples/PRONATION/README.md
@@ -1,0 +1,38 @@
+# Pronation
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Visualize pronation and landing-related gait data.
+
+## このexampleで学べること
+
+- Visualize pronation and landing-related gait data.
+
+## 使うデータ
+
+- プロネーション (pronation)
+- 接地衝撃 (landingImpact)
+- 歩行 (gait)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- 研究者・解析者・スポーツテック開発者
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- [`examples/FOOT ANGLE/`](../FOOT ANGLE/README.md) — Foot Angle
+- [`starter-templates/STEPS.html`](../starter-templates/STEPS.htmlREADME.md) — Starter: Steps
+- [`starter-templates/STRIDE.html`](../starter-templates/STRIDE.htmlREADME.md) — Starter: Stride
+- [`starter-templates/PRONATION.html`](../starter-templates/PRONATION.htmlREADME.md) — Starter: Pronation
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `pronation` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/PRONATION/README.md
+++ b/examples/PRONATION/README.md
@@ -28,10 +28,10 @@ Visualize pronation and landing-related gait data.
 
 ## 関連example
 
-- [`examples/FOOT ANGLE/`](../FOOT ANGLE/README.md) — Foot Angle
-- [`starter-templates/STEPS.html`](../starter-templates/STEPS.htmlREADME.md) — Starter: Steps
-- [`starter-templates/STRIDE.html`](../starter-templates/STRIDE.htmlREADME.md) — Starter: Stride
-- [`starter-templates/PRONATION.html`](../starter-templates/PRONATION.htmlREADME.md) — Starter: Pronation
+- [`examples/FOOT ANGLE/`](<../FOOT ANGLE/README.md>) — Foot Angle
+- [`starter-templates/STEPS.html`](../../starter-templates/STEPS.html) — Starter: Steps
+- [`starter-templates/STRIDE.html`](../../starter-templates/STRIDE.html) — Starter: Stride
+- [`starter-templates/PRONATION.html`](../../starter-templates/PRONATION.html) — Starter: Pronation
 
 ## 元データ
 

--- a/examples/SENSOR-CALIBRATION/README.md
+++ b/examples/SENSOR-CALIBRATION/README.md
@@ -1,0 +1,36 @@
+# Sensor Calibration
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Record and inspect sensor data for calibration workflows.
+
+## このexampleで学べること
+
+- Record and inspect sensor data for calibration workflows.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+- ジャイロ (gyro)
+- オイラー角 (euler)
+- 歩行 (gait)
+
+## 必要なORPHE CORE数
+
+- 1 台
+
+## 想定読者
+
+- 研究者・解析者・デバッグ
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 関連example
+
+- (関連 example なし — `docs/examples-catalog.md` の Overlap Families を参照)
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `sensor-calibration` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/drum_test/README.md
+++ b/examples/drum_test/README.md
@@ -1,0 +1,39 @@
+# Drum Game
+
+> **Status**: `public` — see [`docs/examples-catalog.md`](../../docs/examples-catalog.md) for the full audit.
+
+Sound interaction driven by body motion.
+
+## このexampleで学べること
+
+- Sound interaction driven by body motion.
+
+## 使うデータ
+
+- 加速度 (gotConvertedAcc, 実Gスケール)
+
+## 必要なORPHE CORE数
+
+- 2 台
+
+## 想定読者
+
+- クリエイティブコーダー・ゲームプレイヤー
+
+## 実機確認
+
+- **未実機確認** — 静的検証 (パス・参照) のみ。BLE 接続後の挙動はオーナーレビュー待ち。
+
+## 既知の課題
+
+- Directory name reads like a test rather than a public app
+
+## 関連example
+
+- [`examples/GAME-UDON/`](../GAME-UDON/README.md) — Udon Kneading Game
+- [`examples/MOVEYOURFEET/`](../MOVEYOURFEET/README.md) — Move Your Feet
+- [`examples/GAME-RHYTHM/`](../GAME-RHYTHM/README.md) — Rhythm Game
+
+## 元データ
+
+このREADMEは `examples/catalog.json` の `drum-test` エントリから自動生成された最小スケルトンです。手動で詳細・スクリーンショット・遊び方を加筆してください。

--- a/examples/drum_test/README.md
+++ b/examples/drum_test/README.md
@@ -32,7 +32,7 @@ Sound interaction driven by body motion.
 
 - [`examples/GAME-UDON/`](../GAME-UDON/README.md) — Udon Kneading Game
 - [`examples/MOVEYOURFEET/`](../MOVEYOURFEET/README.md) — Move Your Feet
-- [`examples/GAME-RHYTHM/`](../GAME-RHYTHM/README.md) — Rhythm Game
+- [`examples/GAME-DDR/`](../GAME-DDR/README.md) — DDR Game
 
 ## 元データ
 


### PR DESCRIPTION
## Summary

`examples/catalog.json` で `public` または `public-candidate` 扱いの web-app 17 件に **README が一切なかった**ので、catalog のメタデータをテンプレに流し込んで最小 README を生成しました。

将来のギャラリー / カタログページが各 example について「これは何で、何を学べるか」を出せる最小ラインを引きます。

## Changed files

新規 `README.md` × 17:

| Status | Example |
|---|---|
| public | AIRWALKER / CORETOOLKIT-STARTER / FOOT ANGLE / GAME-HURDLE / GAME-PINGPONG / GAME-UDON / GESTURE-DEMO / MOVEYOURFEET / OH1 / PRONATION / SENSOR-CALIBRATION / drum_test |
| public-candidate | GAME-FIREBALL-MARIO / GAME-MARIO / GAME-PK / GAME-SHOOTING / GAME-SHOOTING2 |

各 README のセクション (テンプレ統一):

```
# <Display title>
> Status: `<status>` — see docs/examples-catalog.md
<1-line value statement>

## このexampleで学べること
## 使うデータ
## 必要なORPHE CORE数
## 想定読者
## 実機確認 (catalog の validation 配列から自動判定)
## (既知の課題 — issues がある場合のみ)
## 関連example (catalog の family / topics 重複から自動)
## 元データ (このREADMEは catalog.json から自動生成された最小スケルトン)
```

## Validation

- catalog.json の `entries[].value` / `data` / `devices` / `audience` / `validation` / `issues` / `family` を引いて埋めるため、catalog と内容ズレが起きにくい
- 17 ファイル全件 `# <title>` で始まり、フッターに「自動生成された最小スケルトン」と明記し**手作業の加筆を促す**
- HTML / JS / asset は一切触っていない

## Assumptions

- 既存の README がある examples (`INFORMATION` / `LIGHT` / `VIEW` / `VISUALIZE` / `POSE` / `WORKSHOP_07` / `DTW` / `ICC2022Sep` / `GAME-DDR` / `GAME-BOXING` 等) は触らない
- internal / needs-review / legacy の examples (`GAME-RHYTHM` / `p5.ORPHE.FSR_visualise_*` / HURDLE family の VS 派生 / ICC2022Sep / etc.) も今回の対象外 (内容を判断して書くべきなので別 PR)
- starter-templates も別 PR (テンプレートは README より代わりに HTML 内コメントが適切と判断)

## Questions

- 「このexampleで学べること」セクションに 1-line value をそのまま入れているが、複数 bullets で展開した方が学習者向けに有用 → 各 example のオーナーが手で書き足すフォーマットでよいか
- catalog の `data` 配列に未調査 (`unknown`) が残るもの (`GAME-RHYTHM`, `GAME-SHOOTING2`, `ICC2022Sep` 等) は静的に補完できないので別 PR で
- スクリーンショット / gif / 遊び方は Codex 側 (catalog schema 拡張) で `screenshot` フィールドを追加する設計が望ましい

## Next PR 候補

- C. `docs/examples-thumbnail-audit.md` 作成 (本 PR と独立)
- D. internal docs の整理方針 (GAME-PK / GAME-DDR の MD)
- E. ws / tutorial / apps の公開価値レビュー