### PR TITLE
CORE_TIME_SYNCの説明とREADMEを追加

### DIFF
--- a/examples/CORE_TIME_SYNC/README.md
+++ b/examples/CORE_TIME_SYNC/README.md
@@ -1,0 +1,36 @@
+# Core Time Sync
+
+`CORE_TIME_SYNC` is a small debugging example for reading and adjusting ORPHE
+CORE device time.
+
+## What this example shows
+
+- Connect one ORPHE CORE module.
+- Start `SENSOR_VALUES` notification to confirm the device is connected.
+- Read the device `DATE_TIME` characteristic.
+- Run `syncCoreTime()` and display round-trip timing information.
+
+## Required devices
+
+- 1 ORPHE CORE
+
+## How to run
+
+Open the demo from a local server or GitHub Pages:
+
+```text
+examples/CORE_TIME_SYNC/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome.
+
+## Data / API
+
+- Notify type: `SENSOR_VALUES`
+- Main APIs: `getDateTime()`, `syncCoreTime()`
+
+## Validation status
+
+Static page/link checks only. DateTime read/write behavior must be validated
+with a real ORPHE CORE before this is promoted to the landing page.
+

--- a/examples/CORE_TIME_SYNC/index.html
+++ b/examples/CORE_TIME_SYNC/index.html
@@ -8,7 +8,8 @@
 </head>
 
 <body>
-    <h1>Adjust Core Time</h1>
+    <h1>Core Time Sync</h1>
+    <p>ORPHE COREのDateTimeを読み取り、PC時刻を基準に時刻補正を試すためのデバッグ用Exampleです。</p>
     <button onclick="activateNotify();">通知を有効化</button> COREから加速度センサの値を取得します<br>
     <p>結果:<br> <span id="acc"></span></p>
     <hr>


### PR DESCRIPTION
## Summary
- CORE_TIME_SYNC にREADMEを追加
- ページ見出しを Core Time Sync に整理
- DateTime取得 / syncCoreTime の用途、必要台数、起動方法、実機確認要否を明記

## Validation
- git diff --check
- node scripts/check-examples-catalog.js
- examples/CORE_TIME_SYNC/index.html exists
- examples/CORE_TIME_SYNC/README.md exists

## Assumptions
- CORE_TIME_SYNC は未掲載Exampleの昇格候補ですが、このPRでは index.html へ追加しません
- HTML/JSの接続ロジックは変更していません

## Needs real-device validation
- getDateTime() の戻り値表示
- syncCoreTime() のDateTime write動作
- SENSOR_VALUES通知開始

## Out of scope
- CoreToolkit化
- index.html掲載
- DateTimeロジック変更

## Next PR candidates
- GAME-SHOOTING README/play instructions
- GAME-MARIO README/play instructions
- VISUALIZE CoreToolkit PoC