### PR TITLE
CoreToolkitのBLEブラウザガードを共通化

### DIFF
--- a/examples/GAME-SHOOTING2/index.html
+++ b/examples/GAME-SHOOTING2/index.html
@@ -213,20 +213,10 @@
         window.ble = ble;
         ble.setup();
         buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'SENSOR_VALUES');
-        const isEmbeddedBrowser = /Electron|Codex/i.test(navigator.userAgent);
-        const canUseWebBluetooth = window.isSecureContext && navigator.bluetooth && !isEmbeddedBrowser;
-        if (!canUseWebBluetooth) {
-            const switchBle = document.querySelector('#switch_ble0');
-            if (switchBle) {
-                switchBle.checked = false;
-                switchBle.disabled = true;
-                switchBle.title = 'Open this page in Chrome to connect ORPHE CORE.';
-            }
-            const message = document.querySelector('#ble-support-message');
-            if (message) {
-                message.style.display = 'block';
-            }
-        }
+        guardCoreToolkitBluetooth({
+            coreIds: [0],
+            messageElement: '#ble-support-message'
+        });
     </script>
     <script src="../../js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
     <script src="main.js"></script>

--- a/js/CoreToolkit.js
+++ b/js/CoreToolkit.js
@@ -177,6 +177,48 @@ function buildCoreToolkit(parent_element, title, core_id = 0, notification = 'ST
 }
 
 /**
+ * CoreToolkitのBLE接続UIを、Web Bluetoothを使えないブラウザでは無効化する。
+ * Codex/Electron系の埋め込みブラウザではBluetoothダイアログを開かず、
+ * 通常のChromeで開く案内だけを表示したい場合に利用する。
+ * @param {object} options
+ * @param {number[]} options.coreIds - 無効化対象のCore ID
+ * @param {Element|string} options.messageElement - 案内メッセージを表示する要素またはセレクタ
+ * @param {string} options.message - 表示する案内メッセージ
+ * @param {string} options.disabledTitle - 無効化したスイッチのtitle
+ * @returns {boolean} Web Bluetoothを利用できる場合はtrue
+ */
+function guardCoreToolkitBluetooth(options = {}) {
+    const coreIds = options.coreIds || [0, 1];
+    const message = options.message || 'Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.';
+    const disabledTitle = options.disabledTitle || 'Open this page in Chrome to connect ORPHE CORE.';
+    const isEmbeddedBrowser = /Electron|Codex/i.test(navigator.userAgent);
+    const canUseWebBluetooth = window.isSecureContext && !!navigator.bluetooth && !isEmbeddedBrowser;
+
+    if (canUseWebBluetooth) return true;
+
+    coreIds.forEach(function (coreId) {
+        const switchBle = document.querySelector(`#switch_ble${coreId}`);
+        if (!switchBle) return;
+        switchBle.checked = false;
+        switchBle.disabled = true;
+        switchBle.title = disabledTitle;
+    });
+
+    let messageElement = options.messageElement;
+    if (typeof messageElement === 'string') {
+        messageElement = document.querySelector(messageElement);
+    }
+    if (messageElement) {
+        if (!messageElement.textContent.trim()) {
+            messageElement.textContent = message;
+        }
+        messageElement.style.display = 'block';
+    }
+
+    return false;
+}
+
+/**
  * BLE接続のトグルボタンが切り替わったときに呼び出される関数
  * @param {Element} dom 
  * @param {object} options 


### PR DESCRIPTION
## Summary
- CoreToolkit.js に Web Bluetooth 非対応/埋め込みブラウザ向けの guardCoreToolkitBluetooth() を追加
- GAME-SHOOTING2 の個別BLEガード処理を共通関数呼び出しに置き換え
- 今回は他Exampleへ一括適用せず、共通ヘルパー導入だけに限定

## Validation
- node --check js/CoreToolkit.js
- node --check examples/GAME-SHOOTING2/main.js
- git diff --check
- node scripts/check-examples-catalog.js
- http://127.0.0.1:8766/examples/GAME-SHOOTING2/ 200 OK
- Codex内ブラウザで switch_ble0 disabled / Chrome案内表示を確認

## Notes
- 通常Chromeでは navigator.bluetooth がある前提でスイッチを有効のままにします
- 他のCoreToolkit系Exampleへの適用は次PRで個別に進める想定です