### PR TITLE
AI並行開発の運用ドキュメントを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.md
+++ b/.github/ISSUE_TEMPLATE/agent-task.md
@@ -1,0 +1,81 @@
+---
+name: Agent Task
+about: Scoped task for Codex or Claude
+title: "[Agent] "
+labels: ["agent-task"]
+assignees: ""
+---
+
+## Goal
+
+Describe the user-visible goal in one or two sentences.
+
+## Background
+
+Link or summarize the relevant docs, research, examples, or previous PRs.
+
+## Preferred Agent
+
+- [ ] Codex
+- [ ] Claude
+- [ ] Either
+- [ ] Human decision needed
+
+## Files Allowed
+
+List files or directories the agent may edit.
+
+- 
+
+## Files Off Limits
+
+List files or directories the agent must not edit in this task.
+
+- `main` direct push
+- 
+
+## Scope
+
+What should be done:
+
+- 
+
+## Out of Scope
+
+What should not be done:
+
+- New examples unless explicitly requested
+- Large renames or deletes
+- Dependency upgrades
+- BLE behavior changes without real-device validation
+- 
+
+## Validation
+
+Required checks:
+
+- [ ] `git diff --check`
+- [ ] `node scripts/check-examples-catalog.js` if catalog or example metadata changes
+- [ ] `node --check <changed-js-file>` if JavaScript changes
+- [ ] Local server `curl -I` or browser preview for changed pages
+- [ ] Real-device Chrome validation if BLE behavior changes
+
+## Acceptance Criteria
+
+- [ ] The PR has one clear purpose.
+- [ ] The change does not edit files outside the allowed scope.
+- [ ] Public-facing text is clear and natural.
+- [ ] Any example status change is justified.
+- [ ] Real-device validation is honestly reported.
+
+## Questions for Human
+
+List decisions that should not be guessed.
+
+- 
+
+## Notes for Other Agents
+
+Mention branch, related PRs, or possible conflicts.
+
+- 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,72 @@
+## Summary
+
+- 
+
+## Why
+
+- 
+
+## Scope
+
+Changed areas:
+
+- [ ] Core library (`js/ORPHE-CORE.js`)
+- [ ] CoreToolkit / connection UI
+- [ ] Existing example behavior
+- [ ] New example
+- [ ] Catalog / gallery / LP
+- [ ] Docs / lessons / research
+- [ ] Tests / scripts
+
+## Validation
+
+- [ ] `git diff --check`
+- [ ] `node scripts/check-examples-catalog.js`
+- [ ] `node --check <changed-js-file>`
+- [ ] Local server or browser preview
+- [ ] Real-device Chrome validation
+- [ ] Not applicable, docs-only
+
+Commands and results:
+
+```text
+
+```
+
+## Real-device Validation
+
+Required?
+
+- [ ] Yes
+- [ ] No
+
+If yes, what was tested?
+
+- Device count:
+- Browser:
+- Example/page:
+- Result:
+
+## Public Example Quality
+
+If this PR touches an example, confirm:
+
+- [ ] Clear title
+- [ ] What it does is explained
+- [ ] Required ORPHE CORE count is stated
+- [ ] Data / notification type is stated where relevant
+- [ ] Startup instructions are present
+- [ ] Known limitations are documented
+- [ ] Catalog status is accurate
+
+## Out of Scope
+
+- 
+
+## Questions for Human
+
+- 
+
+## Next PR Candidates
+
+- 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,130 @@
+# Agent Collaboration Guide
+
+This repository is developed by humans, Codex, and Claude in parallel. The goal is to grow ORPHE-CORE.js as a reliable open-source JavaScript library for ORPHE CORE, while making every public example understandable, runnable, and useful for education, sports science, rehabilitation, and creative coding.
+
+## Priorities
+
+1. Keep the core ORPHE-CORE.js library reliable.
+2. Keep BLE connection, shared connection, reconnection, and CoreToolkit behavior stable.
+3. Bring existing examples to public quality before adding many new examples.
+4. Make examples easy to evaluate: what it does, required devices, data used, how to run, and what to verify.
+5. Add education and research material in a way that does not destabilize the core library.
+
+## Branches and PRs
+
+- Do not push directly to `main`.
+- Use PRs for all changes.
+- Use one PR for one purpose.
+- Use `codex/<topic>` for Codex branches.
+- Use `claude/<topic>` for Claude branches.
+- Keep PRs small enough that a human can review and accept or reject them independently.
+- Do not combine behavior changes, renames, deletes, and docs cleanup in one PR.
+
+## Ownership
+
+| Area | Primary owner | Notes |
+|---|---|---|
+| `js/ORPHE-CORE.js` | Codex | Core SDK, BLE, parser, callbacks, bridge, reconnect. Real-device validation is required for behavior changes. |
+| `js/CoreToolkit.js` | Codex | Connection UI and device controls. Browser and real-device validation are required. |
+| Existing `examples/*` behavior | Codex | Existing examples must not be changed broadly without explicit scope. |
+| `examples/catalog.json` | Codex | Claude should propose metadata in PR body or per-example metadata files, not edit this file directly unless coordinated. |
+| `index.html` | Codex | Public LP/navigation changes need preview. |
+| New `examples/<new>/` | Claude draft, Codex review | New examples should be self-contained and avoid touching existing examples. |
+| `js/CoreAnalytics.js` | Claude draft, Codex API review | Keep analytics separate from `ORPHE-CORE.js` until the API is stable. |
+| `js/CoreRecorder.js` | Claude draft, Codex API review | Prefer extracting reusable recording logic from existing examples without breaking them. |
+| `docs/lessons/` | Claude | Lesson plans, citations, and educator material. |
+| `docs/ai/` | Shared | Research notes and AI handoff prompts. |
+
+## Core Library Rules
+
+- `ORPHE-CORE.js` should stay focused on BLE connection, data parsing, core state, and callback dispatch.
+- Do not add high-level analytics directly into `ORPHE-CORE.js` until the same API has been proven in examples or helper modules.
+- Prefer separate modules first:
+  - `CoreAnalytics.js` for symmetry, baselines, session summaries, CMJ, and gait metrics.
+  - `CoreRecorder.js` for CSV/JSON recording and replay data formats.
+- Any new helper API must work with the existing callback model:
+  - `gotAcc`
+  - `gotConvertedAcc`
+  - `gotGyro`
+  - `gotQuat`
+  - `gotEuler`
+  - `gotGait`
+  - `gotStride`
+  - `gotPronation`
+  - `gotStepsNumber`
+- Do not replace the callback model without a separate design discussion.
+
+## Example Quality Bar
+
+An example can be promoted toward public navigation only when it has:
+
+- A clear title.
+- A short explanation of what it does.
+- Required device count.
+- Data/notification type used.
+- Startup instructions.
+- Real-device validation status.
+- Known limitations.
+- Thumbnail when shown in a gallery.
+- A README if the example is not trivial.
+
+Use these statuses consistently:
+
+- `public`: ready to show broadly.
+- `public-candidate`: useful but still needs validation or polish.
+- `needs-review`: unclear scope or needs human decision.
+- `needs-fix`: known issue blocks public use.
+- `internal`: test, debug, or internal utility.
+
+## Metadata and Catalog
+
+For now, `examples/catalog.json` is the source for public galleries. To reduce conflicts:
+
+- Claude should not directly update `examples/catalog.json` unless explicitly assigned.
+- New examples should include proposed catalog metadata in their PR body.
+- If a new example needs structured metadata, add an `example.meta.json` proposal in the example directory and mark it as a proposal.
+- Codex will reconcile proposals into `examples/catalog.json`.
+
+Future direction:
+
+- Add a script that builds `examples/catalog.json` from per-example metadata files.
+- Keep generated output deterministic.
+- Add validation to CI or local scripts before merging.
+
+## Validation Expectations
+
+Run the smallest relevant checks for each PR. Common checks:
+
+- `git diff --check`
+- `node scripts/check-examples-catalog.js`
+- `node --check <changed-js-file>`
+- `curl -I http://localhost:8767/<changed-page>/`
+- Browser preview for LP or gallery changes.
+- Real-device Chrome validation for BLE behavior changes.
+
+Never claim real-device validation unless it was actually performed.
+
+## Human Decision Points
+
+Escalate these to a human:
+
+- Public navigation changes.
+- Example promotion from `public-candidate` to `public`.
+- Large renames or deletes.
+- Changes to BLE behavior.
+- Changes to ORPHE CORE data interpretation.
+- API naming in `ORPHE-CORE.js`, `CoreAnalytics.js`, or `CoreRecorder.js`.
+- Legal or branding-sensitive names.
+
+## Handoff Format
+
+Every PR should include:
+
+- Summary
+- Validation
+- Needs real-device validation
+- Out of scope
+- Questions for human
+- Next PR candidates
+
+At session end, update `docs/in-flight.md` or leave a PR comment with the current branch, touched files, validation, and remaining questions.

