### PR TITLE
docs: add Tier 1 lesson plans (45-min class drafts)

### DIFF
--- a/docs/in-flight.md
+++ b/docs/in-flight.md
@@ -1,6 +1,6 @@
 # In-flight Work
 
-Last updated: 2026-05-03 00:05 JST
+Last updated: 2026-05-03 (Claude Tier 1 reconstruction sprint)
 
 This file is a lightweight coordination board for humans, Codex, and Claude. It is not a changelog. Keep it short and update it before starting or ending a multi-file task.
 
@@ -18,8 +18,15 @@ This file is a lightweight coordination board for humans, Codex, and Claude. It 
 
 | Agent | Branch | Purpose | Files / Areas | Status | Last Update | Notes |
 |---|---|---|---|---|---|---|
-| Codex | codex/examples-static-quality-audit | Static quality audit and safe checks for existing examples | `scripts/check-examples-static-quality.js`, `docs/examples-static-quality-audit.md`, `docs/in-flight.md` | active | 2026-05-03 00:05 JST | No real-device claims. Focus on public/public-candidate example quality, links, thumbnails, titles, CoreToolkit bridge, and catalog consistency. |
+| Codex | codex/examples-static-quality-audit | Static quality audit and safe checks for existing examples | `scripts/check-examples-static-quality.js`, `docs/examples-static-quality-audit.md`, `docs/in-flight.md` | merged | 2026-05-03 00:05 JST | No real-device claims. Focus on public/public-candidate example quality, links, thumbnails, titles, CoreToolkit bridge, and catalog consistency. |
 | Claude | claude/research-imu-competitors-yWYtf | IMU competitor research and lesson concept | `docs/ai/` research docs | reference | 2026-05-02 23:35 JST | Research should inform roadmap, not directly edit core SDK. |
+| Claude | claude/lessons-tier1-draft | Tier 1 lesson plans (45-min class drafts) | `docs/lessons/*` | active | 2026-05-03 JST | 6 lessons: Step Count Dashboard / Stride & Cadence / L/R Symmetry / CSV Recorder / Replay Player / Vertical Jump (CMJ). No core SDK or catalog edits. |
+| Claude | claude/core-analytics-api-draft | `CoreAnalytics.js` API draft (session summary, baseline, symmetry, CMJ) | `js/CoreAnalytics.js` | planned | 2026-05-03 JST | New file only, opt-in feed* methods over existing callbacks. Codex review needed before any example consumes it as stable. |
+| Claude | claude/core-recorder-api-draft | `CoreRecorder.js` API draft (CSV/JSON schema 0.0.1-draft, fromJSON roundtrip) | `js/CoreRecorder.js` | planned | 2026-05-03 JST | New file only. Does not modify `examples/SENSOR-CALIBRATION/recorder.js`. Codex review needed for schema. |
+| Claude | claude/example-csv-recorder-poc | New `examples/CSV-RECORDER/` PoC (depends on `CoreRecorder.js` PR) | `examples/CSV-RECORDER/*` | planned | 2026-05-03 JST | Uses CoreToolkit; calls `guardCoreToolkitBluetooth({ coreIds: [0] })`. Catalog metadata proposed in README, not edited in `examples/catalog.json`. |
+| Claude | claude/example-step-count-dashboard-poc | New `examples/STEP-COUNT-DASHBOARD/` PoC (depends on `CoreAnalytics.js` PR) | `examples/STEP-COUNT-DASHBOARD/*` | planned | 2026-05-03 JST | Uses CoreToolkit; calls `guardCoreToolkitBluetooth({ coreIds: [0] })`. Includes baseline-comparison panel. |
+| Claude | claude/example-replay-player-poc | New `examples/REPLAY-PLAYER/` PoC (depends on `CoreRecorder.js` PR) | `examples/REPLAY-PLAYER/*` | planned | 2026-05-03 JST | Ships synthetic `sample-session.js` so the page boots without hardware. Uses CoreToolkit only as an optional live-feed path. |
+| Claude | claude/handoff-2026-05-03 | Session handoff doc | `docs/ai/claude-handoff-2026-05-03.md` | planned | 2026-05-03 JST | Records Tier 1 sprint state, dependency order, and what each PR still needs from a human owner. |
 
 ## Planned Work
 

