### PR TITLE
Examples一覧から内部用の実機確認待ち表示を非表示にする

### DIFF
--- a/examples/gallery.js
+++ b/examples/gallery.js
@@ -323,7 +323,6 @@
       ? `<img src="${escapeHtml(normalizeLink(entry.thumbnail))}" alt="">`
       : `<span>サムネイル準備中</span>`;
     const devices = entry.device_count || entry.devices || 1;
-    const verification = entry.needs_real_device_validation || (entry.validation || []).some((item) => item.includes('device'));
 
     return `
       <a class="card" href="${escapeHtml(demoLink(entry))}">
@@ -334,7 +333,6 @@
           <div class="meta">
             <span class="pill">${escapeHtml(difficultyLabel(entry))}</span>
             <span class="pill">${devices}台</span>
-            ${verification ? '<span class="pill">実機確認待ち</span>' : ''}
           </div>
         </div>
       </a>


### PR DESCRIPTION
## Summary
- Examples一覧カードに表示していた実機確認待ち pill を削除
- needs_real_device_validation や validation は catalog の内部管理情報として残し、公開UIには出さない
- 難易度と必要台数のpillは維持

## Validation
- git diff --check
- node --check examples/gallery.js
- node scripts/check-examples-catalog.js
- rg -n "実機確認待ち" examples/gallery.js examples/index.html returns no matches
- curl -I http://localhost:8767/examples/: 200 OK
