### PR TITLE
静的品質チェックで外部JS内のCoreToolkit guardを検出

### DIFF
--- a/scripts/check-examples-static-quality.js
+++ b/scripts/check-examples-static-quality.js
@@ -74,6 +74,26 @@ function maybeRead(relativePath) {
   return readText(relativePath);
 }
 
+function localScriptPaths(html, pagePath) {
+  const pageDir = path.posix.dirname(pagePath);
+  const scripts = [];
+  const scriptRe = /<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi;
+  let match;
+  while ((match = scriptRe.exec(html))) {
+    const src = match[1];
+    if (!src || /^https?:\/\//.test(src) || src.startsWith('//')) continue;
+    scripts.push(normalizeRelative(path.posix.normalize(path.posix.join(pageDir, src))));
+  }
+  return scripts;
+}
+
+function localScriptText(html, pagePath) {
+  return localScriptPaths(html, pagePath)
+    .map((scriptPath) => maybeRead(scriptPath))
+    .filter(Boolean)
+    .join('\n');
+}
+
 function httpHead(url) {
   return new Promise((resolve) => {
     const req = http.request(url, { method: 'HEAD', timeout: 2500 }, (res) => {
@@ -220,10 +240,12 @@ async function main() {
     }
 
     if (html.includes('CoreToolkit.js')) {
+      const scriptText = localScriptText(html, pagePath);
+      const combinedText = `${html}\n${scriptText}`;
       if (!html.includes('BleSharedBridge.js')) {
         addIssue(issues, 'error', id, `${pagePath} uses CoreToolkit.js but does not include BleSharedBridge.js`);
       }
-      if (!html.includes('guardCoreToolkitBluetooth(')) {
+      if (!combinedText.includes('guardCoreToolkitBluetooth(')) {
         addIssue(issues, 'warning', id, `${pagePath} uses CoreToolkit.js but does not call guardCoreToolkitBluetooth()`);
       }
     }


### PR DESCRIPTION
## Summary
- Improve `scripts/check-examples-static-quality.js` so it also scans local scripts loaded by each HTML page.
- This avoids false positive CoreToolkit warnings when `guardCoreToolkitBluetooth()` is called from `sketch.js` or `scripts.js`.
- On current `main`, warnings drop from 19 to 9; the remaining 9 are the starter-template stale CDN comments handled separately in #78.

## Validation
- `node --check scripts/check-examples-static-quality.js`
- `node scripts/check-examples-static-quality.js`
- `node scripts/check-examples-catalog.js`
- `git diff --check`

## Needs real-device validation
- None. This changes only the static checker.

## Out of scope
- Changing any example behavior.
- Adding or changing `guardCoreToolkitBluetooth()` calls in examples.

## Questions for human
- None.

## Next PR candidates
- Merge #78 to remove the remaining starter-template CDN comment warnings.
