### PR TITLE
CoreToolkit BLEブラウザガードを主要Exampleへ適用

### DIFF
--- a/examples/GAME-MARIO/index.html
+++ b/examples/GAME-MARIO/index.html
@@ -14,6 +14,9 @@
       <h1>ORPHE CORE 2D ACTION!</h1>
       
       <div id="toolkit_placeholder1" class="my-4"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
 
   
   <div id="p5Canvas"  ></div> <!-- p5.jsのキャンバスがここに挿入されます -->
@@ -161,8 +164,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/addons/p5.sound.min.js"></script>
 
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"
-  type="text/javascript"></script>
+  <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
   integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
   crossorigin="anonymous"></script>
@@ -172,6 +174,10 @@
     var bles = [new Orphe(0)];
     bles[0].setup();
     buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'SENSOR_VALUES');
+    guardCoreToolkitBluetooth({
+      coreIds: [0],
+      messageElement: '#ble-support-message'
+    });
     var connectedDevices = 0;
     var gamestage = 0;
     var isGameInputReady = false;

--- a/examples/GAME-PINGPONG/index.html
+++ b/examples/GAME-PINGPONG/index.html
@@ -15,6 +15,9 @@
       
       <div id="toolkit_placeholder1" class="my-4"></div>
       <div id="toolkit_placeholder2" class="my-4"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
 
   
   <div id="p5Canvas"  ></div> <!-- p5.jsのキャンバスがここに挿入されます -->
@@ -80,8 +83,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/addons/p5.sound.min.js"></script>
 
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"
-  type="text/javascript"></script>
+  <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
   integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
   crossorigin="anonymous"></script>
@@ -93,6 +95,10 @@
     buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
     bles[1].setup();
     buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({
+      coreIds: [0, 1],
+      messageElement: '#ble-support-message'
+    });
     var connectedDevices = 0;
     var gamestage = 0;
 

--- a/examples/GAME-UDON/index.html
+++ b/examples/GAME-UDON/index.html
@@ -20,6 +20,9 @@
 
         <div id="toolkit_placeholder1" class="my-4"></div>
         <div id="toolkit_placeholder2" class="my-4"></div>
+        <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+            Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+        </div>
 
         <div id="p5Canvas"></div> <!-- p5.jsのキャンバスがここに挿入されます -->
 
@@ -38,8 +41,7 @@
             type="text/javascript"></script>
         <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"
             type="text/javascript"></script>
-        <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"
-            type="text/javascript"></script>
+        <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
             integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
             crossorigin="anonymous"></script>

--- a/examples/GAME-UDON/scripts.js
+++ b/examples/GAME-UDON/scripts.js
@@ -9,6 +9,10 @@ bles[0].setup();
 buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'SENSOR_VALUES');
 bles[1].setup();
 buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'SENSOR_VALUES');
+guardCoreToolkitBluetooth({
+    coreIds: [0, 1],
+    messageElement: '#ble-support-message'
+});
 for (let ble of bles) {
     ble.onConnect = function () {
         connectedDevices++;

--- a/examples/MOVEYOURFEET/index.html
+++ b/examples/MOVEYOURFEET/index.html
@@ -17,6 +17,9 @@
     <h2>Move your feet and exercise!</h2>
     <div id="toolkit_placeholder1" class="my-4"></div>
     <div id="toolkit_placeholder2" class="my-4"></div>
+    <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+    </div>
     <p id="result" class="result-text"></p>
     <p id="connectionStatus" class="status-text"></p>
     <div id="p5Canvas"  ></div> <!-- p5.jsのキャンバスがここに挿入されます -->
@@ -53,8 +56,7 @@
         type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"
         type="text/javascript"></script>
-    <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"
-        type="text/javascript"></script>
+    <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
         integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
         crossorigin="anonymous"></script>

--- a/examples/MOVEYOURFEET/scripts.js
+++ b/examples/MOVEYOURFEET/scripts.js
@@ -18,6 +18,10 @@ bles[0].setup();
 buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'SENSOR_VALUES');
 bles[1].setup();
 buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'SENSOR_VALUES');
+guardCoreToolkitBluetooth({
+    coreIds: [0, 1],
+    messageElement: '#ble-support-message'
+});
 for (let ble of bles) {
     ble.onConnect = function () {
         connectedDevices++;

--- a/examples/SENSOR-CALIBRATION/index.html
+++ b/examples/SENSOR-CALIBRATION/index.html
@@ -348,6 +348,9 @@
       <h1><i class="bi bi-Activity"></i> ORPHE CORE Sensor Calibration Tool</h1>
       <div id="toolkit_placeholder"></div>
     </div>
+    <div id="ble-support-message" class="alert alert-warning mt-3 mb-0" style="display:none;">
+      Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+    </div>
   </div>
 
   <div class="main-container">
@@ -733,6 +736,10 @@
       'STEP_ANALYSIS_AND_SENSOR_VALUES',
       { range: { acc: 16, gyro: 2000 } }
     );
+    guardCoreToolkitBluetooth({
+      coreIds: [0],
+      messageElement: '#ble-support-message'
+    });
   </script>
 
   <script src="recorder.js"></script>


### PR DESCRIPTION
## Summary
- GAME-MARIO / GAME-PINGPONG / MOVEYOURFEET / GAME-UDON / SENSOR-CALIBRATION に guardCoreToolkitBluetooth 呼び出しを追加
- Codex/ElectronなどWeb Bluetoothを使えないブラウザでは接続スイッチを無効化し、Chromeで開く案内を表示
- 触ったゲーム系Exampleでは CoreToolkit.js をローカル参照に変更し、CDNキャッシュに依存しないようにしました
- BLE処理、ゲームロジック、閾値、センサー処理は変更していません

## Validation
- git diff --check
- node scripts/check-examples-catalog.js
- node --check examples/MOVEYOURFEET/scripts.js
- node --check examples/GAME-UDON/scripts.js
- curl -I 200 OK: GAME-MARIO / GAME-PINGPONG / MOVEYOURFEET / GAME-UDON / SENSOR-CALIBRATION
- 静的確認: 各対象に ble-support-message と guardCoreToolkitBluetooth の呼び出しがあることを確認

## Needs manual browser check
- Codex内ブラウザAPIが active pane を取得できない状態だったため、今回は自動ブラウザ視認は未実施です
- 手元では対象URLを開き、Codex/Electron系ブラウザでスイッチ無効化とChrome案内表示を確認してください

## Out of scope
- 通常ChromeでのBLE実機接続確認
- 他のCoreToolkit利用Exampleへの一括適用
- ゲームやセンサー入力の挙動変更