### PR TITLE
public-candidate向けREADMEを追加

### DIFF
--- a/apps/ORPHE-TERMINAL/README.md
+++ b/apps/ORPHE-TERMINAL/README.md
@@ -1,1 +1,54 @@
-# ORPHE-TERMINAL
+# ORPHE TERMINAL
+
+ORPHE TERMINAL is a developer utility for inspecting raw ORPHE CORE
+characteristic data in the browser.
+
+## What It Does
+
+- Connects one ORPHE CORE with CoreToolkit.js.
+- Reads and writes Device Information.
+- Reads and writes Date Time.
+- Streams `SENSOR_VALUES`.
+- Shows raw byte data in text areas.
+- Can export buffered data as CSV.
+
+## Intended Audience
+
+This is a developer/debugging tool. It is not a beginner tutorial and should be
+listed separately from playful examples or starter templates.
+
+## Requirements
+
+- Chrome with Web Bluetooth support.
+- One ORPHE CORE module.
+- Local server such as `python3 -m http.server 8767`.
+
+## Run
+
+Open:
+
+```text
+http://localhost:8767/apps/ORPHE-TERMINAL/
+```
+
+Then connect ORPHE CORE from the CoreToolkit switch.
+
+## Validation
+
+Needs real-device validation before promotion from `public-candidate` to
+`public`.
+
+Human checks:
+
+- Page opens.
+- ORPHE CORE connects in Chrome.
+- Device Information read/write works.
+- Date Time read/write works.
+- SENSOR_VALUES stream updates.
+- Download buttons create CSV files.
+
+## Notes
+
+- This tool uses lower-level raw byte displays. It should remain in a
+  developer-tool category.
+- Do not treat it as a recommended first example for new users.

--- a/examples/WORKSHOP_07/README.md
+++ b/examples/WORKSHOP_07/README.md
@@ -1,0 +1,50 @@
+# Workshop #7 / #8: DFT and FFT
+
+This workshop example shows how to use ORPHE CORE sensor data as a signal for
+Fourier transform / DFT exercises.
+
+## What It Does
+
+- Connects one ORPHE CORE with CoreToolkit.js.
+- Reads `SENSOR_VALUES`.
+- Uses acceleration data as a time-series signal.
+- Visualizes the original signal and a simple DFT-style frequency view.
+
+## Why It Exists
+
+This is workshop material, not a polished beginner app. It is useful when the
+goal is to teach signal processing concepts with real foot motion data.
+
+## Requirements
+
+- Chrome with Web Bluetooth support.
+- One ORPHE CORE module.
+- Local server such as `python3 -m http.server 8767`.
+
+## Run
+
+Open:
+
+```text
+http://localhost:8767/examples/WORKSHOP_07/
+```
+
+Then connect ORPHE CORE from the CoreToolkit switch.
+
+## Validation
+
+Needs real-device validation before promotion from `public-candidate` to
+`public`.
+
+Human checks:
+
+- Page opens.
+- ORPHE CORE connects in Chrome.
+- Acceleration data changes the plotted waveform.
+- The DFT / frequency display is understandable for workshop use.
+
+## Notes
+
+- This page consolidates the old Workshop #7 and Workshop #8 samples.
+- It should probably stay under a workshop/archive category rather than the
+  beginner Examples path.

--- a/ws/tmu2025/README.md
+++ b/ws/tmu2025/README.md
@@ -1,0 +1,46 @@
+# TMU 2025 Workshop Gallery
+
+This directory is a gallery of student / workshop projects made with ORPHE CORE.
+
+## What It Does
+
+- Shows multiple workshop works in one gallery page.
+- Links to individual project pages under `ws/tmu2025/apps/`.
+- Provides a reference for what people can build with ORPHE CORE in a workshop.
+
+## Requirements
+
+Most pages are project showcases. Some individual apps may require:
+
+- Chrome with Web Bluetooth support.
+- One or two ORPHE CORE modules.
+- Local server such as `python3 -m http.server 8767`.
+
+## Run
+
+Open:
+
+```text
+http://localhost:8767/ws/tmu2025/
+```
+
+## Validation
+
+Needs human review before promotion from `public-candidate` to `public`.
+
+Checks that do not require ORPHE CORE:
+
+- Gallery opens.
+- Project cards/images load.
+- Links to individual project pages work.
+- The page reads as a workshop gallery, not as a single maintained example.
+
+Checks that may require ORPHE CORE:
+
+- Individual apps that use BLE should be tested separately in Chrome.
+
+## Notes
+
+- Treat this as `workshop-archive`.
+- Strong individual works can later be split into standalone catalog entries if
+  they are maintained and documented.


### PR DESCRIPTION
## Summary

- `examples/WORKSHOP_07/README.md` を追加しました
- `ws/tmu2025/README.md` を追加しました
- `apps/ORPHE-TERMINAL/README.md` を開発者向けツールとして読める内容に拡充しました

## Validation

- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `curl -I http://localhost:8767/examples/WORKSHOP_07/`
- `curl -I http://localhost:8767/ws/tmu2025/`

## Needs real-device validation

- No for this PR. It adds documentation only.
- The documented pages/tools still need real-device validation before promotion to `public`.

## Out of scope

- Does not change example behavior
- Does not promote any entry to `public`
- Does not move workshop/developer-tool entries in the catalog

## Questions for human

- Should workshop archive entries stay visible in the main examples gallery?
- Should ORPHE TERMINAL eventually move to a separate Developer Tools navigation?

## Next PR candidates

- Catalog metadata polish for workshop/developer-tool entries
- ORPHE TERMINAL UI/static check pass
