### PR TITLE
公開ゲームExampleのORPHE-CORE.js参照をローカル化

### DIFF
--- a/examples/GAME-DDR/index.html
+++ b/examples/GAME-DDR/index.html
@@ -118,7 +118,7 @@
     </div>
 
     <!-- Scripts -->
-    <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+    <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>

--- a/examples/GAME-MARIO/index.html
+++ b/examples/GAME-MARIO/index.html
@@ -163,7 +163,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.1/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/addons/p5.sound.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+  <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"

--- a/examples/GAME-PINGPONG/index.html
+++ b/examples/GAME-PINGPONG/index.html
@@ -82,7 +82,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.1/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.0/addons/p5.sound.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+  <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous" type="text/javascript"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"

--- a/examples/GAME-UDON/index.html
+++ b/examples/GAME-UDON/index.html
@@ -37,8 +37,7 @@
             quickly and thinly you can make it!</p>
 
 
-        <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-            type="text/javascript"></script>
+        <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous" type="text/javascript"></script>
         <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"
             type="text/javascript"></script>
   <script src="../../js/BleSharedBridge.js"></script>

--- a/examples/MOVEYOURFEET/index.html
+++ b/examples/MOVEYOURFEET/index.html
@@ -52,8 +52,7 @@
 
 
 
-    <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script>
+    <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous" type="text/javascript"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js" crossorigin="anonymous"
         type="text/javascript"></script>
   <script src="../../js/BleSharedBridge.js"></script>


### PR DESCRIPTION
## Summary

- Public game examples that were loading `ORPHE-CORE.js@main` from jsDelivr now load the local repository copy instead
- Updated:
  - `examples/GAME-UDON/`
  - `examples/MOVEYOURFEET/`
  - `examples/GAME-PINGPONG/`
  - `examples/GAME-DDR/`
  - `examples/GAME-MARIO/`

## Validation

- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `curl -I http://localhost:8767/examples/GAME-UDON/`
- `curl -I http://localhost:8767/examples/MOVEYOURFEET/`
- `curl -I http://localhost:8767/examples/GAME-PINGPONG/`
- `curl -I http://localhost:8767/examples/GAME-DDR/`
- `curl -I http://localhost:8767/examples/GAME-MARIO/`

## Needs real-device validation

- Yes before making any new behavior claims. This PR only changes script source paths.

## Out of scope

- Does not change game logic
- Does not change BLE thresholds or notification types
- Does not touch starter template comments / optional helper CDN references

## Questions for human

- None for this PR.

## Next PR candidates

- Decide whether starter templates should keep commented CDN snippets or remove them from static audit warnings
- Align optional `quaternion.js` helper references separately if needed
