### PR TITLE
LP下部のExample一覧をカード表示に整理

### DIFF
--- a/css/orphe_custom.css
+++ b/css/orphe_custom.css
@@ -488,6 +488,112 @@ mark {
     margin-top: 1.5rem;
 }
 
+.dx-example-section {
+    margin-top: 1.5rem;
+}
+
+.dx-example-section>p {
+    max-width: 840px;
+    color: #d8d8d8;
+}
+
+.dx-example-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 1rem;
+    margin: 1rem 0 1.5rem;
+}
+
+.dx-example-card {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 8px;
+    background: #202020;
+}
+
+.dx-example-card img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+    object-position: top center;
+    background: #151515;
+}
+
+.dx-example-card-body {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 0.65rem;
+    padding: 0.95rem;
+}
+
+.dx-example-card h4 {
+    margin: 0;
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.dx-example-card p {
+    margin: 0;
+    color: #cfcfcf;
+    font-size: 0.9rem;
+    line-height: 1.55;
+}
+
+.dx-example-tags,
+.dx-example-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.dx-example-tags span {
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    padding: 0.25rem 0.55rem;
+    color: #bdbdbd;
+    font-size: 0.75rem;
+}
+
+.dx-example-links {
+    margin-top: auto;
+}
+
+.dx-example-links a,
+.dx-mini-link {
+    border: 1px solid rgba(69, 230, 230, 0.3);
+    border-radius: 999px;
+    padding: 0.35rem 0.7rem;
+    color: #45e6e6;
+    font-size: 0.82rem;
+    text-decoration: none;
+}
+
+.dx-example-links a:hover,
+.dx-mini-link:hover {
+    border-color: rgba(69, 230, 230, 0.72);
+    color: #ffffff;
+}
+
+.dx-mini-link-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    margin: 0.8rem 0 1.5rem;
+}
+
+.dx-example-subhead {
+    margin-top: 1.4rem;
+    color: #ffffff;
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+
 @media (max-width: 991.98px) {
     .dx-hero {
         min-height: 500px;

--- a/index.html
+++ b/index.html
@@ -611,343 +611,246 @@
     </section>
 
 
-    <h3 id="examples" class="mt-4"><i class="bi bi-code"></i> Application Examples </h3>
-    <section class="ms-4">
-      <p class="lang en">
-        We have prepared several Examples using ORPHE-CORE.js. All Examples are located under the
-        /ORPHE-CORE.js/examples
-        directory.
-      </p>
-      <p class="lang ja active">
-        ORPHE-CORE.jsを使ったいくつかのExamplesを用意しました。すべてのExamplesは/ORPHE-CORE.js/examplesディレクトリにあります。
-      </p>
-      <!-- The following is a list of BLE Advertising by ORPHE CORE Module. Not all advertisements are listed in this page.
-      <table class="table table-dark table-striped table-hover">
-        <thead>
-          <tr>
-            <th scope="col">name</th>
-            <th scope="col">type</th>
-            <th scope="col">UUID</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">ORPHE Information </th>
-            <td>Service</td>
-            <td> 01A9D6B5-FF6E-444A-B266-0BE75E85C064</td>
-          </tr>
-
-          <tr>
-            <th scope="row">Device Information </th>
-            <td>Read/Write</td>
-            <td>24354F22-1C46-430E-A4AB-A1EEABBCDFC0</td>
-          </tr>
-
-          <tr>
-            <th scope="row">Other Service</th>
-            <td>Service</td>
-            <td>DB1B7ACA-CDA5-4453-A49B-33A53D3F0833</td>
-          </tr>
-
-          <tr>
-            <th scope="row">Sensor Values</th>
-            <td>Notify</td>
-            <td>F3F9C7CE-46EE-4205-89AC-ABE64E626C0F</td>
-          </tr>
-
-          <tr>
-            <th scope="row">Step Analysis</th>
-            <td>Notify</td>
-            <td>4EB776DC-CF99-4AF7-B2D3-AD0F791A79DD</td>
-          </tr>
-        </tbody>
-      </table> -->
-
-      <ul class="mt-4">
-        <li><span class="bg-warning">INFORMATION</span>: shows device
-          information [
-          <a href="./examples/INFORMATION" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/INFORMATION" target="_blank">source</a>
-          ]
-        </li>
-        <li><span class="bg-warning">LIGHT</span>: Controls
-          LEDs on ORPHE CORE.
-          [
-          <a href="./examples/LIGHT/" target="_blank">DEMO
-          </a>
-          ]
-          [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/LIGHT" target="_blank">source</a>
-          ]
-        </li>
-
-        <li><span class="bg-warning">VIEW</span>: viewer for step analysis/sensor values [
-          <a href="./examples/VIEW" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VIEW" target="_blank">source</a>
-          ]
-        </li>
-
-        <li><span class="bg-warning">VISUALIZE</span>: Plot viewer for step analysis/sensor values [
-          <a href="./examples/VISUALIZE" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VISUALIZE" target="_blank">source</a>
-          ]
-        </li>
-
-        <li><span class="bg-warning">FOOT ANGLE</span>: Explanation page for acquiring landing angles [
-          <a href="./examples/FOOT ANGLE" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/FOOT ANGLE" target="_blank">source</a>
-          ]
-        </li>
-
-        <li><span class="bg-warning">PRONATION</span>: Explanatory page on acquiring pronation Angel [
-          <a href="./examples/PRONATION" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/PRONATION" target="_blank">source</a>
-          ]
-        </li>
-
-        <li><span class="bg-warning">AIR WALKER</span>: a workout dashboard for an air walker [
-          <a href="./examples/AIRWALKER" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/AIRWALKER" target="_blank">source</a>
-          ]
-        </li>
-        <li><span class="bg-warning">POSE</span>: a MediaPipe Pose with ORPHE CORE [
-          <a href="./examples/POSE" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/POSE" target="_blank">source</a>
-          ]
-        </li>
-        <li><span class="bg-warning">OH1</span>: OH1 Heart Rate with ORPHE CORE [
-          <a href="./examples/OH1" target="_blank">
-            DEMO</a>
-          ][
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/OH1" target="_blank">source</a>
-          ]
-        </li>
-        <li><span class="bg-warning">FOOT ANGLE</span>: Visualization and sonification of foot angle data
-          [
-          <a href="https://editor.p5js.org/tetsuakibaba/sketches/ozss3px1G" target="_blank">p5.js</a>
-          ]
-        </li>
-        <li>
-          <span class="bg-warning">CORETOOLKIT STARTER</span>: template of starting with CoreToolkit.js which makes
-          coding faster!!
-          [ <a href="./examples/CORETOOLKIT-STARTER/" target="_blank">DEMO</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/5nV83PG1A" target="_blank">p5.js</a> ]
-        </li>
-        <li>
-          <span class="bg-warning">SENSOR CALIBRATION</span>: Record sensor data for gesture recognition and AI training
-          [ <a href="./examples/SENSOR-CALIBRATION/" target="_blank">DEMO</a> ]
-          [ <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/SENSOR-CALIBRATION" target="_blank">source</a> ]
-        </li>
-        <li>
-          <span class="bg-success">GESTURE DEMO</span>: Real-time gesture detection (toe tap, heel tap, stomp) with sound feedback
-          [ <a href="./examples/GESTURE-DEMO/" target="_blank">DEMO</a> ]
-          [ <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">source</a> ]
-        </li>
-      </ul>
-
+    <h3 id="examples" class="mt-4"><i class="bi bi-code"></i> Application Examples</h3>
+    <section class="ms-4 dx-example-section">
+      <p class="lang en">Use these examples to inspect the device, control LEDs, visualize sensor and gait data, and connect ORPHE CORE with other web APIs.</p>
+      <p class="lang ja active">デバイス情報、LED制御、センサー値や歩容データの可視化、外部API連携など、アプリ開発の起点になるExampleです。</p>
+      <div class="dx-mini-link-grid">
+        <a class="dx-mini-link lang en" href="./examples/" target="_blank">Browse all examples</a>
+        <a class="dx-mini-link lang ja active" href="./examples/" target="_blank">すべてのExampleを見る</a>
+      </div>
+      <div class="dx-example-card-grid">
+        <article class="dx-example-card">
+          <img src="./examples/INFORMATION/teaser.gif" alt="Device Information">
+          <div class="dx-example-card-body">
+            <h4>INFORMATION</h4>
+            <p class="lang en">Read ORPHE CORE device information before building an app.</p>
+            <p class="lang ja active">アプリを作る前に、ORPHE COREのデバイス情報を確認します。</p>
+            <div class="dx-example-tags"><span>Device</span><span>Setup</span></div>
+            <div class="dx-example-links"><a href="./examples/INFORMATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/INFORMATION" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/LIGHT/teaser.gif" alt="LED Control">
+          <div class="dx-example-card-body">
+            <h4>LIGHT</h4>
+            <p class="lang en">Connect to ORPHE CORE and control the full-color LED.</p>
+            <p class="lang ja active">ORPHE COREに接続して、フルカラーLEDを制御します。</p>
+            <div class="dx-example-tags"><span>LED</span><span>Beginner</span></div>
+            <div class="dx-example-links"><a href="./examples/LIGHT/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/LIGHT" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/VIEW/data-viewer.gif" alt="Data Viewer">
+          <div class="dx-example-card-body">
+            <h4>VIEW</h4>
+            <p class="lang en">Inspect sensor and gait values in a browser UI.</p>
+            <p class="lang ja active">センサー値と歩容解析の値をブラウザ上で確認します。</p>
+            <div class="dx-example-tags"><span>Viewer</span><span>Gait</span></div>
+            <div class="dx-example-links"><a href="./examples/VIEW/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VIEW" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/visualize.png" alt="Sensor Values Visualizer">
+          <div class="dx-example-card-body">
+            <h4>VISUALIZE</h4>
+            <p class="lang en">Visualize SENSOR_VALUES in a simple browser interface.</p>
+            <p class="lang ja active">SENSOR_VALUESをシンプルな画面で可視化します。</p>
+            <div class="dx-example-tags"><span>Sensor</span><span>Chart</span></div>
+            <div class="dx-example-links"><a href="./examples/VISUALIZE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VISUALIZE" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/foot-angle.png" alt="Foot Angle">
+          <div class="dx-example-card-body">
+            <h4>FOOT ANGLE</h4>
+            <p class="lang en">Visualize landing and foot-angle data from ORPHE gait analysis.</p>
+            <p class="lang ja active">歩容解析から得られる接地角や足角度を可視化します。</p>
+            <div class="dx-example-tags"><span>Gait</span><span>Foot angle</span></div>
+            <div class="dx-example-links"><a href="./examples/FOOT%20ANGLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/FOOT%20ANGLE" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/ozss3px1G" target="_blank">p5.js</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/pronation.png" alt="Pronation">
+          <div class="dx-example-card-body">
+            <h4>PRONATION</h4>
+            <p class="lang en">Visualize pronation and landing-related gait data.</p>
+            <p class="lang ja active">プロネーションや着地に関わる歩容データを可視化します。</p>
+            <div class="dx-example-tags"><span>Gait</span><span>Pronation</span></div>
+            <div class="dx-example-links"><a href="./examples/PRONATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/PRONATION" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/airwalker.png" alt="Air Walker">
+          <div class="dx-example-card-body">
+            <h4>AIR WALKER</h4>
+            <p class="lang en">Show steps, motion, and activity in a workout dashboard.</p>
+            <p class="lang ja active">歩数、動き、アクティビティをダッシュボードで表示します。</p>
+            <div class="dx-example-tags"><span>Dashboard</span><span>Activity</span></div>
+            <div class="dx-example-links"><a href="./examples/AIRWALKER/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/AIRWALKER" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/pose.png" alt="Pose with ORPHE CORE">
+          <div class="dx-example-card-body">
+            <h4>POSE</h4>
+            <p class="lang en">Combine MediaPipe Pose with ORPHE CORE sensor data.</p>
+            <p class="lang ja active">MediaPipe PoseとORPHE COREのセンサーデータを組み合わせます。</p>
+            <div class="dx-example-tags"><span>Pose</span><span>Creative</span></div>
+            <div class="dx-example-links"><a href="./examples/POSE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/POSE" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/oh1.png" alt="OH1 Heart Rate">
+          <div class="dx-example-card-body">
+            <h4>OH1</h4>
+            <p class="lang en">Connect OH1 heart rate data with ORPHE CORE motion data.</p>
+            <p class="lang ja active">OH1の心拍データとORPHE COREのモーションデータを連携します。</p>
+            <div class="dx-example-tags"><span>BLE</span><span>Heart rate</span></div>
+            <div class="dx-example-links"><a href="./examples/OH1/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/OH1" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/coretoolkit-starter.png" alt="CoreToolkit Starter">
+          <div class="dx-example-card-body">
+            <h4>CORETOOLKIT STARTER</h4>
+            <p class="lang en">Start faster with CoreToolkit.js connection UI and sensor monitor.</p>
+            <p class="lang ja active">CoreToolkit.jsの接続UIとセンサーモニターからすばやく始めます。</p>
+            <div class="dx-example-tags"><span>CoreToolkit</span><span>UI</span></div>
+            <div class="dx-example-links"><a href="./examples/CORETOOLKIT-STARTER/" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/5nV83PG1A" target="_blank">p5.js</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/sensor-calibration.png" alt="Sensor Calibration">
+          <div class="dx-example-card-body">
+            <h4>SENSOR CALIBRATION</h4>
+            <p class="lang en">Record sensor data for gesture recognition and AI training.</p>
+            <p class="lang ja active">ジェスチャー認識やAI学習用にセンサーデータを記録します。</p>
+            <div class="dx-example-tags"><span>Recording</span><span>AI</span></div>
+            <div class="dx-example-links"><a href="./examples/SENSOR-CALIBRATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/SENSOR-CALIBRATION" target="_blank">Source</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/gesture-demo.png" alt="Gesture Demo">
+          <div class="dx-example-card-body">
+            <h4>GESTURE DEMO</h4>
+            <p class="lang en">Detect toe tap, heel tap, and stomp gestures in real time.</p>
+            <p class="lang ja active">つま先タップ、かかとタップ、踏み込みをリアルタイムに検出します。</p>
+            <div class="dx-example-tags"><span>Gesture</span><span>Sound</span></div>
+            <div class="dx-example-links"><a href="./examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
+          </div>
+        </article>
+      </div>
     </section>
 
-    <h3 id="starter-templates" class="mt-4"><i class="bi bi-star"></i> Starter Templates </h3>
-    <section class="ms-4">
-      <p class="lang en">
-        If you want to create your own application using ORPHE-CORE, it is useful to start from a simpler example. In
-        this section, as Starter Templates, we provide very simple working examples without css. All starter templates
-        are located under the
-        /ORPHE-CORE.js/starter-templates/ directory.
-      </p>
-      <p class="lang ja active">
-        ORPHE-COREを使って独自のアプリケーションを作成したい場合は、よりシンプルな例があると良いでしょう。このセクションでは、Starter
-        Templatesとして、非常にシンプルな動作する例を提供します。すべてのスターターテンプレートは/ORPHE-CORE.js/starter-templates/ディレクトリにあります。
-      </p>
-      <ul>
-        <li><span class="bg-warning">TWO COREs</span>: template of connecting two core modules
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/XHZ2lHQtN" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">QUATERNION</span>: {w, x,y,z}
-          [ <a href="./starter-templates/QUATERNION.html" target="_blank">DEMO</a> ] [ <a
-            href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/QUATERNION.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/4modSEX2J" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">EULER</span>: {pitch,roll,yaw}
-          [ <a href="./starter-templates/EULER.html" target="_blank">DEMO</a> ] [ <a
-            href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/EULER.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/WiTZ23rw2" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">ACCELEROMETER</span>: {x,y,z} [ <a href="./starter-templates/ACCELEROMETER.html"
-            target="_blank">DEMO</a> ] [ <a
-            href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/ACCELEROMETER.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/WqUWEul5N" target="_blank">p5.js</a> ]
-        </li>
-        </li>
-        <li><span class="bg-warning">GYRO</span>: {x,y,z}[
-          <a href="./starter-templates/GYRO.html" target="_blank">DEMO</a> ] [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/GYRO.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/LvUXsj0WT" target="_blank">p5.js</a> ]
-        </li>
-        </li>
-        <li><span class="bg-warning">STEPS</span>: {value} number of steps [
-          <a href="./starter-templates/STEPS.html" target="_blank">DEMO</a> ] [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STEPS.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/fTR9Jj0kC" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">GAIT/DURATION</span>: {value} gait type, deirection, distance, standing and swing
-          phase duraion
-          [ <a href="https://editor.p5js.org/kikukawayuya/sketches/uu_YYhowG" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">STRIDE</span>: {x,y,z}
-          [
-          <a href="./starter-templates/STRIDE.html" target="_blank">DEMO</a> ] [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STRIDE.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/PbW-apAGP" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">PRONATION</span>: {x,y,z}
-          [
-          <a href="./starter-templates/PRONATION.html" target="_blank">DEMO</a> ] [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/PRONATION.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/FAw49ZU7g" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">LIGHT</span>
-          [
-          <a href="./starter-templates/LIGHT.html" target="_blank">DEMO</a> ] [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/LIGHT.html"
-            target="_blank">Source</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/X7O5PU87S" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">STEP_ANALYSIS and SENSOR_VALUES</span>: template of starting 'STEP_ANALYSIS_AND_SENSOR_VALUES' notify.
-          [ <a href="./starter-templates/ANALYSIS_AND_RAW.html" target="_blank">DEMO</a> ]
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/1mNA7vd1g" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">ALL GAIT INFORMATION</span>: {value} gait, stride, pronation etc..
-          [ <a href="https://editor.p5js.org/kikukawayuya/sketches/boqkxL47u" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">ALL GAIT AND SPEED</span>: {value} Calculate duration, cadence, pace, and speed
-          from gait and stride
-          [ <a href="https://editor.p5js.org/kikukawayuya/sketches/boqkxL47u" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">GAIT AND RECORD</span>: {value} record gait data and make json file
-          [ <a href="https://editor.p5js.org/kikukawayuya/sketches/D-NbsGfcE" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">ALL SENSOR VALUES AND GAIT DATA</span>: {value} realtime sensor values and gait analysis
-          [ <a href="https://editor.p5js.org/kikukawayuya/sketches/boqkxL47u" target="_blank">p5.js</a> ]
-        </li>
-
-      </ul>
+    <h3 id="starter-templates" class="mt-4"><i class="bi bi-star"></i> Starter Templates</h3>
+    <section class="ms-4 dx-example-section">
+      <p class="lang en">Starter Templates are small working examples for learning one data type or one notification mode at a time.</p>
+      <p class="lang ja active">Starter Templatesは、1つのデータ型や通知モードを小さく試すための最小サンプルです。</p>
+      <div class="dx-example-card-grid">
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-light.png" alt="LED Starter">
+          <div class="dx-example-card-body"><h4>LIGHT</h4><p>LED control.</p><div class="dx-example-tags"><span>LED</span></div><div class="dx-example-links"><a href="./starter-templates/LIGHT.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/LIGHT.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/X7O5PU87S" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-accelerometer.png" alt="Accelerometer Starter">
+          <div class="dx-example-card-body"><h4>ACCELEROMETER</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Acc</span></div><div class="dx-example-links"><a href="./starter-templates/ACCELEROMETER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/ACCELEROMETER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WqUWEul5N" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-gyro.png" alt="Gyro Starter">
+          <div class="dx-example-card-body"><h4>GYRO</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Gyro</span></div><div class="dx-example-links"><a href="./starter-templates/GYRO.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/GYRO.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/LvUXsj0WT" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-quaternion.png" alt="Quaternion Starter">
+          <div class="dx-example-card-body"><h4>QUATERNION</h4><p>{w, x, y, z}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="./starter-templates/QUATERNION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/QUATERNION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/4modSEX2J" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-euler.png" alt="Euler Starter">
+          <div class="dx-example-card-body"><h4>EULER</h4><p>{pitch, roll, yaw}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="./starter-templates/EULER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/EULER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WiTZ23rw2" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-steps.png" alt="Steps Starter">
+          <div class="dx-example-card-body"><h4>STEPS</h4><p>Number of steps.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/STEPS.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STEPS.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/fTR9Jj0kC" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-stride.png" alt="Stride Starter">
+          <div class="dx-example-card-body"><h4>STRIDE</h4><p>Stride data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/STRIDE.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STRIDE.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/PbW-apAGP" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-pronation.png" alt="Pronation Starter">
+          <div class="dx-example-card-body"><h4>PRONATION</h4><p>Pronation data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/PRONATION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/PRONATION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/FAw49ZU7g" target="_blank">p5.js</a></div></div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/starter-analysis-and-sensor-values.png" alt="Step Analysis and Sensor Values">
+          <div class="dx-example-card-body"><h4>STEP_ANALYSIS + SENSOR_VALUES</h4><p class="lang en">Start STEP_ANALYSIS_AND_SENSOR_VALUES notify.</p><p class="lang ja active">解析値と生センサー値を同時に受け取ります。</p><div class="dx-example-tags"><span>Gait</span><span>Sensor</span></div><div class="dx-example-links"><a href="./starter-templates/ANALYSIS_AND_RAW.html" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/1mNA7vd1g" target="_blank">p5.js</a></div></div>
+        </article>
+      </div>
+      <h4 class="dx-example-subhead">p5.js Recipes</h4>
+      <div class="dx-mini-link-grid">
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/XHZ2lHQtN" target="_blank">TWO COREs</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/kikukawayuya/sketches/uu_YYhowG" target="_blank">GAIT / DURATION</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/kikukawayuya/sketches/boqkxL47u" target="_blank">ALL GAIT INFORMATION</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/kikukawayuya/sketches/boqkxL47u" target="_blank">ALL GAIT AND SPEED</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/kikukawayuya/sketches/D-NbsGfcE" target="_blank">GAIT AND RECORD</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/kikukawayuya/sketches/boqkxL47u" target="_blank">SENSOR VALUES + GAIT DATA</a>
+      </div>
     </section>
-
 
     <h3 id="creative-examples" class="mt-4"><i class="bi bi-stars"></i> Creative Examples</h3>
-    <section class="ms-4">
-      <p class="lang en">
-        Are you a creative coder? If so or not, why don't you try the creative examples. Graphics, Sounds makes your
-        ORPHE-CORE
-        colorful and playful!!
-      </p>
-      <p class="lang ja active">
-        クリエイティブコーダーですか？そうでない場合でも、遊び心のある例を試してみませんか。グラフィック、サウンドがあなたのORPHE-COREをカラフルで遊び心のあるものにします！
-      </p>
-
-      <ul>
-        <li><span class="bg-warning">UDON</span>: うどんふみふみゲーム！Step on the ORPHE CORE and stretch the udon out thinly!
-          [ <a href="https://orphe-oss.github.io/ORPHE-CORE.js/examples/GAME-UDON/" target="_blank">DEMO</a> ]
-          [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-UDON" target="_blank">Source</a> ]
-        </li>
-        <li><span class="bg-warning">MOVEYOURFEET</span>: 足バタバタゲーム⭐︎ Move your feet and exercise!
-          [ <a href="https://orphe-oss.github.io/ORPHE-CORE.js/examples/MOVEYOURFEET/" target="_blank">DEMO</a> ]
-          [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/MOVEYOURFEET"
-            target="_blank">Source</a> ]
-        </li>
-
-        <li><span class="bg-warning">PINGPONGGAME</span>: ピンポンゲーム This is a 3-point ping pong game using ORPHE CORE!
-          [ <a href="https://orphe-oss.github.io/ORPHE-CORE.js/examples/GAME-PINGPONG/" target="_blank">DEMO</a> ]
-          [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-PINGPONG"
-            target="_blank">Source</a> ]
-        </li>
-
-        <li><span class="bg-warning">ORPHE CORE Gesture Drum</span>: ジェスチャードラム This is a DRUM SAMPLER using ORPHE CORE!
-          [ <a href="https://orphe-oss.github.io/ORPHE-CORE.js/examples/drum_test/" target="_blank">DEMO</a> ]
-          [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/drum_test" target="_blank">Source</a> ]
-        </li>
-
-        <li><span class="bg-warning">ORPHE 110m hurdles game</span>: 世界バーチャルハードル走　110m
-          [ <a href="https://orphe-oss.github.io/ORPHE-CORE.js/examples/GAME-HURDLE/index.html" target="_blank">DEMO</a> ]
-          [
-          <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-HURDLE/index.html" target="_blank">Source</a> ]
-        </li>
-
-
-        <li><span class="bg-warning">3DBOX</span>: Control a 3D box with ORPHE CORE Module
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/waUWo6ZZN" target="_blank">p5.js</a> ]
-        </li>
-        <li><span class="bg-warning">ORPHEMIN</span>: a theremin like musical instrument with ORPHE CORE Module
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/PE438XURD" target="_blank">p5.js</a> ]
-        </li>
-        <li>
-          <span class="bg-warning">ZANGEKI</span>: slashing sword sound effects with ORPHE CORE Module
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/QiE0E88Gc" target="_blank">p5.js</a> ]
-        </li>
-        <li>
-          <span class="bg-warning">ORPHE SHOOTING</span>: Let's make a simple shooting game and operate it with ORPHE!
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/QUzPJzpVO" target="_blank">p5.js</a> ]
-        </li>
-      </ul>
+    <section class="ms-4 dx-example-section">
+      <p class="lang en">Play with graphics, sounds, and physical game mechanics using ORPHE CORE as an input device.</p>
+      <p class="lang ja active">ORPHE COREを入力デバイスとして使い、グラフィック、サウンド、身体動作のゲームを作るExampleです。</p>
+      <div class="dx-example-card-grid">
+        <article class="dx-example-card"><img src="./examples/_thumbnails/udon.png" alt="Udon game"><div class="dx-example-card-body"><h4>UDON</h4><p>足踏みでうどんをこねるゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-UDON/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-UDON" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="./examples/_thumbnails/move-your-feet.png" alt="Move your feet"><div class="dx-example-card-body"><h4>MOVEYOURFEET</h4><p>足を動かして遊ぶエクササイズ系ゲーム。</p><div class="dx-example-links"><a href="./examples/MOVEYOURFEET/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/MOVEYOURFEET" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="./examples/_thumbnails/pingpong.png" alt="Ping pong game"><div class="dx-example-card-body"><h4>PINGPONG GAME</h4><p>2人で遊べるシンプルな対戦ゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-PINGPONG/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-PINGPONG" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="./examples/_thumbnails/drum.png" alt="Drum game"><div class="dx-example-card-body"><h4>ORPHE CORE Gesture Drum</h4><p>ジェスチャーで音を鳴らすドラムサンプラー。</p><div class="dx-example-links"><a href="./examples/drum_test/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/drum_test" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="./examples/_thumbnails/hurdle-110m.png" alt="110m hurdles"><div class="dx-example-card-body"><h4>110m Hurdles</h4><p>世界バーチャルハードル走 110m。</p><div class="dx-example-links"><a href="./examples/GAME-HURDLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-HURDLE" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="./examples/_thumbnails/boxing.png" alt="Boxing game"><div class="dx-example-card-body"><h4>BOXING GAME</h4><p>パンチ動作を使ったアクションゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-BOXING/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-BOXING" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="./examples/_thumbnails/ddr.png" alt="DDR game"><div class="dx-example-card-body"><h4>DDR GAME</h4><p>音楽と足の動きを組み合わせたリズムゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-DDR/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-DDR" target="_blank">Source</a></div></div></article>
+      </div>
+      <h4 class="dx-example-subhead">p5.js Sketches</h4>
+      <div class="dx-mini-link-grid">
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/waUWo6ZZN" target="_blank">3DBOX</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/PE438XURD" target="_blank">ORPHEMIN</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/QiE0E88Gc" target="_blank">ZANGEKI</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/QUzPJzpVO" target="_blank">ORPHE SHOOTING</a>
+      </div>
     </section>
 
-
     <h3 id="motion-intelligence" class="mt-4"><i class="bi bi-wrench-adjustable-circle"></i> Technical Examples</h3>
-    <section class="ms-4">
-      <p class="lang en">
-        Are you interested in gesture recognition, frequency analysis, or something more engineering and difficult? Then
-        give it a try.
-      </p>
-      <p class="lang ja active">
-        ジェスチャー認識、周波数解析、またはよりエンジニアリング的で難しいものに興味がありますか？それでは、試してみてください。
-      </p>
-      <ul>
-        <li>
-          <span class="bg-warning">FFT</span>: X-axis motion FFT
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/kfH-VPqK5" target="_blank">p5.js</a> ]
-        </li>
-        <li>
-          <span class="bg-warning">PLOT</span>: visualize your ORPHE CORE sensor values with
-          Chart.js
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/3kT0WfHu7" target="_blank">p5.js</a> ]
-        </li>
-        <li>
-          <span class="bg-warning">RMS</span>: recognizes swipe gesture using the RMS (Root Mean Square) method with
-          ORPHE CORE module.
-          [ <a href="https://editor.p5js.org/kikukawayuya/sketches/tOlve54S2" target="_blank">p5.js</a> ]
-        </li>
-        <li>
-          <span class="bg-warning">DTW</span>: recognizes swipe gesture using DTW (Dynamic time warping) method with
-          ORPHE CORE module.
-          [ <a href="https://editor.p5js.org/tetsuakibaba/sketches/4RFO2smtC" target="_blank">p5.js</a> ]
-        </li>
-      </ul>
+    <section class="ms-4 dx-example-section">
+      <p class="lang en">Examples for gesture recognition, time-series matching, frequency analysis, and data plotting.</p>
+      <p class="lang ja active">ジェスチャー認識、時系列マッチング、周波数解析、データ可視化を試すためのExampleです。</p>
+      <div class="dx-example-card-grid">
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/dtw.png" alt="DTW Example">
+          <div class="dx-example-card-body">
+            <h4>DTW</h4>
+            <p class="lang en">Try Dynamic Time Warping with ORPHE CORE motion data.</p>
+            <p class="lang ja active">ORPHE COREのモーションデータでDynamic Time Warpingを試します。</p>
+            <div class="dx-example-tags"><span>Analysis</span><span>Time series</span></div>
+            <div class="dx-example-links"><a href="./examples/DTW/" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/4RFO2smtC" target="_blank">p5.js</a></div>
+          </div>
+        </article>
+        <article class="dx-example-card">
+          <img src="./examples/_thumbnails/gesture-demo.png" alt="Gesture recognition">
+          <div class="dx-example-card-body">
+            <h4>GESTURE DEMO</h4>
+            <p class="lang en">A practical starting point for real-time gesture detection.</p>
+            <p class="lang ja active">リアルタイムのジェスチャー検出を試す実用的な起点です。</p>
+            <div class="dx-example-tags"><span>Gesture</span><span>Detection</span></div>
+            <div class="dx-example-links"><a href="./examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
+          </div>
+        </article>
+      </div>
+      <h4 class="dx-example-subhead">p5.js Analysis Sketches</h4>
+      <div class="dx-mini-link-grid">
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/kfH-VPqK5" target="_blank">FFT</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/3kT0WfHu7" target="_blank">PLOT</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/kikukawayuya/sketches/tOlve54S2" target="_blank">RMS</a>
+        <a class="dx-mini-link" href="https://editor.p5js.org/tetsuakibaba/sketches/4RFO2smtC" target="_blank">DTW</a>
+      </div>
     </section>
 
 


### PR DESCRIPTION
## Summary
- Application Examples / Starter Templates / Creative Examples / Technical Examples をサムネイル付きカード表示に整理
- 補助的な p5.js リンクは小さなリンクグリッドに分離
- すべてのExampleを見る導線を追加
- カード表示用CSSを追加

## Validation
- git diff --check
- node scripts/check-examples-catalog.js
- index.html: 200 OK
- examples/_thumbnails/ddr.png: 200 OK
- examples/FOOT%20ANGLE/: 200 OK
- local image refs in index.html: 40 refs, missing 0