### PR TITLE
Starter Templatesの古いCDNコメントを削除

### DIFF
--- a/starter-templates/ACCELEROMETER.html
+++ b/starter-templates/ACCELEROMETER.html
@@ -16,10 +16,6 @@
         <li id="y"></li>
         <li id="z"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/ANALYSIS_AND_RAW.html
+++ b/starter-templates/ANALYSIS_AND_RAW.html
@@ -17,10 +17,6 @@
         <li id="z"></li>
         <li id="steps_number"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/EULER.html
+++ b/starter-templates/EULER.html
@@ -16,10 +16,6 @@
         <li id="roll"></li>
         <li id="yaw"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/GYRO.html
+++ b/starter-templates/GYRO.html
@@ -16,10 +16,6 @@
         <li id="y"></li>
         <li id="z"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/LIGHT.html
+++ b/starter-templates/LIGHT.html
@@ -16,11 +16,6 @@
     <button onclick="ble.setLED(1,2);">2</button>
     <button onclick="ble.setLED(1,3);">3</button>
     <button onclick="ble.setLED(1,4);">4</button>
-
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/PRONATION.html
+++ b/starter-templates/PRONATION.html
@@ -16,10 +16,6 @@
         <li id="y"></li>
         <li id="z"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/QUATERNION.html
+++ b/starter-templates/QUATERNION.html
@@ -17,10 +17,6 @@
         <li id="y"></li>
         <li id="z"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/STEPS.html
+++ b/starter-templates/STEPS.html
@@ -14,10 +14,6 @@
     <ul>
         <li id="steps_number"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>

--- a/starter-templates/STRIDE.html
+++ b/starter-templates/STRIDE.html
@@ -16,10 +16,6 @@
         <li id="y"></li>
         <li id="z"></li>
     </ul>
-
-
-    <!-- <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/ORPHE-CORE.js" crossorigin="anonymous"
-        type="text/javascript"></script> -->
     <script src="../js/ORPHE-CORE.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js" crossorigin="anonymous"
         type="text/javascript"></script>


### PR DESCRIPTION
## Summary
- Remove obsolete commented `ORPHE-CORE.js@main` CDN script tags from starter templates.
- The active script tags already use the local `../js/ORPHE-CORE.js`; this PR only removes stale comments.
- Reduces `scripts/check-examples-static-quality.js` warnings from 19 to 10.

## Validation
- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `node scripts/check-examples-static-quality.js`
- `curl -I http://localhost:8770/starter-templates/LIGHT.html`
- `curl -I http://localhost:8770/starter-templates/ANALYSIS_AND_RAW.html`

## Needs real-device validation
- None. This is comment-only cleanup and does not change active script loading.

## Out of scope
- Updating `float16.min.js` or `quaternion.js` helper references.
- Changing starter template UI or BLE behavior.

## Questions for human
- None.

## Next PR candidates
- Add `guardCoreToolkitBluetooth()` calls to remaining CoreToolkit examples where safe.