--- a/docs/lessons/01-step-count-dashboard.md
+++ b/docs/lessons/01-step-count-dashboard.md
@@ -1,0 +1,151 @@
+# Lesson 01: Step Count Dashboard
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: introductory sports science, HCI, or physical computing students
+  with basic JavaScript reading ability.
+- Devices: 1 ORPHE CORE per learner pair.
+- Notification: `STEP_ANALYSIS`.
+- Example: `examples/STEP-COUNT-DASHBOARD/` (planned in a sibling PR). Until it
+  lands, run the lesson against `examples/CORETOOLKIT-STARTER/` and use the
+  console to inspect `gotGait` / `gotStepsNumber`.
+- Browser: Chrome on macOS or Windows. Safari and Firefox cannot use Web
+  Bluetooth.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Explain why a foot-mounted IMU can count steps even when the wearer is
+   walking in place, and where that breaks down.
+2. Read the difference between an event-driven `STEP_ANALYSIS` callback and a
+   high-rate `SENSOR_VALUES` callback.
+3. Modify a small dashboard to add a new metric (for example, the moving
+   average of cadence over the last 10 steps).
+
+## Required materials
+
+- One laptop per pair, charged, on a campus or guest network.
+- One ORPHE CORE module per pair, charged, with the foot mount attached.
+- A 3 m straight walking lane and a 5 m lane.
+- Stopwatch on the instructor's phone for the validation activity.
+
+## Pre-class setup
+
+The instructor should:
+
+- Clone the repo and run `python3 -m http.server 8767` from the repo root.
+- Confirm `examples/STEP-COUNT-DASHBOARD/index.html` (or
+  `examples/CORETOOLKIT-STARTER/index.html` as the fallback) opens in Chrome and
+  the CoreToolkit switch is enabled.
+- Pre-pair the demo ORPHE CORE so the instructor demo doesn't burn class time on
+  the device chooser.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show one walking demo. Ask learners to predict what the dashboard reports and what it cannot infer. |
+| 5–15 min | Concept | Walk through `STEP_ANALYSIS` vs `SENSOR_VALUES` using the side-by-side table from `CLAUDE.md`. Explain why this lesson uses the lower-rate event stream. |
+| 15–35 min | Hands-on | Pairs walk a 5 m lane three times: normal pace, deliberately small steps, and walking in place. They record the dashboard's step count and the human-counted step count for each trial. |
+| 35–42 min | Modify | Add one of the suggested code snippets (see "Modification ideas") to the example and re-run a single 5 m trial. |
+| 42–45 min | Debrief | Each pair reports one moment where the device count and the human count diverged and proposes a hypothesis. |
+
+## Hands-on activity
+
+Pairs use the planned `examples/STEP-COUNT-DASHBOARD/` page (or
+`examples/CORETOOLKIT-STARTER/` with the developer console showing
+`gotStepsNumber` updates) and complete this trial table:
+
+| Trial | Description | Human-counted steps | Device-counted steps | Notes |
+|---|---|---|---|---|
+| 1 | Normal pace, 5 m lane | | | |
+| 2 | Deliberately tiny steps, 5 m lane | | | |
+| 3 | Walking in place for 20 s | | | |
+
+The point of trial 2 is to surface that step detection has a minimum signal
+threshold, and the point of trial 3 is to surface that the device measures foot
+events, not floor displacement.
+
+## Modification ideas
+
+Have learners add one of the following to the dashboard's `<script>` block. The
+exact API names match the planned `examples/STEP-COUNT-DASHBOARD/` example; if
+you are using `CORETOOLKIT-STARTER` as a fallback, attach the same logic to
+`bles[0].gotGait`.
+
+```javascript
+// 1. Show the rolling 10-step cadence in steps/min.
+let stepTimestamps = [];
+ble.gotGait = function () {
+  stepTimestamps.push(performance.now());
+  if (stepTimestamps.length > 10) stepTimestamps.shift();
+  if (stepTimestamps.length >= 2) {
+    const elapsedSec = (stepTimestamps.at(-1) - stepTimestamps[0]) / 1000;
+    const cadence = ((stepTimestamps.length - 1) / elapsedSec) * 60;
+    document.getElementById('cadence').textContent = cadence.toFixed(0);
+  }
+};
+
+// 2. Show the swing/stance ratio.
+ble.gotGait = function (gait) {
+  const swing = gait.swing_phase_duration ?? 0;
+  const stance = gait.standing_phase_duration ?? 0;
+  if (stance > 0) {
+    document.getElementById('ratio').textContent = (swing / stance).toFixed(2);
+  }
+};
+```
+
+## Discussion prompts
+
+- "Where would you trust a foot-mounted step count more than a wrist-mounted
+  one, and where would you trust the wrist more?"
+- "If you wanted to compare two students' step counts, what new question would
+  you have to answer about the device or the protocol?"
+- "What does it mean that the device gives you both `steps` on `gait` and a
+  separate `gotStepsNumber` callback?" Use this to introduce the idea that
+  redundant signals exist for different application styles.
+
+## Assessment ideas
+
+- A two-paragraph reflection naming one limitation of the dashboard for a
+  rehabilitation context. Look for whether learners recognize that step count
+  alone does not describe gait quality.
+- A small code change reviewed in pairs. The grade is on whether the code reads
+  and stops cleanly, not on bytes added.
+
+## Safety and ethics
+
+- The ORPHE CORE module is small and falls inside the shoe, so the only
+  physical risk is dropping the laptop while learners switch shoes. Have
+  learners sit while attaching the module.
+- Treat all step counts as personal data for the duration of the class and have
+  learners delete browser localStorage for the example after class if any
+  identifying notes were typed in.
+
+## References
+
+- Whittle, M. W. _Gait Analysis: An Introduction_. 5th ed., Churchill
+  Livingstone, 2014. Chapter on the gait cycle for swing/stance terminology.
+- Bouten, C. V. C. et al. "A Triaxial Accelerometer and Portable Data Processing
+  Unit for the Assessment of Daily Physical Activity." _IEEE Transactions on
+  Biomedical Engineering_, vol. 44, no. 3, 1997. Used to anchor the lesson's
+  framing of why a foot IMU is a reasonable activity sensor.
+
+## Out of scope
+
+- Comparisons to clinical gold-standard gait labs. Mention as a follow-up
+  research direction, not a class deliverable.
+- Statistical tests on the trial table. Defer to a follow-up methods class.
+
+## Open questions for the human owner
+
+- Should the dashboard expose step count from `gotGait.steps` or from
+  `gotStepsNumber`? Decide before this lesson is published so the activity
+  matches the example.
+- Do we want a printable trial table for classroom use? If yes, generate from
+  this Markdown rather than maintaining a parallel PDF.