--- a/docs/ai/claude-parallel-sprint-reply.md
+++ b/docs/ai/claude-parallel-sprint-reply.md
@@ -1,0 +1,87 @@
+# Reply Prompt for Claude: Parallel Development Sprint
+
+Use this prompt when asking Claude to proceed from the IMU competitor research and sprint proposal.
+
+```text
+ORPHE-CORE.js の並行開発方針を Codex 側と相談しました。
+
+結論として、Claude には新規追加・教材・分析/録画ヘルパーの初稿を進めてもらい、Codex は ORPHE-CORE.js ライブラリ本体の品質維持、既存 examples の整理、公開品質化、BLE/CoreToolkit/catalog/index 周りを優先します。
+
+作業前に必ず以下を読んでください。
+
+- docs/agents.md
+- docs/in-flight.md
+- docs/examples-roadmap.md
+- docs/examples-catalog.md
+- docs/public-candidate-validation.md
+
+重要な方針:
+
+1. main へ直接 push しない
+2. 1 PR = 1 目的
+3. Claude は原則として以下を担当
+   - 新規 examples/<new>/ の追加
+   - docs/lessons/ の授業案
+   - docs/ai/ の調査/設計ドキュメント
+   - js/CoreAnalytics.js の初稿
+   - js/CoreRecorder.js の初稿
+4. Claude は原則として以下を直接編集しない
+   - js/ORPHE-CORE.js
+   - js/CoreToolkit.js
+   - index.html
+   - examples/catalog.json
+   - 既存 examples のゲームロジックやBLE処理
+5. catalog 追加が必要な場合は、PR本文に proposed catalog metadata として提案してください。Codex が取り込みます。
+6. 新規 example は実機未確認なら public と断定せず、public-candidate または needs-review 前提で提案してください。
+7. BLE、通知タイプ、歩容指標、CMJ計算、左右差計算などの仕様判断は、Assumptions / Questions for human に明記してください。
+
+Codex側の優先順位:
+
+- ORPHE-CORE.js 本体の信頼性
+- BLE接続、共有接続、再接続、CoreToolkit UIの安定性
+- 既存 examples を全て公開品質に近づけること
+- examples/catalog.json と index.html の整合性
+- 実機確認が必要なものを正直に分けること
+
+Claudeにお願いしたい次の作業:
+
+まずは以下の順で、衝突しにくいPRを作ってください。
+
+PR 1: docs/lessons/ の構成案
+- Tier 1 example 6本に対する45分授業プランのテンプレートを作成
+- 実装は不要
+- 論文引用は候補として記載し、事実確認が必要なものは明記
+
+PR 2: js/CoreAnalytics.js API draft
+- 新規ファイルのみ
+- ORPHE-CORE.js 本体には触らない
+- gotGait / gotStride / gotPronation / gotConvertedAcc など既存callbackからデータを受け取れる形にする
+- session summary, baseline, symmetry, CMJ計算の関数名と入力/出力を明確にする
+- 実装は最小でもよいが、API設計とJSDocを重視
+
+PR 3: js/CoreRecorder.js API draft
+- 新規ファイルのみ
+- examples/SENSOR-CALIBRATION/recorder.js を参考にする
+- 既存 SENSOR-CALIBRATION はまだ変更しない
+- CSV/JSON schema と replay 互換性を説明
+
+PR 4以降: 新規 Tier 1 example の小さなPoC
+- まずは Step Count Dashboard または CSV Recorder のどちらか1本
+- 既存 example を壊さない
+- 実機未確認ならREADMEに Needs real-device validation と書く
+- catalog.json には直接触らず、PR本文に proposed catalog metadata を書く
+
+各PR本文には必ず以下を入れてください。
+
+- Summary
+- Validation
+- Assumptions
+- Needs real-device validation
+- Out of scope
+- Proposed catalog metadata if relevant
+- Questions for human
+- Next PR candidates
+
+作業開始時と終了時には docs/in-flight.md を更新してください。
+もし Codex が触るべきファイルに変更が必要だと思った場合は、直接編集せず、docs/in-flight.md またはPR本文に Codex follow-up として書いてください。
+```

