### PR TITLE
public-candidate確認手順を整理

### DIFF
--- a/docs/public-candidate-validation.md
+++ b/docs/public-candidate-validation.md
@@ -1,10 +1,13 @@
-# Public candidate validation queue
+# Public Candidate Validation Queue
 
 This document tracks examples that are valuable enough to show in the catalog
 but still need human review before they should be treated as stable public
 examples.
 
-## Current status
+This is an internal validation document. Do not show "needs real-device
+validation" as a public badge in the examples gallery.
+
+## Current Status
 
 - `public`: 35 entries
 - `public-candidate`: 7 entries
@@ -12,20 +15,57 @@ examples.
 `GAME-MARIO` and `GAME-SHOOTING2` were promoted to `public` after owner
 real-device checks. The entries below remain candidates.
 
-## Validation order
+## Morning Check List
+
+Open these URLs from a local server and use Chrome for BLE tests.
+
+| Order | Entry | URL | Device | Main check | Promotion blocker |
+|---|---|---|---:|---|---|
+| 1 | `game-pk` | `http://localhost:8767/examples/GAME-PK/` | 1 | Kick detection and restart flow | BLE chooser / kick detection still needs owner confirmation |
+| 2 | `game-shooting` | `http://localhost:8767/examples/GAME-SHOOTING/` | 1 | Tilt movement, fire input, restart | Decide whether it coexists with `GAME-SHOOTING2` |
+| 3 | `game-fireball-mario` | `http://localhost:8767/examples/GAME-FIREBALL-MARIO/` | 1 | Step, kick, jump, restart, naming | Confirm no public-facing Mario text remains |
+| 4 | `dtw` | `http://localhost:8767/examples/DTW/` | 1 | Mouse demo plus sensor input path | Needs clarity check for technical users |
+| 5 | `workshop-07` | `http://localhost:8767/examples/WORKSHOP_07/` | 1 | Page opens and workshop value is clear | Decide catalog vs workshop-only placement |
+| 6 | `ws-tmu2025` | `http://localhost:8767/ws/tmu2025/` | varies | Gallery opens and links work | Decide whether to split strong works later |
+| 7 | `app-orphe-terminal` | `http://localhost:8767/apps/ORPHE-TERMINAL/` | 1 | Developer tool opens and can connect | Needs README and developer-tool positioning |
+
+## Promotion Rules
+
+Promote a candidate to `public` only when all relevant items are true:
+
+- Human owner confirms the example in Chrome with the required ORPHE CORE count.
+- The example title and visible UI are acceptable for public use.
+- Restart/reconnect flow does not obviously break the session.
+- README or page copy explains what it does, required device count, startup, and known limitations.
+- `examples/catalog.json` has `needs_real_device_validation: false`.
+- `validation` includes a real-device validation note.
+
+Do not promote workshop galleries or developer tools just because they open.
+They need a navigation decision first.
+
+## Candidate Details
 
 ### 1. `examples/GAME-PK/`
 
 Purpose: one-device penalty kick game.
 
-What changed:
+Current state:
 
+- `status`: `public-candidate`
+- Requires one ORPHE CORE.
+- Uses `STEP_ANALYSIS_AND_SENSOR_VALUES`.
 - Uses the same `bles[0]` instance as CoreToolkit.
-- Does not call `begin()` again from `onConnect`; CoreToolkit owns the notify
-  start.
+- CoreToolkit owns `begin()` and notify start.
 - Uses local `ORPHE-CORE.js` and `CoreToolkit.js`.
 
-Human checks:
+Can be checked without device:
+
+- Page loads.
+- Start screen and instructions are visible.
+- No public gallery badge exposes internal validation state.
+- README explains purpose, device count, and startup.
+
+Human BLE checks:
 
 - Connect one ORPHE CORE from the CoreToolkit switch.
 - Press START.
@@ -42,19 +82,27 @@ Promotion condition:
 
 Purpose: simple p5.js shooting game.
 
-What changed:
+Current state:
 
+- `status`: `public-candidate`
+- Requires one ORPHE CORE.
+- Uses `SENSOR_VALUES`.
 - Uses the same `bles[0]` instance as CoreToolkit.
-- Uses `SENSOR_VALUES` because the game reads Euler and acceleration values.
-- Metadata now records one ORPHE CORE device instead of two.
+- Metadata records one ORPHE CORE device.
 
-Human checks:
+Can be checked without device:
+
+- Page loads.
+- Keyboard fallback still starts and moves the game.
+- README states that BLE input needs device validation.
+
+Human BLE checks:
 
 - Connect one ORPHE CORE.
 - Tilt to move left/right.
-- Strong motion fires a missile.
-- Keyboard fallback still works.
-- Restart after game over works.
+- Confirm the fire action.
+- Confirm keyboard fallback still works.
+- Confirm restart after game over works.
 
 Promotion condition:
 
@@ -65,17 +113,25 @@ Promotion condition:
 
 Purpose: one-device action game with stepping, kicking, and jumping gestures.
 
-What changed:
+Current state:
 