--- a/docs/lessons/02-stride-and-cadence.md
+++ b/docs/lessons/02-stride-and-cadence.md
@@ -1,0 +1,139 @@
+# Lesson 02: Stride & Cadence
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: introductory sports science, kinesiology, or applied data students
+  who have completed Lesson 01 or an equivalent.
+- Devices: 1 ORPHE CORE per learner pair.
+- Notification: `STEP_ANALYSIS`.
+- Example: `examples/STEP-COUNT-DASHBOARD/` _(planned)_, with the stride and
+  cadence panels enabled. Until it lands, run the lesson against
+  `examples/CORETOOLKIT-STARTER/` and inspect `bles[0].gotStride` and
+  `bles[0].gotGait` from the developer console.
+- Browser: Chrome on macOS or Windows.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Define stride length and cadence in their own words and explain why they are
+   complementary, not interchangeable.
+2. Read a `gotStride` payload (`{x, y, z, steps_number}`) and explain why the
+   `x` component dominates for forward walking.
+3. Decide when stride length is more informative than step count for a given
+   research or product question.
+
+## Required materials
+
+- One laptop per pair, charged.
+- One ORPHE CORE per pair, charged.
+- A 10 m walking lane with a measuring tape laid alongside it.
+- Painter's tape to mark a start line and a turn-around line.
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm the local server is running.
+- Confirm the planned example or `CORETOOLKIT-STARTER` opens cleanly in Chrome.
+- Print or sketch a simple cadence-vs-stride scatter plot on the board so the
+  class has a shared mental model before learners collect data.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Define stride length and cadence verbally and on the board. Ask: "Two runners cover 100 m in the same time. How might their stride and cadence differ?" |
+| 5–15 min | Concept | Walk through the `gait` and `stride` payloads. Highlight that `gait.steps` is a count, `gait.standing_phase_duration` and `swing_phase_duration` are seconds, and `stride` is a 3-axis displacement in meters. |
+| 15–35 min | Hands-on | Pairs walk a 10 m lane four times: normal pace, fast pace, deliberately long stride, deliberately fast cadence. They record cadence and average stride per trial. |
+| 35–42 min | Plot | Pairs sketch their four points on a cadence (x) vs stride length (y) plot. |
+| 42–45 min | Debrief | Pairs share which trial surprised them and why. |
+
+## Hands-on activity
+
+For each trial, learners walk 10 m, then read off:
+
+- `cadence` = (steps reported during the trial / trial duration in seconds) × 60.
+- `average stride` = mean of the magnitudes of the `gotStride` payloads received
+  during the trial. The planned dashboard surfaces this as a number; the
+  fallback path is to push each `Math.hypot(stride.x, stride.y, stride.z)` into
+  an array and average it after the trial.
+
+| Trial | Description | Cadence (steps/min) | Avg stride (m) | Notes |
+|---|---|---|---|---|
+| 1 | Normal pace | | | |
+| 2 | Fast pace | | | |
+| 3 | Deliberately long stride | | | |
+| 4 | Deliberately fast cadence | | | |
+
+The expected pattern is that trials 3 and 4 sit on opposite axes of the cadence
+vs stride plot, which makes the trade-off concrete.
+
+## Code snippet for the fallback path
+
+If learners are using `CORETOOLKIT-STARTER` because the planned dashboard has
+not landed yet, paste the following into the developer console after the
+CoreToolkit switch is on:
+
+```javascript
+window.strideSamples = [];
+bles[0].gotStride = function (stride) {
+  const magnitude = Math.hypot(stride.x ?? 0, stride.y ?? 0, stride.z ?? 0);
+  window.strideSamples.push({ t: performance.now(), magnitude, stride });
+};
+function strideStats() {
+  const ms = window.strideSamples.map(s => s.magnitude);
+  const mean = ms.reduce((a, b) => a + b, 0) / (ms.length || 1);
+  return { count: ms.length, meanMeters: mean };
+}
+```
+
+After each trial, call `strideStats()` in the console and clear
+`window.strideSamples = []` before the next trial.
+
+## Discussion prompts
+
+- "Stride length is reported on three axes. When would the y or z component
+  matter as much as x?" Use this to introduce lateral movement and ramps.
+- "If two learners report the same average stride, but the variance is very
+  different, what hypotheses do you have about their gait?"
+- "Cadence is convenient because it is one number. What does that convenience
+  cost you compared to stride length?"
+
+## Assessment ideas
+
+- A short written analysis: pick one of the four trials and describe what a
+  coach or clinician would actually do with the cadence and stride numbers.
+- A code review where learners explain why `Math.hypot` is used instead of
+  reading `stride.x` directly.
+
+## Safety and ethics
+
+- Use a clear lane with no foot traffic. Spotters at each end during fast trials
+  if the room is small.
+- The lesson can produce gait data that, in aggregate, can identify a learner.
+  Treat the trial table as personal data for the class and discard.
+
+## References
+
+- Perry, J. and Burnfield, J. M. _Gait Analysis: Normal and Pathological
+  Function_. 2nd ed., SLACK Inc., 2010. Chapter on stride and cadence
+  terminology.
+- Cavagna, G. A. and Margaria, R. "Mechanics of Walking." _Journal of Applied
+  Physiology_, vol. 21, no. 1, 1966. Use as the historical reference for the
+  cadence/stride trade-off.
+
+## Out of scope
+
+- Energetics or VO2 estimation. The example does not measure metabolic load.
+- Treadmill calibration. Lesson assumes overground walking.
+
+## Open questions for the human owner
+
+- Should the planned dashboard show stride magnitude, or each component? Decide
+  before this lesson is published so the activity matches the example.
+- Do we expose cadence as steps/minute or as Hz? Pick one for consistency across
+  Tier 1 lessons.

