### PR TITLE
残りのCoreToolkit利用ExampleへBLEブラウザガードを適用

### DIFF
--- a/examples/AIRWALKER/index.html
+++ b/examples/AIRWALKER/index.html
@@ -29,6 +29,10 @@
         </div> -->
       </div>
 
+      <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+    Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+  </div>
+
     </nav>
 
     <!-- <div class="col-12 mt-4">

--- a/examples/AIRWALKER/sketch.js
+++ b/examples/AIRWALKER/sketch.js
@@ -292,4 +292,5 @@ window.onload = function () {
   loadHistory();
   loadParameters();
   buildCoreToolkit(document.querySelector('#CoreToolkit_placeholder'), '01', 0, 'SENSOR_VALUES');
+  guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
 }

--- a/examples/CORETOOLKIT-STARTER/index.html
+++ b/examples/CORETOOLKIT-STARTER/index.html
@@ -19,6 +19,10 @@
           <!--<p class="align-bottom">SIMPLE VISUALIZATION SERIES</p>  --> 
           <img src="../../images/orphe.svg" alt="" height="24"></div>
           <!-- 本当はテキストとロゴを右に表示したい and テキストを真ん中揃えしたい -->      
+        <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+    Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+  </div>
+
       </nav>
 
     <div class="row mt-4">

--- a/examples/CORETOOLKIT-STARTER/sketch.js
+++ b/examples/CORETOOLKIT-STARTER/sketch.js
@@ -34,6 +34,7 @@ window.onload = function () {
         '01', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
     buildCoreToolkit(document.querySelector('#toolkit_placeholder'),
         '02', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 
     for (let ble of bles) {
         ble.setup();

--- a/examples/DTW/index.html
+++ b/examples/DTW/index.html
@@ -19,6 +19,9 @@
 <body class="bg-dark">
     <h1>DTW Example</h1>
     <div id='toolkit_placeholder'></div>
+    <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+      Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+    </div>
 
     <p>
         描き方<br>

--- a/examples/DTW/sketch.js
+++ b/examples/DTW/sketch.js
@@ -38,6 +38,7 @@ window.addEventListener('DOMContentLoaded', function () {
         document.querySelector('#toolkit_placeholder'),
         'ORPHE CORE01', ble.id, 'STEP_ANALYSIS_AND_SENSOR_VALUES'
     );
+    guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
 })
 
 function setup() {

--- a/examples/FOOT ANGLE/index.html
+++ b/examples/FOOT ANGLE/index.html
@@ -19,6 +19,10 @@
         <!--<p class="align-bottom">SIMPLE VISUALIZATION SERIES</p>  --> 
         <img src="../../images/orphe.svg" alt="" height="24"></div>
         <!-- 本当はテキストとロゴを右に表示したい and テキストを真ん中揃えしたい -->      
+      <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+    Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+  </div>
+
     </nav>
 
     <div class="row mt-4">

--- a/examples/FOOT ANGLE/sketch.js
+++ b/examples/FOOT ANGLE/sketch.js
@@ -294,6 +294,6 @@ window.onload = function () {
       console.log('> Stop Notify!');
       //document.getElementById('uuid_name').innerHTML = uuid;
   }
+  }
+  guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 }
-}
-

--- a/examples/FOOT ANGLE/utils.js
+++ b/examples/FOOT ANGLE/utils.js
@@ -15,7 +15,7 @@ function getParam(name, url) {
 }
 
 var s_time = Date.now();
-function millis() {
+function elapsedMillis() {
     let e_time = Date.now();;
     let diff = e_time - s_time;
     //console.log("経過時間(ミリ秒):", diff);

--- a/examples/GAME-DDR/index.html
+++ b/examples/GAME-DDR/index.html
@@ -22,6 +22,9 @@
         <div class="toolkit-container">
             <div id="toolkit_placeholder1" class="toolkit-box"></div>
             <div id="toolkit_placeholder2" class="toolkit-box"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
         </div>
 
         <!-- Game Controls (moved here) -->
@@ -116,7 +119,7 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"></script>
+    <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>
     
     <!-- ORPHE Device Setup (must be after ORPHE-CORE.js loads) -->
@@ -127,6 +130,7 @@
         buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'STEP_ANALYSIS');
         bles[1].setup();
         buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'STEP_ANALYSIS');
+        guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
         var connectedDevices = 0;
         
         console.log('🎮 ORPHE devices initialized:', bles);

--- a/examples/GAME-FIREBALL-MARIO/index.html
+++ b/examples/GAME-FIREBALL-MARIO/index.html
@@ -178,6 +178,9 @@
   <div class="header">
     <div class="title">ORPHE Fireball Mario</div>
     <div id="toolkit_placeholder"></div>
