### PR TITLE
CoreToolkitガイドとORPHE TERMINALにBLE共有bridgeを追加

### DIFF
--- a/apps/ORPHE-TERMINAL/index.html
+++ b/apps/ORPHE-TERMINAL/index.html
@@ -138,6 +138,7 @@
         </div>
         <script src="../../js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
         <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+        <script src="../../js/BleSharedBridge.js"></script>
         <script src="../../js/CoreToolkit.js"></script>
         <script src="./index.js"></script>
 

--- a/docs/getting-started-coretoolkit.html
+++ b/docs/getting-started-coretoolkit.html
@@ -76,6 +76,8 @@
           &lt;div id=&quot;toolkit_placeholder&quot;&gt;&lt;/div&gt;
           &lt;script src=&quot;https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js&quot;
               crossorigin=&quot;anonymous&quot;&gt;&lt;/script&gt;
+          &lt;script src=&quot;https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/BleSharedBridge.js&quot;
+              crossorigin=&quot;anonymous&quot;&gt;&lt;/script&gt;
           &lt;script src=&quot;https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/CoreToolkit.js&quot; crossorigin=&quot;anonymous&quot;
               type=&quot;text/javascript&quot;&gt;&lt;/script&gt;
           &lt;script src=&quot;https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js&quot;
@@ -85,6 +87,7 @@
               window.onload = function () {
                   cores[0].setup();
                   buildCoreToolkit(document.querySelector(&#039;#toolkit_placeholder&#039;), &#039;01&#039;, 0, &#039;SENSOR_VALUES&#039;);
+                  guardCoreToolkitBluetooth({ coreIds: [0] });
 
                   cores[0].gotAcc = function (acc) {
                   }


### PR DESCRIPTION
## Summary

- `apps/ORPHE-TERMINAL/index.html` に `BleSharedBridge.js` の読み込みを追加しました
- `docs/getting-started-coretoolkit.html` のCoreToolkitサンプルに `BleSharedBridge.js` と `guardCoreToolkitBluetooth()` を追記しました

## Validation

- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `curl -I http://localhost:8767/docs/getting-started-coretoolkit.html`
- `curl -I http://localhost:8767/apps/ORPHE-TERMINAL/`

## Needs real-device validation

- No for this PR scope. It only adds the bridge script reference and updates guide code.
- ORPHE TERMINAL itself remains a public-candidate tool and still needs human/device validation before promotion.

## Out of scope

- Does not change `ORPHE-CORE.js` or `CoreToolkit.js`
- Does not add `guardCoreToolkitBluetooth()` to ORPHE TERMINAL because it may be used in Electron-like environments
- Does not promote ORPHE TERMINAL to public

## Questions for human

- Should ORPHE TERMINAL remain in the Examples catalog, or move to a separate Developer Tools page later?

## Next PR candidates

- Add a fuller ORPHE TERMINAL README
- Refine public-candidate validation checklist