--- a/docs/lessons/03-lr-symmetry.md
+++ b/docs/lessons/03-lr-symmetry.md
@@ -1,0 +1,162 @@
+# Lesson 03: Left/Right Symmetry
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students who have completed Lessons 01 and 02 and are comfortable
+  switching between two CoreToolkit instances.
+- Devices: 2 ORPHE CORE modules per learner pair, one per foot. The lesson can
+  fall back to a one-device protocol where the same learner walks twice (once
+  per foot) and the data is compared post hoc.
+- Notification: `STEP_ANALYSIS`.
+- Example: dual-device variant of the planned `examples/STEP-COUNT-DASHBOARD/`,
+  or `examples/CORETOOLKIT-STARTER/` opened twice with `bles[0]` and `bles[1]`
+  bound to the left and right modules.
+- Browser: Chrome on macOS or Windows.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Define the symmetry index used in the lesson and explain what it does and
+   does not capture about gait.
+2. Identify at least two physiological reasons two healthy walkers might show
+   stable, non-zero asymmetry.
+3. Use a paired left/right ORPHE CORE setup to compute symmetry from cadence,
+   swing time, and stride length.
+
+## Required materials
+
+- One laptop per pair, charged.
+- Two ORPHE CORE modules per pair, charged. One mounted on the left shoe and
+  one on the right shoe.
+- A 10 m walking lane.
+- The trial table from Lesson 02 (cadence and stride values are reused).
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm that two CoreToolkit switches initialize and that the device chooser
+  can distinguish the two modules. Pre-pair both before class.
+- Confirm `bles[0].id === 0` and `bles[1].id === 1` after both connect, since
+  the lesson uses `this.id` inside callbacks.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show a short video or live demo of two walkers, one with and one without a mild asymmetry. Ask: "How would you measure that the walkers are different without saying which is 'normal'?" |
+| 5–15 min | Concept | Introduce the symmetry index used here: SI = 2 × (R − L) / (R + L) × 100. Discuss why the absolute value is what is reported in most studies and why a zero SI does not mean a perfectly symmetric gait. |
+| 15–35 min | Hands-on | Pairs walk a 10 m lane three times. They record left and right cadence, swing time, and stride magnitude per trial, then compute SI for each metric. |
+| 35–42 min | Compare | Pairs swap modules to check for device bias: rerun trial 1 with the left and right modules switched. |
+| 42–45 min | Debrief | Each pair reports one source of asymmetry that came from the device, the protocol, or the human, and proposes how to control for it. |
+
+## Hands-on activity
+
+For each trial, learners record per foot:
+
+- `cadence_L`, `cadence_R` from `gotGait` events.
+- `swing_L`, `swing_R` from `gait.swing_phase_duration`.
+- `stride_L`, `stride_R` from the magnitude of `gotStride`.
+
+For each metric `M`, learners compute:
+
+```
+SI = 2 × |R − L| / (R + L) × 100   // Robinson symmetry index, percent
+```
+
+| Trial | Description | Cadence SI | Swing SI | Stride SI | Notes |
+|---|---|---|---|---|---|
+| 1 | Normal pace | | | | |
+| 2 | Carrying a bag in the right hand | | | | |
+| 3 | Trial 1 with modules swapped | | | | |
+
+The expected discussion is that trial 2 shifts SI in a known direction and
+trial 3 shows whether the shift came from the body or from the modules.
+
+## Code snippet for the fallback path
+
+If the planned dashboard is not yet available, learners can collect data from
+`CORETOOLKIT-STARTER` opened with both switches on, then run:
+
+```javascript
+window.lr = { 0: [], 1: [] };
+[0, 1].forEach(function (id) {
+  bles[id].gotGait = function (gait) {
+    window.lr[this.id].push({
+      t: performance.now(),
+      steps: gait.steps,
+      swing: gait.swing_phase_duration,
+      stance: gait.standing_phase_duration,
+    });
+  };
+  bles[id].gotStride = function (stride) {
+    window.lr[this.id].push({
+      t: performance.now(),
+      strideMag: Math.hypot(stride.x ?? 0, stride.y ?? 0, stride.z ?? 0),
+    });
+  };
+});
+
+function summarize(samples, key) {
+  const values = samples.map(s => s[key]).filter(v => typeof v === 'number');
+  return values.reduce((a, b) => a + b, 0) / (values.length || 1);
+}
+
+function symmetryIndex(left, right) {
+  return (2 * Math.abs(right - left)) / (right + left) * 100;
+}
+```
+
+## Discussion prompts
+
+- "Why is symmetry not a goal in itself?" Use to introduce the idea that
+  asymmetry can be functional (e.g., dominant kicking leg in soccer).
+- "Your SI is 4% on cadence but 18% on stride. Which one would you investigate
+  first and why?"
+- "What part of this protocol is sensitive to mounting?" Use to motivate the
+  module-swap trial.
+
+## Assessment ideas
+
+- A short report (one page) describing the symmetry pattern of one learner
+  across three trials, with one paragraph on what would have to be true for
+  this number to mean something clinical.
+- A code reading exercise where learners trace why `this.id` is `0` or `1`
+  inside the gait callback (it must be a regular function, not an arrow
+  function).
+
+## Safety and ethics
+
+- Asymmetry data can feel personal. Do not require learners to share their own
+  numbers; allow opting out and using a peer's anonymized data for the
+  reflection.
+- Two-module setups require two BLE pairings, so plan for an extra 2–3 minutes
+  per pair on the first run.
+
+## References
+
+- Robinson, R. O., Herzog, W., and Nigg, B. M. "Use of Force Platform
+  Variables to Quantify the Effects of Chiropractic Manipulation on Gait
+  Symmetry." _Journal of Manipulative and Physiological Therapeutics_, vol. 10,
+  no. 4, 1987. Use as the original source of the SI formula.
+- Sadeghi, H. et al. "Symmetry and Limb Dominance in Able-Bodied Gait: A
+  Review." _Gait & Posture_, vol. 12, no. 1, 2000. Use to ground the discussion
+  that asymmetry is normal.
+
+## Out of scope
+
+- Statistical inference on small N. Lesson treats SI as a descriptive number.
+- Mediolateral COP analysis. ORPHE CORE is an inertial sensor, not a pressure
+  insole. Mention as a follow-up technology comparison.
+
+## Open questions for the human owner
+
+- Should the planned dashboard surface SI directly or only the per-foot
+  numbers? If it computes SI, lock the formula to the Robinson SI used here so
+  the lesson and the example agree.
+- Do we want a sample dataset of left/right walking shipped in the example so
+  this lesson can be run without two devices?