+    <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+      Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+    </div>
   </div>
 
   <div class="game-container">
@@ -257,6 +260,7 @@
       'STEP_ANALYSIS_AND_SENSOR_VALUES',
       { range: { acc: 16, gyro: 2000 } }
     );
+    guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
   </script>
 </body>
 </html>

--- a/examples/GAME-HURDLE-2D-VS/index.html
+++ b/examples/GAME-HURDLE-2D-VS/index.html
@@ -134,6 +134,9 @@
       <div class="player-toolkits">
         <h4>👤 Player 2</h4>
         <div id="toolkit_p2"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
       </div>
     </div>
   </div>
@@ -175,7 +178,7 @@
 
   <!-- ORPHE CORE -->
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"></script>
+  <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
 
   <script>
     // Game constants
@@ -764,6 +767,7 @@
 
     buildCoreToolkit(document.querySelector('#toolkit_p1'), 'Player 1', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
     buildCoreToolkit(document.querySelector('#toolkit_p2'), 'Player 2', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 
     var connectedDevices = 0;
     window.devices = {

--- a/examples/GAME-HURDLE-400M-VS/index.html
+++ b/examples/GAME-HURDLE-400M-VS/index.html
@@ -283,7 +283,7 @@
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"></script>
+  <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>
   <script type="module">
   import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
@@ -989,6 +989,9 @@
       <div class="player-toolkits">
         <h4>👤 Player 2</h4>
         <div id="toolkit_p2"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
       </div>
     </div>
   </div>
@@ -1204,6 +1207,7 @@
     // Build CoreToolkit for each device
     buildCoreToolkit(document.querySelector('#toolkit_p1'), 'Player 1', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
     buildCoreToolkit(document.querySelector('#toolkit_p2'), 'Player 2', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 
     var connectedDevices = 0;
 

--- a/examples/GAME-HURDLE-VS-advance/index.html
+++ b/examples/GAME-HURDLE-VS-advance/index.html
@@ -300,7 +300,7 @@
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"></script>
+  <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>
   <script type="module">
   import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
@@ -1370,6 +1370,9 @@
       <div class="player-toolkits">
         <h4>👤 Player 2</h4>
         <div id="toolkit_p2"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
       </div>
     </div>
   </div>
@@ -1585,6 +1588,7 @@
     // Build CoreToolkit for each device
     buildCoreToolkit(document.querySelector('#toolkit_p1'), 'Player 1', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
     buildCoreToolkit(document.querySelector('#toolkit_p2'), 'Player 2', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 
     var connectedDevices = 0;
 

--- a/examples/GAME-HURDLE-VS/index.html
+++ b/examples/GAME-HURDLE-VS/index.html
@@ -283,7 +283,7 @@
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"></script>
+  <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>
   <script type="module">
   import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
@@ -989,6 +989,9 @@
       <div class="player-toolkits">
         <h4>👤 Player 2</h4>
         <div id="toolkit_p2"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
       </div>
     </div>
   </div>
@@ -1204,6 +1207,7 @@
     // Build CoreToolkit for each device
     buildCoreToolkit(document.querySelector('#toolkit_p1'), 'Player 1', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
     buildCoreToolkit(document.querySelector('#toolkit_p2'), 'Player 2', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 
     var connectedDevices = 0;
 

--- a/examples/GAME-HURDLE/index.html
+++ b/examples/GAME-HURDLE/index.html
@@ -1295,6 +1295,9 @@
   <div class="my-4" style="display: flex; gap: 20px; justify-content: center; flex-wrap: wrap;">
     <div id="toolkit_placeholder1" style="max-width: 600px;"></div>
     <div id="toolkit_placeholder2" style="max-width: 600px;"></div>
+    <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+      Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+    </div>
   </div>
   
   <!-- Game description -->
@@ -1466,6 +1469,7 @@
     //SENSOR_VALUES
     bles[1].setup();
     buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
     
     var connectedDevices = 0;
     

--- a/examples/GAME-SHOOTING/index.html
+++ b/examples/GAME-SHOOTING/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="styles.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/p5.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
+    <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
 <script src="../../js/site-analytics.js"></script>
 </head>
 <body>
@@ -18,6 +18,9 @@
         敵を撃ち落とし、ハイスコアを目指そう！<br>
         ※キーボードの左右矢印や「m」キーでも操作できます。</p>
         <div id="toolkit_placeholder1" class="my-4"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
     </div>
     <div id="p5Canvas" style="display:flex; justify-content:center;"></div>
     <script>
@@ -25,6 +28,7 @@
       var ble = new Orphe(0);
       ble.setup();
       buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+      guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
     </script>
     <script src="sketch.js"></script>
 </body>

--- a/examples/GAME-SPRINT-100M-VS/index.html
+++ b/examples/GAME-SPRINT-100M-VS/index.html
@@ -258,7 +258,7 @@
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"></script>
+  <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>
   <script type="module">
   import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
@@ -1136,6 +1136,9 @@
       <div class="player-toolkits">
         <h4>👤 Player 2</h4>
         <div id="toolkit_p2"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
 
         <!-- Motion Detection Visualization -->
         <div style="margin-top: 15px; padding: 15px; background: #0d0d1a; border-radius: 8px;">
@@ -1400,6 +1403,7 @@
     // Build CoreToolkit for each device
     buildCoreToolkit(document.querySelector('#toolkit_p1'), 'Player 1', 0, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
     buildCoreToolkit(document.querySelector('#toolkit_p2'), 'Player 2', 1, 'STEP_ANALYSIS_AND_SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 
     // Setup threshold sliders
     const p1UpSlider = document.getElementById('p1-accelZUp');

--- a/examples/GESTURE-DEMO/index.html
+++ b/examples/GESTURE-DEMO/index.html
@@ -263,6 +263,9 @@
     <!-- Connection -->
     <div class="panel">
       <div id="toolkit_placeholder"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
     </div>
 
     <!-- Status Bar -->
@@ -344,6 +347,7 @@
       'STEP_ANALYSIS_AND_SENSOR_VALUES',
       { range: { acc: 16, gyro: 2000 } }
     );
+    guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
   </script>
 </body>
 </html>

--- a/examples/OH1/index.html
+++ b/examples/OH1/index.html
@@ -19,6 +19,10 @@
       <div id='toolkit_placeholder' class="container-fluid justify-content-between" style="padding:0px;margin:0px;">
 
       </div>
+      <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+    Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+  </div>
+
     </nav>
 
     <div class="row mt-4">

--- a/examples/OH1/sketch.js
+++ b/examples/OH1/sketch.js
@@ -52,4 +52,5 @@ window.onload = function () {
       `CORE 0${ble.id + 1}`,
       ble.id);
   }
+  guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 }

--- a/examples/PRONATION/index.html
+++ b/examples/PRONATION/index.html
@@ -19,6 +19,10 @@
         <!--<p class="align-bottom">SIMPLE VISUALIZATION SERIES</p>  --> 
         <img src="../../images/orphe.svg" alt="" height="24"></div>
         <!-- 本当はテキストとロゴを右に表示したい and テキストを真ん中揃えしたい -->      
+      <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+    Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+  </div>
+
     </nav>
 
     <div class="row mt-4">

--- a/examples/PRONATION/sketch.js
+++ b/examples/PRONATION/sketch.js
@@ -232,6 +232,6 @@ window.onload = function () {
       console.log('> Stop Notify!');
       //document.getElementById('uuid_name').innerHTML = uuid;
   }
+  }
+  guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
 }
-}
-

--- a/examples/WORKSHOP_07/index.html
+++ b/examples/WORKSHOP_07/index.html
@@ -26,9 +26,11 @@
 <body>
     <h1>Hello, CoreToolkit.js</h1>
     <div id="toolkit_placeholder"></div>
+    <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+      Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+    </div>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"
-        type="text/javascript"></script>
+    <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
         integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
         crossorigin="anonymous"></script>
@@ -56,6 +58,7 @@
             // ORPHE CORE Init; bles[0] and bles[1] are used by CoreToolkit.js
             bles[0].setup();
             buildCoreToolkit(document.querySelector('#toolkit_placeholder'), '01', 0, 'SENSOR_VALUES');
+            guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
             // alternative begin function call
             // buildCoreToolkit(document.querySelector('#toolkit_placeholder'),
             //     '01', // name to be shown on the UI

--- a/examples/drum_test/index.html
+++ b/examples/drum_test/index.html
@@ -23,6 +23,9 @@
 
         <div id="toolkit_placeholder1" class="my-4"></div>
         <div id="toolkit_placeholder2" class="my-4"></div>
+      <div id="ble-support-message" class="alert alert-warning mx-4" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+      </div>
         <div id="p5Canvas"></div> <!-- p5.jsのキャンバスがここに挿入されます -->
 
         <!-- 現在のジェスチャー内容を表示 -->
@@ -60,8 +63,7 @@
 
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"
         type="text/javascript"></script>
-    <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js" crossorigin="anonymous"
-        type="text/javascript"></script>
+    <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"
         integrity="sha384-IDwe1+LCz02ROU9k972gdyvl+AESN10+x7tBKgc9I5HFtuNz0wWnPclzo6p9vxnk"
         crossorigin="anonymous"></script>

--- a/examples/drum_test/scripts.js
+++ b/examples/drum_test/scripts.js
@@ -50,6 +50,7 @@ function setup() {
     buildCoreToolkit(document.querySelector('#toolkit_placeholder1'), '01', 0, 'SENSOR_VALUES');
     bles[1].setup();
     buildCoreToolkit(document.querySelector('#toolkit_placeholder2'), '02', 1, 'SENSOR_VALUES');
+    guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
     
    // ORPHE CORE Init
 

--- a/examples/p5.ORPHE.FSR_visualise_0327_submit/index.html
+++ b/examples/p5.ORPHE.FSR_visualise_0327_submit/index.html
@@ -29,6 +29,10 @@
           class="container-fluid justify-content-between"
           style="padding:0px;margin:0px;"
         ></div>
+        <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+    Web Bluetooth is disabled in this browser. Open this page in Chrome to connect ORPHE CORE.
+  </div>
+
       </nav>
 
       <div class="row mt-4">
@@ -77,11 +81,7 @@
       crossorigin="anonymous"
       type="text/javascript"
     ></script>
-    <script
-      src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/CoreToolkit.js"
-      crossorigin="anonymous"
-      type="text/javascript"
-    ></script>
+    <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
     <script
       src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js"
       crossorigin="anonymous"

--- a/examples/p5.ORPHE.FSR_visualise_0327_submit/sketch.js
+++ b/examples/p5.ORPHE.FSR_visualise_0327_submit/sketch.js
@@ -76,6 +76,8 @@ window.onload = function () {
       ble.id
     );
   }
+  guardCoreToolkitBluetooth({ coreIds: [0, 1], messageElement: '#ble-support-message' });
+
   if (window.name != "ORPHE-CORE") {
     let new_win = window.open(document.URL, "ORPHE-CORE", "width=500px");
     document.querySelector("body").hidden = true;

--- a/js/CoreToolkit.js
+++ b/js/CoreToolkit.js
@@ -230,7 +230,15 @@ async function toggleCoreModule(dom, options = {}) {
     let ble = bles[number];
     let notification = dom.getAttribute('notification');
     if (checked == true) {
-        let ret = await ble.begin(notification, options);
+        let ret;
+        try {
+            ret = await ble.begin(notification, options);
+        } catch (error) {
+            document.querySelector(`#switch_ble${number}`).checked = false;
+            document.querySelector(`#ui${number}`).style.visibility = 'hidden';
+            ble.onError(error);
+            return;
+        }
         if (!ret) {
             document.querySelector(`#switch_ble${number}`).checked = false;
             return;


### PR DESCRIPTION
## Summary
- CoreToolkitを使う残りのExampleへ共通のBLEブラウザガードを適用
- Codex/Electron系ブラウザや navigator.bluetooth 非対応環境では接続UIを無効化し、Chrome利用メッセージを表示
- 対象ページのCoreToolkit.js参照をローカル参照へ揃え、GitHub Pagesでも共通helperを使うように調整
- CoreToolkitの接続失敗時にスイッチとUIを戻し、未処理Promiseエラーを出さないように調整
- FOOT ANGLEの未使用 millis() を elapsedMillis() に変更し、p5.js global function warningを避ける
- ゲームロジック、BLE通知種別、閾値、センサー処理は変更なし
- GAME-PKは既存のCoreToolkit接続設計に問題があり、今回の一括適用から除外

## Validation
- git diff --check
- node scripts/check-examples-catalog.js
- node --check for changed sketch/scripts files
- node --check js/CoreToolkit.js and examples/FOOT ANGLE/utils.js
- static coverage check: 25 guarded / 26 CoreToolkit example pages; GAME-PK excluded intentionally
- curl -I on all touched example pages: 200 OK

## Needs real-device validation
- 今回追加した残りExampleは静的確認とHTTP確認までです
- Chromeでは接続スイッチが有効、Codex/Electron系ブラウザでは無効化される想定です
- HURDLEはユーザー側で実機確認済み
- FOOT ANGLEの01接続はユーザー側で確認済み。接続失敗時の未処理Promiseだけ今回追加で抑制しています
- GAME-PKは bles[0] ではなく別の new Orphe(0) に setup/callback を付けているため、別PRで接続構造を直す必要があります

## Out of scope
- CoreToolkit UIのデザイン変更
- Exampleのゲーム挙動、センサー処理、閾値調整
- CoreToolkit非利用Exampleへの変更
- GAME-PKの接続構造修正
