### PR TITLE
Action gameの旧名称メモを整理

### DIFF
--- a/examples/GAME-FIREBALL-MARIO/game.js
+++ b/examples/GAME-FIREBALL-MARIO/game.js
@@ -603,7 +603,7 @@
       this.setupKeyboard();
       this.loop();
 
-      console.log('[GAME] Fireball Mario initialized');
+      console.log('[GAME] Fireball Action initialized');
     }
 
     initClouds() {

--- a/examples/GAME-FIREBALL-MARIO/main.js
+++ b/examples/GAME-FIREBALL-MARIO/main.js
@@ -1,5 +1,5 @@
 /**
- * ORPHE CORE Integration for Fireball Mario Game
+ * ORPHE CORE Integration for Fireball Action Game
  *
  * Sensor Mapping:
  * - Walking (steps) → Character moves forward

--- a/examples/GAME-MARIO/sketch.js
+++ b/examples/GAME-MARIO/sketch.js
@@ -1005,7 +1005,7 @@ function drawPlayer(p) {
     translate(-p.w, 0);
   }
   
-  // スモールマリオの場合、サイズ調整
+  // 小さい状態の場合、サイズ調整
   if (p.powerState === 'small') {
     scale(0.7, 0.7);
     translate(p.w * 0.15, p.h * 0.3);
@@ -1251,12 +1251,12 @@ function handlePlayerDamage() {
   player.vy = -300;
   
   if (player.powerState === 'big') {
-    // ビッグから小さいマリオへ
+    // 大きい状態から小さい状態へ
     player.powerState = 'small';
     player.h = 30; // 高さを小さく
     score = max(0, score - 50);
   } else {
-    // 小さいマリオからゲームオーバー
+    // 小さい状態からゲームオーバー
     gameOver();
   }
 }

--- a/examples/GAME-PK/README.md
+++ b/examples/GAME-PK/README.md
@@ -37,7 +37,7 @@ GitHub Pagesでも試せます。
 
 ## 関連example
 
-- [`examples/GAME-FIREBALL-MARIO/`](../GAME-FIREBALL-MARIO/README.md) — Fireball Mario
+- [`examples/GAME-FIREBALL-MARIO/`](../GAME-FIREBALL-MARIO/README.md) — Fireball Action
 - [`examples/GAME-SHOOTING2/`](../GAME-SHOOTING2/README.md) — 3D Shooting Game
 
 ## 元データ

--- a/ws/tmu2025/apps/8.html
+++ b/ws/tmu2025/apps/8.html
@@ -1081,7 +1081,7 @@
             }
             
             function drawCloud(x, y) {
-                // マリオ風の雲（モコモコした形）
+                // モコモコした雲
                 p.fill(255);
                 p.ellipse(x, y, 60, 40);
                 p.ellipse(x + 25, y - 5, 50, 35);
@@ -2563,4 +2563,3 @@
     </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- Public-adjacent action game naming is cleaned up without changing URLs or behavior.
- `Fireball Mario` log/comment/link text is changed to `Fireball Action`.
- Internal Japanese comments in `GAME-MARIO` no longer use the character-specific name.

## Validation
- `git diff --check`
- `node --check examples/GAME-FIREBALL-MARIO/main.js`
- `node --check examples/GAME-FIREBALL-MARIO/game.js`
- `node --check examples/GAME-MARIO/sketch.js`
- `curl -I http://localhost:8767/examples/GAME-FIREBALL-MARIO/`
- `curl -I http://localhost:8767/examples/GAME-MARIO/`
- `curl -I http://localhost:8767/examples/GAME-PK/`
- `curl -I http://localhost:8767/ws/tmu2025/apps/8.html`

## Needs real-device validation
- None. This PR only changes comments, console text, and README link text.

## Out of scope
- Directory renames such as `GAME-FIREBALL-MARIO/` or `GAME-MARIO/`.
- Game logic, BLE logic, thresholds, and sensor processing.

## Questions for human
- Should directory names be renamed in a future compatibility-managed PR, or should we keep them as legacy paths?

## Next PR candidates
- Continue replacing internal/developer-only legacy naming in older audit docs if needed.