--- a/docs/lessons/04-csv-recorder.md
+++ b/docs/lessons/04-csv-recorder.md
@@ -1,0 +1,153 @@
+# Lesson 04: CSV Recorder
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students who can read JavaScript and have used a spreadsheet for
+  basic data analysis. No prior recording experience required.
+- Devices: 1 ORPHE CORE per learner pair.
+- Notification: `STEP_ANALYSIS_AND_SENSOR_VALUES`.
+- Example: `examples/CSV-RECORDER/` _(planned in a sibling PR)_. Until it
+  lands, run the lesson against `examples/SENSOR-CALIBRATION/`, which already
+  records CSV in the existing recorder; do not modify that example for the
+  lesson.
+- Browser: Chrome on macOS or Windows.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Explain why a recorded CSV file from an IMU is not the same as a clean
+   dataset, and identify three things that have to be decided before recording.
+2. Record a session, describe the schema of the resulting CSV, and replay or
+   plot it in any spreadsheet or notebook.
+3. Add one new column to the recorder by defining what value goes into it and
+   what timestamp it is anchored to.
+
+## Required materials
+
+- One laptop per pair, charged.
+- One ORPHE CORE per pair, charged.
+- A short walking lane (5 m is enough).
+- A spreadsheet (Google Sheets, Excel, or Numbers) for the post-recording
+  inspection.
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm that the planned recorder example or `SENSOR-CALIBRATION` opens in
+  Chrome and the recording controls work.
+- Have a sample CSV from a previous run open in the spreadsheet so the class
+  can see the target format before they collect their own data.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show a 5 s recorded CSV. Ask: "What three decisions did the recorder make for you, and which one would you most want to change?" |
+| 5–15 min | Concept | Walk through the schema: each row is one sample, columns are timestamp, sample type, and the per-callback fields. Explain why `gotAcc` and `gotConvertedAcc` need different rows or different columns and which the lesson uses. |
+| 15–35 min | Hands-on | Pairs record three sessions: 10 s of standing still, 10 s of normal walking, 10 s of stomping in place. They open each CSV in a spreadsheet and inspect at least one cell per sample type. |
+| 35–42 min | Modify | Pairs add a column to the recorder for either device id or notification type and re-record one session. |
+| 42–45 min | Debrief | Each pair reports one column they wished was already there and what they would use it for. |
+
+## Hands-on activity
+
+Each pair fills in this inspection table for the three sessions. Cell values
+are read directly from the spreadsheet view of the CSV.
+
+| Session | Sample types observed | First timestamp | Last timestamp | Approx. samples per second | Notes |
+|---|---|---|---|---|---|
+| Standing | | | | | |
+| Walking | | | | | |
+| Stomping | | | | | |
+
+Expected outcomes:
+
+- Standing should have very low gait events but normal `gotConvertedAcc` rates.
+- Stomping should produce many `gait` and `landing impact` rows and saturate
+  the accelerometer if the range is set to 2 G — this is a good moment to
+  return to `CLAUDE.md`'s sensor range guidance.
+- Walking should fall in between.
+
+## Code snippet for the fallback path
+
+If learners are using `SENSOR-CALIBRATION` because the planned example has not
+landed yet, do not edit the existing recorder. Instead, attach a parallel
+listener for inspection only:
+
+```javascript
+window.lessonSamples = [];
+const ble = bles[0];
+ble.gotConvertedAcc = function (acc) {
+  window.lessonSamples.push({ t: Date.now(), kind: 'acc', x: acc.x, y: acc.y, z: acc.z });
+};
+ble.gotGait = function (gait) {
+  window.lessonSamples.push({ t: Date.now(), kind: 'gait', steps: gait.steps, swing: gait.swing_phase_duration });
+};
+function downloadLessonCSV() {
+  const header = 't,kind,x,y,z,steps,swing\n';
+  const rows = window.lessonSamples.map(s =>
+    `${s.t},${s.kind},${s.x ?? ''},${s.y ?? ''},${s.z ?? ''},${s.steps ?? ''},${s.swing ?? ''}`
+  ).join('\n');
+  const blob = new Blob([header + rows], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = Object.assign(document.createElement('a'), { href: url, download: 'lesson-04.csv' });
+  a.click();
+  URL.revokeObjectURL(url);
+}
+```
+
+This is a teaching helper, not the recorder API. The planned `CoreRecorder.js`
+helper provides a real, opt-in feed-based recorder.
+
+## Discussion prompts
+
+- "If two learners record the same walk, why would their CSVs be different
+  shapes?" Use to introduce the idea that recordings are sampled, not
+  continuous.
+- "What is the right timestamp for an analysis you have not designed yet?"
+  Discuss the trade-off between `performance.now()`, `Date.now()`, and the
+  device-emitted timestamp where available.
+- "If you wanted to share this CSV publicly, what would you remove or
+  anonymize?"
+
+## Assessment ideas
+
+- A one-page reflection describing the schema of a recorded CSV and one column
+  the learner would add, with the new column's definition.
+- A code review where learners explain why the `gotAcc` and `gotConvertedAcc`
+  callbacks both exist and which one they used.
+
+## Safety and ethics
+
+- The recording can include enough sensor data to identify a person across
+  sessions. Treat all CSVs as personal data and do not share off the local
+  laptop without consent.
+- Do not record minors without parental consent if the cohort includes them.
+
+## References
+
+- Bouten, C. V. C. et al. "A Triaxial Accelerometer and Portable Data
+  Processing Unit for the Assessment of Daily Physical Activity." _IEEE
+  Transactions on Biomedical Engineering_, vol. 44, no. 3, 1997. Use to ground
+  the discussion of what an IMU recording is.
+- Tukey, J. W. _Exploratory Data Analysis_. Addison-Wesley, 1977. Use for the
+  framing that inspecting a recording is itself a method, not a chore.
+
+## Out of scope
+
+- File formats other than CSV. JSON support is intentionally introduced in
+  Lesson 05 (Replay Player), not here.
+- Cloud upload or remote storage. Out of scope for this lesson and not
+  supported by the planned recorder.
+
+## Open questions for the human owner
+
+- The planned `CoreRecorder.js` API uses opt-in `feedAcc` / `feedGait` calls.
+  Should this lesson teach learners to wire those calls themselves, or hide
+  them behind a single "start recording" button in the example?
+- Do we want to ship a small synthetic CSV with the example so this lesson can
+  be run without a device for at least the inspection block?