-- Public-facing title changed from `Fireball Mario` to `Fireball Action`.
-- README now explains startup, data, and validation points.
+- `status`: `public-candidate`
+- Public-facing title changed to `Fireball Action`.
+- Directory name still contains `MARIO` for compatibility.
+- README explains startup, data, and validation points.
 
-Human checks:
+Can be checked without device:
+
+- Page title and visible heading use `Fireball Action`.
+- No public-facing `Mario` label remains in the UI.
+- Page opens from the examples gallery.
+
+Human BLE checks:
 
 - Connect one ORPHE CORE.
 - Confirm step, kick, and jump gestures work.
 - Confirm restart/game-over flow.
-- Confirm there are no remaining public-facing `Mario` labels in the UI.
+- Confirm shared BLE streaming still works when another page is primary.
 
 Promotion condition:
 
@@ -85,16 +141,23 @@ Promotion condition:
 
 Purpose: technical example for time-series matching with Dynamic Time Warping.
 
-What changed:
+Current state:
 
-- README now explains what the example teaches and how to run it.
+- `status`: `public-candidate`
+- Requires one ORPHE CORE for sensor input.
+- Also has a mouse/shape demo path that can be inspected without hardware.
+- README explains what the example teaches and how to run it.
 
-Human checks:
+Can be checked without device:
 
 - Open the page and confirm mouse input still demonstrates DTW behavior.
+- Confirm triangle/circle/square matching is understandable.
+- Confirm the page has enough instruction for a technical reader.
+
+Human BLE checks:
+
 - Connect one ORPHE CORE.
 - Confirm sensor input updates the time-series path used for matching.
-- Confirm triangle/circle/square matching is understandable.
 
 Promotion condition:
 
@@ -105,6 +168,18 @@ Promotion condition:
 
 Purpose: workshop material for Fourier / DFT.
 
+Current state:
+
+- `status`: `public-candidate`
+- This is workshop material, not a beginner app.
+- Missing a dedicated README.
+
+Can be checked without device:
+
+- Page opens.
+- The workshop purpose is understandable.
+- Links and embedded references work.
+
 Decision needed:
 
 - Keep listed under the Examples catalog as workshop material, or move to a
@@ -113,10 +188,23 @@ Decision needed:
 Suggested default:
 
 - Keep in the catalog, but do not feature it on the LP.
+- Add a README before promotion.
 
 ### 6. `ws/tmu2025/`
 
 Purpose: workshop gallery.
+
+Current state:
+
+- `status`: `public-candidate`
+- This is a gallery of workshop works, not a single maintained example.
+- Missing a dedicated README.
+
+Can be checked without device:
+
+- Gallery opens.
+- Project links and thumbnails are intact.
+- The page does not imply every project is a maintained official example.
 
 Decision needed:
 
@@ -124,12 +212,32 @@ Decision needed:
 
 Suggested default:
 
-- Keep in the catalog under `workshop-archive`; later split strong individual
-  works into separate catalog entries if they are maintained.
+- Keep in the catalog under `workshop-archive`.
+- Later split strong individual works into separate catalog entries if they are
+  maintained.
 
 ### 7. `apps/ORPHE-TERMINAL/`
 
 Purpose: developer utility.
+
+Current state:
+
+- `status`: `public-candidate`
+- Developer tool rather than beginner example.
+- Needs a fuller README before promotion.
+
+Can be checked without device:
+
+- Page opens.
+- Tool sections and controls are visible.
+- The purpose is clear enough for a developer.
+
+Human BLE checks:
+
+- Connect one ORPHE CORE.
+- Confirm Device Information read/write area works.
+- Confirm SENSOR_VALUES stream area updates.
+- Confirm download buttons still create data files.
 
 Decision needed:
 
@@ -137,5 +245,5 @@ Decision needed:
 
 Suggested default:
 
-- Keep in the catalog under `developer-tool`; improve README before promoting
-  it from `public-candidate` to `public`.
+- Keep in the catalog under `developer-tool`.
+- Improve README before promoting from `public-candidate` to `public`.


### PR DESCRIPTION
## Summary

- `docs/public-candidate-validation.md` を明日の人間チェック向けに整理しました
- public-candidate 7件のURL、必要台数、確認項目、昇格条件、判断が必要な点を明確化しました
- 公開画面には「実機確認待ち」などの内部ステータスを出さない方針を明記しました

## Validation

- `git diff --check`
- `node scripts/check-examples-catalog.js`

## Needs real-device validation

- No for this PR. It only documents which examples still need real-device validation.

## Out of scope

- Does not promote any example
- Does not change `examples/catalog.json`
- Does not change BLE/game logic

## Questions for human

- Should `WORKSHOP_07` and `ws/tmu2025` remain in the same Examples gallery, or move to workshop-only navigation later?
- Should `ORPHE TERMINAL` remain in Examples, or move to a Developer Tools page?

## Next PR candidates

- Add README for `WORKSHOP_07`
- Add README for `ws/tmu2025`
- Add fuller README for `apps/ORPHE-TERMINAL`