--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -1,0 +1,63 @@
+# In-flight Work
+
+Last updated: 2026-05-02 23:35 JST
+
+This file is a lightweight coordination board for humans, Codex, and Claude. It is not a changelog. Keep it short and update it before starting or ending a multi-file task.
+
+## Rules
+
+- Read `docs/agents.md` before starting agent work.
+- Do not push directly to `main`.
+- One PR should have one purpose.
+- Update this file before starting work and before ending a session.
+- If a row is older than 24 hours and has no active PR, treat it as stale.
+- Do not edit files claimed by another active row unless explicitly coordinated.
+- If a task needs real-device validation, mark it clearly.
+
+## Active Work
+
+| Agent | Branch | Purpose | Files / Areas | Status | Last Update | Notes |
+|---|---|---|---|---|---|---|
+| Codex | main | Create agent collaboration docs | `docs/agents.md`, `docs/in-flight.md`, `.github/*`, `docs/ai/*` | active | 2026-05-02 23:35 JST | Codex priority is core library quality and public-quality existing examples. |
+| Claude | claude/research-imu-competitors-yWYtf | IMU competitor research and lesson concept | `docs/ai/` research docs | reference | 2026-05-02 23:35 JST | Research should inform roadmap, not directly edit core SDK. |
+
+## Planned Work
+
+| Priority | Owner | Topic | Files / Areas | Notes |
+|---|---|---|---|---|
+| P1 | Codex | Existing example quality pass | `examples/*`, `examples/catalog.json` | Bring current examples to public quality before broad new additions. |
+| P1 | Codex | Core SDK/API quality | `js/ORPHE-CORE.js`, `js/CoreToolkit.js` | BLE behavior and callback compatibility are highest priority. |
+| P2 | Claude draft, Codex review | `CoreAnalytics.js` API proposal | `js/CoreAnalytics.js`, docs/examples using it | Start as separate helper module, not direct `ORPHE-CORE.js` methods. |
+| P2 | Claude draft, Codex review | `CoreRecorder.js` extraction proposal | `js/CoreRecorder.js`, `examples/SENSOR-CALIBRATION/recorder.js` | Reuse existing recorder logic without breaking current example. |
+| P2 | Claude | Lesson plans | `docs/lessons/` | Tier 1 lessons can be drafted independently. |
+| P3 | Codex | Catalog metadata workflow | `examples/catalog.json`, scripts | Consider per-example metadata to reduce conflicts. |
+
+## File Ownership Guidelines
+
+| Area | Primary Owner | Notes |
+|---|---|---|
+| `js/ORPHE-CORE.js` | Codex | Core SDK changes require design review and real-device validation. |
+| `js/CoreToolkit.js` | Codex | Connection UI changes require browser and real-device validation. |
+| Existing `examples/*` behavior | Codex | Preserve behavior unless the PR explicitly targets a fix. |
+| New `examples/<new>/` | Claude draft, Codex review | Keep isolated; do not edit existing examples in the same PR. |
+| `js/CoreAnalytics.js` | Claude draft, Codex review | New file is okay; API must remain separable from core until reviewed. |
+| `js/CoreRecorder.js` | Claude draft, Codex review | New file is okay; extraction from existing recorder needs Codex review. |
+| `examples/catalog.json` | Codex | Claude should propose metadata, not directly edit unless assigned. |
+| `README.md`, `index.html` | Codex | Public-facing navigation and positioning changes need preview. |
+| `docs/lessons/` | Claude | Include citations and educator framing. |
+
+## Pending Coordination
+
+| Topic | Owner | Decision Needed |
+|---|---|---|
+| Per-example metadata | Codex | Decide whether to introduce `example.meta.json` and a catalog build script. |
+| `CoreAnalytics.js` API | Codex + Claude | Decide method names, input shape, and session data format. |
+| `CoreRecorder.js` API | Codex + Claude | Decide CSV/JSON schema and replay compatibility. |
+| Tier 1 examples | Human + Codex + Claude | Confirm acceptance criteria and real-device validation requirements. |
+| Educator navigation | Human + Codex | Decide when `For Educators` appears in `index.html`. |
+
+## Session Notes
+
+- Codex should prioritize library stability, existing example cleanup, and public-quality validation.
+- Claude can move faster on isolated new examples, lesson plans, and research docs.
+- Any changes to BLE, callbacks, gait interpretation, or public catalog status need Codex/human review.


### PR DESCRIPTION
## Summary
- Codex / Claude / human の並行開発ルールを docs/agents.md に整理しました
- 作業中ブランチと触る領域を共有する docs/in-flight.md を追加しました
- GitHub Issue / PR テンプレートを追加しました
- Claude のスプリント提案へ返すための返信プロンプトを docs/ai/claude-parallel-sprint-reply.md に残しました

## Validation
- git diff --check

## Notes
- Codex側の本筋は ORPHE-CORE.js ライブラリ品質維持、既存 examples の整理、公開品質化を優先する方針にしています
- Claude側は新規example、lesson plan、CoreAnalytics/CoreRecorderの初稿など、衝突しにくい新規追加を担当する前提です