--- a/docs/lessons/05-replay-player.md
+++ b/docs/lessons/05-replay-player.md
@@ -1,0 +1,144 @@
+# Lesson 05: Replay Player
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students who have completed Lesson 04 (CSV Recorder) or have a
+  recording from a prior session. The lesson runs without a device by using a
+  shipped synthetic sample.
+- Devices: 0 (synthetic sample) or 1 (live recording at the start of class).
+- Notification: none from BLE; the player calls the same callback shapes from
+  recorded JSON.
+- Example: `examples/REPLAY-PLAYER/` _(planned in a sibling PR)_, including a
+  `sample-session.js` that boots without hardware. Until it lands, run the
+  lesson by manually feeding a JSON array into a Lesson 04 recording in the
+  developer console.
+- Browser: Chrome on macOS or Windows. Safari and Firefox are fine for replay
+  even though they cannot do live BLE.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Explain why replay is a different problem from recording, and name two
+   things a replay player must decide that a recorder did not.
+2. Step through a recorded session and inspect the same callback payloads
+   their analysis code would see live.
+3. Distinguish a clean playback (one event per real event) from a re-issued
+   playback (the same event fired multiple times) and explain when each is
+   appropriate.
+
+## Required materials
+
+- One laptop per pair, charged. No ORPHE CORE required.
+- The shipped `sample-session.js` from the planned example.
+- Optional: a CSV or JSON recording from Lesson 04 to use as a second dataset.
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm that the planned `examples/REPLAY-PLAYER/` page opens, plays the
+  shipped sample, and surfaces the timestamps and callback names as it plays.
+- If using a Lesson 04 recording, convert it to JSON ahead of time so class
+  time is spent on analysis, not format conversion.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Play the shipped sample. Ask: "If this had a bug, where in the recorder, the file, or the player would you look first?" |
+| 5–15 min | Concept | Walk through what the player does: read the JSON, sort by timestamp, schedule each callback to fire at the right relative time. Discuss real-time vs faster-than-real-time playback. |
+| 15–35 min | Hands-on | Pairs play three sessions: the shipped sample at 1×, the shipped sample at 4×, and (if available) a Lesson 04 recording at 1×. They record the elapsed playback time and the number of `gotGait` events. |
+| 35–42 min | Modify | Pairs reduce the playback to "events only" by filtering the sample to drop `gotConvertedAcc` rows in the player. They observe what their downstream callback code stops receiving. |
+| 42–45 min | Debrief | Each pair reports one assumption their analysis code made about the source of the data. |
+
+## Hands-on activity
+
+| Trial | Source | Speed | Elapsed wall time | gotGait events | gotConvertedAcc events | Notes |
+|---|---|---|---|---|---|---|
+| 1 | Shipped sample | 1× | | | | |
+| 2 | Shipped sample | 4× | | | | |
+| 3 | Lesson 04 recording (optional) | 1× | | | | |
+
+Discuss why trial 2 should produce the same number of `gotGait` events as
+trial 1 in roughly a quarter of the wall time, and why downstream code that
+uses `Date.now()` for windows breaks under faster-than-real-time playback.
+
+## Code snippet for the fallback path
+
+If the planned example has not landed yet, the lesson can run from the console
+on any page that already loads `ORPHE-CORE.js`. Drop a recorded array into the
+page and replay it through a fake `bles[0]`-shaped object:
+
+```javascript
+window.recorded = [
+  { t: 0, kind: 'gait', payload: { steps: 1, swing_phase_duration: 0.45, standing_phase_duration: 0.55, direction: 2 } },
+  { t: 480, kind: 'gait', payload: { steps: 2, swing_phase_duration: 0.46, standing_phase_duration: 0.54, direction: 2 } },
+  // ...
+];
+
+const fake = { gotGait: function (g) { console.log('gait', g); } };
+const start = performance.now();
+function playAt(speed = 1) {
+  window.recorded.forEach(function (sample) {
+    setTimeout(function () {
+      if (sample.kind === 'gait' && fake.gotGait) fake.gotGait(sample.payload);
+    }, sample.t / speed);
+  });
+}
+playAt(1);
+```
+
+This is a teaching helper, not the player API. The planned `CoreRecorder.js`
+helper provides a `replay` shape that feeds the real callback model without
+requiring the user to write the loop above.
+
+## Discussion prompts
+
+- "What does it mean for a callback that was originally driven by a sensor to
+  now be driven by a file?" Use to introduce determinism.
+- "If your analysis code uses `performance.now()` to measure elapsed time, what
+  happens during a 4× replay?" Use to motivate that the player should provide a
+  virtual clock the analysis code can opt into.
+- "Why would you ever not want a perfect replay?" Use to introduce
+  data-augmentation use cases.
+
+## Assessment ideas
+
+- A one-paragraph reflection on whether the learner's downstream analysis code
+  would survive being replayed at 4×, and what change would make it survive.
+- A small code change that adds a "skip first 2 seconds" feature to the
+  playback loop, to surface that the player is just code.
+
+## Safety and ethics
+
+- Replays remove some of the immediacy of personal data, but the underlying
+  recording is still personal. Use only the shipped sample or fully consenting
+  recordings.
+
+## References
+
+- Tukey, J. W. _Exploratory Data Analysis_. Addison-Wesley, 1977. Carry over
+  from Lesson 04 — replay is part of inspection.
+- Hilbert, M. and López, P. "The World's Technological Capacity to Store,
+  Communicate, and Compute Information." _Science_, vol. 332, no. 6025, 2011.
+  Use for a one-line framing that recorded data outlives the moment of
+  recording.
+
+## Out of scope
+
+- Networked or multi-machine replay. The lesson runs locally only.
+- Re-encoding recordings into different schemas. Stick to the JSON shape the
+  recorder produces.
+
+## Open questions for the human owner
+
+- Should the player support a virtual clock (a `now()` injected into analysis
+  code), or rely on `performance.now()` and document the trade-off? The lesson
+  can teach either, but please pick one.
+- The synthetic sample shipped with the example should be short enough to
+  iterate on (≤30 s) and long enough to show a few `gotGait` events. Confirm
+  the target length before this lesson is published.

