### PR TITLE
index掲載ExampleのREADME案内を整理

### DIFF
--- a/examples/GAME-BOXING/README.md
+++ b/examples/GAME-BOXING/README.md
@@ -7,9 +7,10 @@ ORPHE CORE モジュールを使ったリアルタイム・ボクシング音ゲ
 
 ## 🎮 デモ
 
-GitHub Pages でプレイ可能（予定）:
-```
-https://[your-username].github.io/orphe-fight-core/
+GitHub Pages でプレイできます:
+
+```text
+https://orphe-oss.github.io/ORPHE-CORE.js/examples/GAME-BOXING/
 ```
 
 ## ✨ 特徴
@@ -47,7 +48,7 @@ npx http-server -p 8000
 php -S localhost:8000
 ```
 
-ブラウザで `http://localhost:8000` にアクセス。
+ブラウザで `http://localhost:8000/examples/GAME-BOXING/` にアクセス。
 
 > **注意**: Web Bluetooth API は Chrome/Edge のみ対応。Firefox/Safari は未対応です。
 

--- a/examples/VIEW/README.md
+++ b/examples/VIEW/README.md
@@ -1,14 +1,46 @@
-# Data Viewer
-<img src="./data-viewer.gif">
+# Sensor Viewer
 
-## Overview
-Simple viewer application for Step Analysis and Sensor Values by BLE ORPHE Core Module.
+`VIEW` is a browser-based table viewer for ORPHE CORE sensor and gait values.
+It is useful when you want to inspect values directly rather than plot them.
 
-## Known issues
-  * CGが両方のとも右用
-  * 5分くらいつないでから一回disconnectしても一回つなごうとするとエラーになっちゃう（Uncaught (in promise) DOMException: Failed to execute 'startNotifications' on 'BluetoothRemoteGATTCharacteristic': GATT Server is disconnected. Cannot perform GATT operations. (Re)connect first with `device.gatt.connect`. at http://127.0.0.1:5501/assets/js/orphe.js:208:31）
-  * 最初に右側をつなげようとするとエラー。必ず左側からお願いします。
+## What this example shows
 
-## モジュール対応
-  * CR-2
-  * CR-3
+- Connect up to two ORPHE CORE modules.
+- Switch each device between `STEP_ANALYSIS` and `SENSOR_VALUES`.
+- Inspect quaternion, gyro, accelerometer, gait, stride, foot angle, pronation,
+  and landing impact values.
+- Reset motion sensor attitude after connection.
+
+## Required devices
+
+- 1 ORPHE CORE is enough to test one side of the viewer.
+- 2 ORPHE CORE modules can be connected for left/right comparison.
+
+## How to run
+
+Open the demo from a local server or GitHub Pages:
+
+```text
+examples/VIEW/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome. Select the notify type
+for each device, then use the switch beside the selector to connect.
+
+## Data
+
+- Notify types: `STEP_ANALYSIS` or `SENSOR_VALUES`
+- Main callbacks: quaternion, gyro, accelerometer, gait, stride, foot angle,
+  pronation, landing impact
+
+## Known validation items
+
+- Confirm whether either side can be connected first, or whether device 01 must
+  be connected before device 02.
+- Confirm disconnect/reconnect behavior after several minutes of notification.
+- Confirm the 3D shoe orientation matches left/right expectations.
+
+## Validation status
+
+Static page/link checks only. BLE connection and reconnect behavior still need
+real-device validation.

--- a/examples/VISUALIZE/README.md
+++ b/examples/VISUALIZE/README.md
@@ -1,5 +1,38 @@
-# RAW DATA Visualizer
+# Sensor Visualize (Chart.js)
 
-## モジュール対応
-  * CR-2
-  * CR-3
+`VISUALIZE` plots ORPHE CORE `SENSOR_VALUES` in the browser with Chart.js.
+It is useful when you want to quickly see accelerometer, gyro, quaternion, and
+Euler values as time-series charts.
+
+## What this example shows
+
+- Connect ORPHE CORE modules from the browser.
+- Receive `SENSOR_VALUES`.
+- Plot accelerometer, gyro, quaternion, and Euler streams.
+- Compare device 01 and device 02 side by side.
+
+## Required devices
+
+- 1 ORPHE CORE is enough to test the left-side charts.
+- 2 ORPHE CORE modules can be connected to compare both sides.
+
+## How to run
+
+Open the demo from a local server or GitHub Pages:
+
+```text
+examples/VISUALIZE/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome. Select the connect
+switch for device 01 first, then device 02 if needed.
+
+## Data
+
+- Notify type: `SENSOR_VALUES`
+- Main callbacks: accelerometer, gyro, quaternion, Euler
+
+## Validation status
+
+Static page/link checks only. BLE connection and chart updates still need
+real-device validation after any connection UI changes.

--- a/starter-templates/README.md
+++ b/starter-templates/README.md
@@ -1,0 +1,34 @@
+# Starter Templates
+
+The files in this directory are intentionally small raw API examples.
+They show the direct ORPHE-CORE.js flow without CoreToolkit:
+
+```js
+const ble = new Orphe(0);
+ble.setup();
+await ble.begin("SENSOR_VALUES");
+```
+
+Use these templates when you want to learn one data stream or one notification
+mode at a time.
+
+## Templates
+
+| File | Notify type | Purpose |
+| --- | --- | --- |
+| `LIGHT.html` | `STEP_ANALYSIS` | Connect and control the LED. |
+| `ACCELEROMETER.html` | `SENSOR_VALUES` | Read accelerometer values. |
+| `GYRO.html` | `SENSOR_VALUES` | Read gyro values. |
+| `QUATERNION.html` | `SENSOR_VALUES` | Read orientation as quaternion. |
+| `EULER.html` | `SENSOR_VALUES` | Read orientation as pitch, roll, yaw. |
+| `STEPS.html` | `STEP_ANALYSIS` | Read step count. |
+| `STRIDE.html` | `STEP_ANALYSIS` | Read stride values. |
+| `PRONATION.html` | `STEP_ANALYSIS` | Read pronation values. |
+| `ANALYSIS_AND_RAW.html` | `STEP_ANALYSIS_AND_SENSOR_VALUES` | Receive gait analysis and sensor values together. |
+
+## CoreToolkit policy
+
+Do not convert these files to CoreToolkit by default. Their role is to teach the
+minimal API. Use `examples/CORETOOLKIT-STARTER/` when you want a connection UI
+and sensor monitor.
+


### PR DESCRIPTION
## Summary
- VISUALIZE README を RAW 表記から SENSOR_VALUES / Chart.js の説明に更新
- VIEW README の古い既知課題表現を、実機確認項目として整理
- Starter Templates のディレクトリREADMEを追加し、raw API教材としての位置づけを明記
- GAME-BOXING README のデモURLとローカル起動パスをこのリポジトリ向けに修正

## Validation
- git diff --check
- node scripts/check-examples-catalog.js
- local target files exist: VIEW / VISUALIZE / GAME-BOXING / CORETOOLKIT-STARTER

## Assumptions
- READMEのみの変更で、HTML/JSの挙動は変更していません
- Starter Templates はCoreToolkit化せず、raw API教材として維持する方針です

## Needs real-device validation
- VIEW reconnect behavior
- VISUALIZE chart updates after future connection UI changes
- GAME-BOXING gameplay and calibration flow

## Out of scope
- BLE接続ロジック変更
- CoreToolkit PoC実装
- index.htmlへの新規Example追加

## Next PR candidates
- CORE_TIME_SYNC README/title整備
- GAME-SHOOTING README/play instructions
- VISUALIZE CoreToolkit PoC