--- a/docs/lessons/06-vertical-jump-cmj.md
+++ b/docs/lessons/06-vertical-jump-cmj.md
@@ -1,0 +1,163 @@
+# Lesson 06: Vertical Jump (Countermovement Jump)
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students with prior physics or biomechanics exposure who can read
+  a small JavaScript callback. Lesson assumes Lessons 01–02 vocabulary
+  (cadence, swing/stance) and Lesson 04's data inspection habits.
+- Devices: 1 ORPHE CORE per learner pair, mounted on the dominant foot.
+- Notification: `SENSOR_VALUES`. Use range `acc=16`, `gyro=2000` so peaks are
+  not clipped; this matches the action-game guidance in `CLAUDE.md`.
+- Example: a CMJ panel inside the planned `examples/STEP-COUNT-DASHBOARD/` or
+  a small standalone CMJ example. Until either lands, run the lesson against
+  `examples/CORETOOLKIT-STARTER/` with `STEP_ANALYSIS_AND_SENSOR_VALUES` and
+  inspect `bles[0].gotConvertedAcc` from the developer console.
+- Browser: Chrome on macOS or Windows.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Describe the four phases of a countermovement jump (CMJ): unweighting,
+   braking, propulsion, flight, and landing.
+2. Use a foot-mounted IMU to identify the unweighting and landing peaks in
+   `gotConvertedAcc` and explain why the flight phase is the part the IMU does
+   _not_ measure directly.
+3. Compute a flight-time-based jump height estimate and discuss why it
+   differs from a force-platform estimate.
+
+## Required materials
+
+- One laptop per pair, charged.
+- One ORPHE CORE per pair, charged, mounted on the dominant foot.
+- A 2 m × 2 m clear floor area per learner.
+- Optional: a phone with a slow-motion camera for cross-checking flight time.
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm the lesson page connects and the connector switch is on.
+- Run one CMJ themselves and confirm the `gotConvertedAcc` magnitude rises to
+  at least 4–5 G at landing on the chosen device, so the lesson does not chase
+  ghost peaks.
+- Lay out clear floor space and remind learners not to jump on a desk chair
+  area.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show one slow-motion CMJ if available. Ask: "Which moment of this jump do you think the foot sensor measures most directly?" |
+| 5–15 min | Concept | Walk the four-phase CMJ on the board. Explain that the IMU sees foot acceleration, not center-of-mass force, so it is excellent at marking events and weaker at amplitudes. |
+| 15–35 min | Hands-on | Pairs perform three sets of three CMJs each. Per jump, they record the timestamp of the unweighting trough and the landing peak from `gotConvertedAcc`. They derive flight time = landing time − take-off time. |
+| 35–42 min | Compute | Pairs compute jump height from flight time using `h = g × t² / 8` and discuss the assumptions (g = 9.81 m/s², take-off height equals landing height). |
+| 42–45 min | Debrief | Each pair reports one source of measurement error and one source of biological variability they observed. |
+
+## Hands-on activity
+
+Per learner, three jumps. Per jump, fill in the table.
+
+| Jump | Take-off time (s) | Landing time (s) | Flight time (s) | Estimated height (cm) |
+|---|---|---|---|---|
+| 1 | | | | |
+| 2 | | | | |
+| 3 | | | | |
+
+The estimated height comes from `h = (9.81 × t²) / 8`, where `t` is the flight
+time in seconds and `h` is in meters; multiply by 100 for cm.
+
+Take-off time can be estimated as the moment after the unweighting trough
+where vertical acceleration crosses back through 1 G upward, and landing time
+as the first peak that exceeds an instructor-chosen threshold (start with 4 G).
+
+## Code snippet for the hands-on path
+
+This snippet is intentionally written so it can be pasted into the developer
+console of `CORETOOLKIT-STARTER` while waiting for the planned example to
+land. It marks events; it does not pretend to be a force platform.
+
+```javascript
+window.cmjEvents = [];
+const TAKEOFF_THRESHOLD_LOW = 0.6;  // G, magnitude during unweighting
+const LANDING_THRESHOLD = 4.0;      // G, peak at landing
+let inUnweighting = false;
+
+bles[0].gotConvertedAcc = function (acc) {
+  const magnitude = Math.hypot(acc.x ?? 0, acc.y ?? 0, acc.z ?? 0);
+  const t = performance.now() / 1000;
+  if (!inUnweighting && magnitude < TAKEOFF_THRESHOLD_LOW) {
+    inUnweighting = true;
+    window.cmjEvents.push({ t, kind: 'takeoff_window_start', magnitude });
+  }
+  if (inUnweighting && magnitude > LANDING_THRESHOLD) {
+    inUnweighting = false;
+    window.cmjEvents.push({ t, kind: 'landing', magnitude });
+  }
+};
+
+function lastJump() {
+  const events = window.cmjEvents.slice(-2);
+  if (events.length < 2) return null;
+  const flight = events[1].t - events[0].t;
+  return { flightSec: flight, heightMeters: (9.81 * flight * flight) / 8 };
+}
+```
+
+The thresholds are deliberately conservative so that this lesson can run
+without per-learner tuning. Stronger jumpers will exceed them; the discussion
+section below uses that as a teaching moment, not a bug.
+
+## Discussion prompts
+
+- "Why does this method overestimate jump height for some learners and
+  underestimate it for others?" Use to introduce that take-off and landing
+  postures change effective height of the foot relative to the center of
+  mass.
+- "If the IMU does not measure the flight phase, why does it give us a flight
+  time at all?" Use to discuss event timing vs continuous measurement.
+- "What would you change in the protocol if the goal was to compare two
+  learners rather than two trials of the same learner?"
+
+## Assessment ideas
+
+- A one-page report comparing each learner's three jumps and proposing one
+  protocol change that would make the within-learner numbers more stable.
+- A code review where learners explain why `Math.hypot` is used and what would
+  change if the lesson used only the z-axis.
+
+## Safety and ethics
+
+- Clear floor space, no chairs in the landing area.
+- Learners with recent lower-limb injury opt out and act as recorders.
+- Body-weight inferences (e.g., power) are explicitly out of scope; the lesson
+  only reports flight time and the derived height.
+
+## References
+
+- Linthorne, N. P. "Analysis of Standing Vertical Jumps Using a Force
+  Platform." _American Journal of Physics_, vol. 69, no. 11, 2001. Use for the
+  derivation of `h = g × t² / 8` and for the explicit caveats around
+  IMU-based estimates.
+- Bosco, C., Luhtanen, P., and Komi, P. V. "A Simple Method for Measurement of
+  Mechanical Power in Jumping." _European Journal of Applied Physiology and
+  Occupational Physiology_, vol. 50, no. 2, 1983. Historical reference for
+  flight-time-based jump assessment.
+
+## Out of scope
+
+- Power, strength, or rate-of-force-development estimates. The IMU does not
+  measure these directly.
+- Comparing across learners as if the numbers were absolute. The lesson is
+  about within-learner change and measurement awareness.
+
+## Open questions for the human owner
+
+- Do we want a dedicated CMJ example, or does the CMJ panel live inside the
+  Step Count Dashboard? The lesson is written to survive either choice.
+- Should we ship a recommended threshold table per body size, or keep the
+  threshold tuning as a discussion point? Either is workable; pick one before
+  publication so the lesson and the example agree.

--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -1,0 +1,82 @@
+# Lesson Plans (Draft)
+
+Status: `draft` — opened for review by Codex and human owners. None of these
+lesson plans should be linked from the public LP until they have been reviewed
+and at least one cohort has run them.
+
+This directory holds 45-minute class plans that pair an ORPHE CORE example with
+educator framing, hands-on tasks, and discussion prompts. They are written for
+JavaScript-comfortable instructors in undergraduate sports science,
+rehabilitation, HCI, or creative coding programs, but most can be adapted for
+high school clubs and adult workshops.
+
+## Tier 1 Lessons
+
+The first six plans share the same structure so they can be slotted into any
+syllabus order:
+
+| # | Lesson | Example | Notification | Devices |
+|---|---|---|---|---|
+| 1 | [Step Count Dashboard](./01-step-count-dashboard.md) | `examples/STEP-COUNT-DASHBOARD/` _(planned)_ | `STEP_ANALYSIS` | 1 |
+| 2 | [Stride & Cadence](./02-stride-and-cadence.md) | `examples/STEP-COUNT-DASHBOARD/` _(planned)_ | `STEP_ANALYSIS` | 1 |
+| 3 | [L/R Symmetry](./03-lr-symmetry.md) | `examples/STEP-COUNT-DASHBOARD/` _(planned, dual-device variant)_ | `STEP_ANALYSIS` | 2 |
+| 4 | [CSV Recorder](./04-csv-recorder.md) | `examples/CSV-RECORDER/` _(planned)_ | `STEP_ANALYSIS_AND_SENSOR_VALUES` | 1 |
+| 5 | [Replay Player](./05-replay-player.md) | `examples/REPLAY-PLAYER/` _(planned)_ | none — uses recorded JSON | 0 (synthetic data) or 1 (live) |
+| 6 | [Vertical Jump (CMJ)](./06-vertical-jump-cmj.md) | `examples/STEP-COUNT-DASHBOARD/` or new `CMJ` _(planned)_ | `SENSOR_VALUES` | 1 |
+
+The example directories listed as _(planned)_ are introduced in sibling PRs in
+this sprint. Until those land, instructors can run the lesson against
+`examples/CORETOOLKIT-STARTER/` for steps 1–3 and `examples/SENSOR-CALIBRATION/`
+for step 4 — the lesson plans call this out explicitly.
+
+## Educator framing
+
+All Tier 1 lessons assume:
+
+- Chrome on macOS or Windows. Safari and Firefox cannot use the Web Bluetooth
+  API and are not supported.
+- One ORPHE CORE per learner pair, except where noted.
+- A local static server on the example so Web Bluetooth permissions persist.
+  `python3 -m http.server 8767` from the repo root works.
+- Learners have seen a 5-minute demo of `examples/CORETOOLKIT-STARTER/` so the
+  connection toggle is familiar.
+
+## Citations and further reading
+
+Each lesson cites sources by topic rather than by a single textbook so the
+material can be substituted for whatever is on the local syllabus. The most
+common references are:
+
+- Whittle, M. W. _Gait Analysis: An Introduction_. 5th ed., Churchill
+  Livingstone, 2014. Use for terminology around the gait cycle and stance/swing
+  phases.
+- Perry, J. and Burnfield, J. M. _Gait Analysis: Normal and Pathological
+  Function_. 2nd ed., SLACK Inc., 2010. Use for clinical gait deviations.
+- Bouten, C. V. C. et al. "A Triaxial Accelerometer and Portable Data Processing
+  Unit for the Assessment of Daily Physical Activity." _IEEE Transactions on
+  Biomedical Engineering_, vol. 44, no. 3, 1997. Use for the basic case for
+  wearable accelerometry.
+- Bishop, P. A. and Herron, R. L. "Use and Misuse of the Likert Item Responses
+  and Other Ordinal Measures." _International Journal of Exercise Science_,
+  vol. 8, no. 3, 2015. Use when teaching learners to design self-report
+  follow-ups.
+- Linthorne, N. P. "Analysis of Standing Vertical Jumps Using a Force Platform."
+  _American Journal of Physics_, vol. 69, no. 11, 2001. Use as the conceptual
+  reference for the CMJ lesson; ORPHE CORE is a foot-mounted IMU, not a force
+  platform, so the lesson teaches comparison rather than equivalence.
+
+Lesson-specific references appear in each plan.
+
+## Status
+
+These plans are drafts. They have not been classroom-tested with the current
+example branches because the dependent examples are still in PR. Treat the
+"Activity" sections as design intent until a real cohort has run them.
+
+## Out of scope
+
+- Translation to other languages. Drafts are written in English first so Codex
+  can review terminology before localization.
+- Slide decks or printable handouts. Add later when the example PRs land.
+- Assessment rubrics tied to a specific institution. The "Assessment ideas"
+  section gives suggestions, not a graded rubric.


### PR DESCRIPTION
## Summary

Adds six 45-minute Tier 1 lesson plans under `docs/lessons/` plus an index README. Each plan covers learning objectives, materials, schedule, hands-on activity, modification ideas, discussion prompts, assessment ideas, references, out of scope, and explicit open questions for the human owner.

Lessons:

1. Step Count Dashboard
2. Stride & Cadence
3. L/R Symmetry
4. CSV Recorder
5. Replay Player
6. Vertical Jump (CMJ)

Each lesson is written so an instructor can run it today against `CORETOOLKIT-STARTER` or `SENSOR-CALIBRATION` (the fallback paths are explicit in each plan), and re-run it cleanly when the dependent example PRs land.

`docs/in-flight.md` is updated with the Tier 1 sprint rows so Codex can see the planned work and avoid file collisions.

## Validation

- `node scripts/check-examples-catalog.js` — `Catalog OK: 48 entries checked`.
- `node scripts/check-examples-static-quality.js` — 0 errors, warnings unchanged from main (none introduced by this PR).
- No JS files added or modified, so `node --check` is not applicable.
- Diff scope is `docs/lessons/*` and `docs/in-flight.md` only.

## Assumptions

- "Tier 1 examples" are the six titles selected by the previous Claude session (Step Count Dashboard / Stride & Cadence / L/R Symmetry / CSV Recorder / Replay Player / Vertical Jump CMJ). If that list changes, only the README index needs to track it.
- Lessons are drafted in English first so Codex can review terminology before translation.
- 45-minute slot, JavaScript-comfortable instructor, Chrome on macOS or Windows.

## Real-device validation

Not required. No SDK or example behavior changes. Lessons themselves should be classroom-tested before being linked from the public LP, but that is a separate human task tracked in each lesson's "Status: draft" line.

## Out of scope

- Translation, slides, or printable handouts.
- Linking lessons from `index.html` or the README. Promotion is a navigation decision for the human owner.
- Editing existing examples. Lessons read-only against `CORETOOLKIT-STARTER` and `SENSOR-CALIBRATION`.
- Catalog edits. Lessons reference example IDs only.

## Questions for human

- Should the Tier 1 lesson set live under `docs/lessons/` or move into a future `docs/educators/` tree once we add tiers 2+?
- Do we want a printable trial-table appendix (PDF) per lesson, or generate ad hoc from the Markdown?
- Each lesson includes a "Open questions for the human owner" block with example-specific questions that should be answered before the lesson is published.

## Next PR candidates

- `claude/core-analytics-api-draft` (`js/CoreAnalytics.js` API draft for symmetry, baseline, CMJ).
- `claude/core-recorder-api-draft` (`js/CoreRecorder.js` CSV/JSON schema 0.0.1-draft).
- Three example PoCs that consume those helpers: `STEP-COUNT-DASHBOARD`, `CSV-RECORDER`, `REPLAY-PLAYER`.
- `claude/handoff-2026-05-03` to close the sprint with a handoff doc.