### PR TITLE
feat(recorder): add CoreRecorder.js draft (0.0.1-draft schema)

### DIFF
--- a/js/CoreRecorder.js
+++ b/js/CoreRecorder.js
@@ -1,0 +1,435 @@
+/*!
+ * CoreRecorder.js — recording / replay helpers for ORPHE CORE.js
+ *
+ * Status: 0.0.1-draft (Claude proposal). API and schema are unstable.
+ * Owner: Claude draft, Codex API review (see docs/agents.md).
+ *
+ * This module is intentionally separate from `js/ORPHE-CORE.js` and from the
+ * existing `examples/SENSOR-CALIBRATION/recorder.js`. It does not modify the
+ * SENSOR-CALIBRATION recorder; instead it proposes a small, opt-in helper
+ * that any new example can adopt.
+ *
+ * Design goals
+ *   1. Users wire it explicitly via `feed*` methods called from their own
+ *      `gotAcc` / `gotConvertedAcc` / `gotGyro` / `gotEuler` / `gotGait` /
+ *      `gotStride` / `gotPronation` / `gotStepsNumber` / `gotLandingImpact` /
+ *      `gotFootAngle` handlers. CoreRecorder never overwrites a callback.
+ *   2. CSV and JSON share the same in-memory sample shape. JSON is the
+ *      authoritative format; CSV is a flat projection for spreadsheets.
+ *   3. `fromJSON()` round-trips: `CoreRecorder.fromJSON(rec.toJSON())` yields a
+ *      recorder whose `replay()` callback shapes are byte-for-byte equal.
+ *   4. Replay is a deterministic loop over recorded samples. The wall clock is
+ *      injectable so tests don't sleep.
+ *
+ * Browser usage (no bundler):
+ *   <script src="../../js/CoreRecorder.js"></script>
+ *   const rec = new CoreRecorder({ session: 'lesson-04' });
+ *   rec.start();
+ *   bles[0].gotConvertedAcc = function (acc) { rec.feedAcc(acc); };
+ *   bles[0].gotGait         = function (gait) { rec.feedGait(gait); };
+ *   // ...
+ *   rec.stop();
+ *   const json = rec.toJSON();
+ *   const csv  = rec.toCSV();
+ *
+ * Node / test usage:
+ *   const CoreRecorder = require('./js/CoreRecorder.js');
+ *   const r = new CoreRecorder({ now: () => Date.now() });
+ */
+
+(function (root, factory) {
+    'use strict';
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.CoreRecorder = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    /** Schema identifier emitted in toJSON(). Bump when the JSON shape changes. */
+    var RECORDING_SCHEMA_VERSION = '0.0.1-draft';
+
+    /**
+     * The set of sample kinds the recorder knows about. Each kind corresponds
+     * to one ORPHE-CORE.js callback. Adding a new kind here also requires
+     * adding it to CSV_COLUMNS and replay() below.
+     */
+    var SAMPLE_KINDS = [
+        'acc',           // gotConvertedAcc (G) — also accepts gotAcc (normalized)
+        'gyro',          // gotConvertedGyro (deg/s) — also accepts gotGyro (normalized)
+        'euler',         // gotEuler (radians)
+        'quat',          // gotQuat
+        'gait',          // gotGait
+        'stride',        // gotStride
+        'pronation',     // gotPronation
+        'landingImpact', // gotLandingImpact
+        'footAngle',     // gotFootAngle
+        'stepsNumber',   // gotStepsNumber
+    ];
+
+    /**
+     * Flat CSV columns. Every sample becomes one row; columns it doesn't
+     * populate are left blank. Order is stable so spreadsheet workflows can
+     * pin column references.
+     */
+    var CSV_COLUMNS = [
+        't_relative_ms', 'kind',
+        'x', 'y', 'z', 'w',
+        'pitch', 'roll', 'yaw',
+        'steps', 'direction', 'distance', 'calorie',
+        'standing_phase_duration', 'swing_phase_duration',
+        'steps_number', 'value',
+    ];
+
+    function nowMs() {
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+            return performance.now();
+        }
+        return Date.now();
+    }
+
+    function isFiniteNumber(value) {
+        return typeof value === 'number' && isFinite(value);
+    }
+
+    function escapeCsvCell(value) {
+        if (value == null) return '';
+        var str = String(value);
+        if (/[",\n]/.test(str)) return '"' + str.replace(/"/g, '""') + '"';
+        return str;
+    }
+
+    function unescapeCsvCell(cell) {
+        if (cell == null || cell === '') return '';
+        if (cell.charAt(0) === '"' && cell.charAt(cell.length - 1) === '"') {
+            return cell.slice(1, -1).replace(/""/g, '"');
+        }
+        return cell;
+    }
+
+    function parseCsvLine(line) {
+        var cells = [];
+        var current = '';
+        var inQuotes = false;
+        for (var i = 0; i < line.length; i++) {
+            var ch = line.charAt(i);
+            if (inQuotes) {
+                if (ch === '"' && line.charAt(i + 1) === '"') {
+                    current += '"';
+                    i++;
+                } else if (ch === '"') {
+                    inQuotes = false;
+                } else {
+                    current += ch;
+                }
+            } else if (ch === '"') {
+                inQuotes = true;
+            } else if (ch === ',') {
+                cells.push(current);
+                current = '';
+            } else {
+                current += ch;
+            }
+        }
+        cells.push(current);
+        return cells;
+    }
+
+    /**
+     * @typedef {Object} CoreRecorderOptions
+     * @property {string} [session]           Free-form label saved into JSON metadata.
+     * @property {() => number} [now]         Clock function returning ms (test seam).
+     * @property {Object} [meta]              Arbitrary metadata persisted in JSON header.
+     */
+
+    /**
+     * @class CoreRecorder
+     */
+    function CoreRecorder(options) {
+        if (!(this instanceof CoreRecorder)) {
+            return new CoreRecorder(options);
+        }
+        var opts = options || {};
+        this._now = typeof opts.now === 'function' ? opts.now : nowMs;
+        this._sessionLabel = opts.session || 'session';
+        this._meta = Object.assign({}, opts.meta || {});
+        this._samples = [];
+        this._startMs = null;
+        this._endMs = null;
+        this._isRecording = false;
+    }
+
+    /**
+     * Start a new recording. Discards any previously buffered samples.
+     */
+    CoreRecorder.prototype.start = function () {
+        this._samples = [];
+        this._startMs = this._now();
+        this._endMs = null;
+        this._isRecording = true;
+        return this;
+    };
+
+    /**
+     * Stop the recording. Subsequent feed* calls are ignored until start().
+     */
+    CoreRecorder.prototype.stop = function () {
+        if (!this._isRecording) return this;
+        this._endMs = this._now();
+        this._isRecording = false;
+        return this;
+    };
+
+    /** @returns {boolean} */
+    CoreRecorder.prototype.isRecording = function () { return this._isRecording; };
+
+    /** @returns {number} samples recorded so far */
+    CoreRecorder.prototype.size = function () { return this._samples.length; };
+
+    /** @returns {number} duration in ms (live or final) */
+    CoreRecorder.prototype.durationMs = function () {
+        if (this._startMs == null) return 0;
+        var end = this._endMs == null ? this._now() : this._endMs;
+        return Math.max(0, end - this._startMs);
+    };
+
+    function pickFields(payload, fields) {
+        var result = {};
+        for (var i = 0; i < fields.length; i++) {
+            var key = fields[i];
+            if (payload && Object.prototype.hasOwnProperty.call(payload, key) && payload[key] !== undefined) {
+                result[key] = payload[key];
+            }
+        }
+        return result;
+    }
+
+    var FIELDS_BY_KIND = {
+        acc: ['x', 'y', 'z'],
+        gyro: ['x', 'y', 'z'],
+        euler: ['pitch', 'roll', 'yaw'],
+        quat: ['w', 'x', 'y', 'z'],
+        gait: ['steps', 'direction', 'distance', 'calorie',
+            'standing_phase_duration', 'swing_phase_duration', 'type'],
+        stride: ['x', 'y', 'z', 'steps_number'],
+        pronation: ['x', 'y', 'z'],
+        landingImpact: ['value'],
+        footAngle: ['value'],
+        stepsNumber: ['value'],
+    };
+
+    CoreRecorder.prototype._record = function (kind, payload) {
+        if (!this._isRecording) return;
+        if (SAMPLE_KINDS.indexOf(kind) === -1) return;
+        var t = this._now();
+        var fields = FIELDS_BY_KIND[kind] || [];
+        this._samples.push({
+            t_relative_ms: t - this._startMs,
+            kind: kind,
+            payload: pickFields(payload, fields),
+        });
+    };
+
+    // Opt-in feeds — call from your own callback handlers.
+    CoreRecorder.prototype.feedAcc = function (acc) { this._record('acc', acc); };
+    CoreRecorder.prototype.feedGyro = function (gyro) { this._record('gyro', gyro); };
+    CoreRecorder.prototype.feedEuler = function (euler) { this._record('euler', euler); };
+    CoreRecorder.prototype.feedQuat = function (quat) { this._record('quat', quat); };
+    CoreRecorder.prototype.feedGait = function (gait) { this._record('gait', gait); };
+    CoreRecorder.prototype.feedStride = function (stride) { this._record('stride', stride); };
+    CoreRecorder.prototype.feedPronation = function (pronation) { this._record('pronation', pronation); };
+    CoreRecorder.prototype.feedLandingImpact = function (impact) { this._record('landingImpact', impact); };
+    CoreRecorder.prototype.feedFootAngle = function (footAngle) { this._record('footAngle', footAngle); };
+    CoreRecorder.prototype.feedStepsNumber = function (steps) { this._record('stepsNumber', steps); };
+
+    /**
+     * @returns {Object} JSON-serializable recording.
+     */
+    CoreRecorder.prototype.toJSON = function () {
+        return {
+            schema: RECORDING_SCHEMA_VERSION,
+            session: this._sessionLabel,
+            startMs: this._startMs,
+            endMs: this._endMs,
+            durationMs: this.durationMs(),
+            sampleCount: this._samples.length,
+            meta: Object.assign({}, this._meta),
+            samples: this._samples.map(function (s) {
+                return {
+                    t_relative_ms: s.t_relative_ms,
+                    kind: s.kind,
+                    payload: Object.assign({}, s.payload),
+                };
+            }),
+        };
+    };
+
+    /**
+     * @returns {string} CSV with header row.
+     */
+    CoreRecorder.prototype.toCSV = function () {
+        var lines = [CSV_COLUMNS.join(',')];
+        for (var i = 0; i < this._samples.length; i++) {
+            var sample = this._samples[i];
+            var row = [];
+            for (var c = 0; c < CSV_COLUMNS.length; c++) {
+                var col = CSV_COLUMNS[c];
+                var value;
+                if (col === 't_relative_ms') value = sample.t_relative_ms;
+                else if (col === 'kind') value = sample.kind;
+                else if (sample.payload && Object.prototype.hasOwnProperty.call(sample.payload, col)) value = sample.payload[col];
+                else value = '';
+                row.push(escapeCsvCell(value));
+            }
+            lines.push(row.join(','));
+        }
+        return lines.join('\n');
+    };
+
+    /**
+     * Reconstruct a recorder from a JSON object produced by toJSON().
+     * The result is a stopped recorder ready for replay() / toCSV() / toJSON().
+     *
+     * @param {Object} json
+     * @returns {CoreRecorder}
+     */
+    CoreRecorder.fromJSON = function (json) {
+        if (!json || typeof json !== 'object') {
+            throw new Error('CoreRecorder.fromJSON: expected an object');
+        }
+        if (json.schema && json.schema !== RECORDING_SCHEMA_VERSION) {
+            // Forward-compatible: warn instead of throw so old recordings can still load.
+            if (typeof console !== 'undefined' && console.warn) {
+                console.warn('CoreRecorder.fromJSON: schema mismatch ' + json.schema + ' vs ' + RECORDING_SCHEMA_VERSION);
+            }
+        }
+        var rec = new CoreRecorder({ session: json.session, meta: json.meta });
+        rec._startMs = isFiniteNumber(json.startMs) ? json.startMs : 0;
+        rec._endMs = isFiniteNumber(json.endMs) ? json.endMs : (rec._startMs + (json.durationMs || 0));
+        rec._isRecording = false;
+        var samples = Array.isArray(json.samples) ? json.samples : [];
+        rec._samples = samples.map(function (s) {
+            return {
+                t_relative_ms: isFiniteNumber(s.t_relative_ms) ? s.t_relative_ms : 0,
+                kind: s.kind,
+                payload: Object.assign({}, s.payload || {}),
+            };
+        });
+        return rec;
+    };
+
+    /**
+     * Reconstruct a recorder from a CSV string produced by toCSV().
+     *
+     * @param {string} csv
+     * @param {Object} [options]
+     * @param {string} [options.session]
+     * @param {Object} [options.meta]
+     * @returns {CoreRecorder}
+     */
+    CoreRecorder.fromCSV = function (csv, options) {
+        if (typeof csv !== 'string') throw new Error('CoreRecorder.fromCSV: expected a string');
+        var opts = options || {};
+        var rec = new CoreRecorder({ session: opts.session, meta: opts.meta });
+        var lines = csv.split(/\r?\n/);
+        if (lines.length === 0) return rec;
+        var header = parseCsvLine(lines[0]);
+        var indexOf = {};
+        for (var h = 0; h < header.length; h++) indexOf[header[h]] = h;
+        var startSet = false;
+        for (var i = 1; i < lines.length; i++) {
+            if (!lines[i]) continue;
+            var cells = parseCsvLine(lines[i]);
+            var kind = unescapeCsvCell(cells[indexOf.kind]);
+            if (SAMPLE_KINDS.indexOf(kind) === -1) continue;
+            var t = parseFloat(unescapeCsvCell(cells[indexOf.t_relative_ms]));
+            if (!startSet) {
+                rec._startMs = 0;
+                startSet = true;
+            }
+            var fields = FIELDS_BY_KIND[kind] || [];
+            var payload = {};
+            for (var f = 0; f < fields.length; f++) {
+                var col = fields[f];
+                if (indexOf[col] == null) continue;
+                var raw = unescapeCsvCell(cells[indexOf[col]]);
+                if (raw === '') continue;
+                var num = Number(raw);
+                payload[col] = isFinite(num) && raw !== '' ? num : raw;
+            }
+            rec._samples.push({ t_relative_ms: t, kind: kind, payload: payload });
+        }
+        if (rec._samples.length > 0) {
+            rec._endMs = rec._samples[rec._samples.length - 1].t_relative_ms;
+        }
+        rec._isRecording = false;
+        return rec;
+    };
+
+    /**
+     * @typedef {Object} ReplayHandlers
+     * @property {(payload:Object)=>void} [acc]
+     * @property {(payload:Object)=>void} [gyro]
+     * @property {(payload:Object)=>void} [euler]
+     * @property {(payload:Object)=>void} [quat]
+     * @property {(payload:Object)=>void} [gait]
+     * @property {(payload:Object)=>void} [stride]
+     * @property {(payload:Object)=>void} [pronation]
+     * @property {(payload:Object)=>void} [landingImpact]
+     * @property {(payload:Object)=>void} [footAngle]
+     * @property {(payload:Object)=>void} [stepsNumber]
+     */
+
+    /**
+     * @typedef {Object} ReplayOptions
+     * @property {ReplayHandlers} handlers
+     * @property {number} [speed=1]   Playback speed multiplier; 0 means "fire all immediately".
+     * @property {(cb:Function, ms:number)=>any} [scheduler] Defaults to setTimeout.
+     * @property {(handle:any)=>void} [cancel]               Defaults to clearTimeout.
+     */
+
+    /**
+     * Replay the recording, firing the matching handler for each sample at
+     * the right relative time.
+     *
+     * @param {ReplayOptions} options
+     * @returns {{stop:()=>void, durationMs:number, sampleCount:number}}
+     */
+    CoreRecorder.prototype.replay = function (options) {
+        var opts = options || {};
+        var handlers = opts.handlers || {};
+        var speed = isFiniteNumber(opts.speed) ? opts.speed : 1;
+        var scheduler = typeof opts.scheduler === 'function' ? opts.scheduler : function (fn, ms) { return setTimeout(fn, ms); };
+        var cancel = typeof opts.cancel === 'function' ? opts.cancel : function (handle) { clearTimeout(handle); };
+
+        var pending = [];
+        var samples = this._samples;
+        for (var i = 0; i < samples.length; i++) {
+            (function (sample) {
+                var handler = handlers[sample.kind];
+                if (typeof handler !== 'function') return;
+                var delay = speed > 0 ? (sample.t_relative_ms / speed) : 0;
+                var handle = scheduler(function () { handler(Object.assign({}, sample.payload)); }, delay);
+                pending.push(handle);
+            }(samples[i]));
+        }
+
+        return {
+            stop: function () {
+                for (var p = 0; p < pending.length; p++) cancel(pending[p]);
+                pending = [];
+            },
+            durationMs: this.durationMs(),
+            sampleCount: samples.length,
+        };
+    };
+
+    // Static surface for direct use without instantiating a recording.
+    CoreRecorder.SCHEMA_VERSION = RECORDING_SCHEMA_VERSION;
+    CoreRecorder.SAMPLE_KINDS = SAMPLE_KINDS.slice();
+    CoreRecorder.CSV_COLUMNS = CSV_COLUMNS.slice();
+    CoreRecorder.FIELDS_BY_KIND = JSON.parse(JSON.stringify(FIELDS_BY_KIND));
+
+    return CoreRecorder;
+}));


### PR DESCRIPTION
## Summary

Adds `js/CoreRecorder.js` as a separate helper module that records ORPHE-CORE.js callback payloads to a shared JSON/CSV schema and replays them through the same callback shapes. Status: `0.0.1-draft` — unstable, intended for Codex API and schema review before any example pins to it.

The existing `examples/SENSOR-CALIBRATION/recorder.js` is **not modified**. This module is a sibling proposal that new examples (CSV-RECORDER, REPLAY-PLAYER) can adopt without disturbing what works today.

## API surface

| Method | Notes |
|---|---|
| `new CoreRecorder({ session, now, meta })` | `now` is injectable for tests. `meta` is persisted into JSON. |
| `start()` / `stop()` / `isRecording()` / `size()` / `durationMs()` | Lifecycle. `start()` discards prior buffer. |
| `feedAcc` / `feedGyro` / `feedEuler` / `feedQuat` / `feedGait` / `feedStride` / `feedPronation` / `feedLandingImpact` / `feedFootAngle` / `feedStepsNumber` | Opt-in feeds; never overwrite a callback. |
| `toJSON()` / `toCSV()` | Authoritative JSON, flat CSV projection. |
| `CoreRecorder.fromJSON(json)` / `CoreRecorder.fromCSV(csv, opts)` | Reconstruct a stopped recorder. |
| `replay({ handlers, speed, scheduler, cancel })` | Fire recorded payloads through caller-provided handlers. `speed: 0` fires immediately, `speed: 4` plays back 4×. |
| Static surface | `CoreRecorder.SCHEMA_VERSION`, `CoreRecorder.SAMPLE_KINDS`, `CoreRecorder.CSV_COLUMNS`, `CoreRecorder.FIELDS_BY_KIND`. |

## Schema (0.0.1-draft)

JSON top-level:

```jsonc
{
  "schema": "0.0.1-draft",
  "session": "lesson-04",
  "startMs": 1731000000000,
  "endMs":   1731000010000,
  "durationMs": 10000,
  "sampleCount": 423,
  "meta": { /* opaque caller metadata */ },
  "samples": [
    { "t_relative_ms": 50, "kind": "acc", "payload": { "x": 0.1, "y": 0.2, "z": 0.95 } },
    { "t_relative_ms": 480, "kind": "gait", "payload": { "steps": 1, "swing_phase_duration": 0.45, "standing_phase_duration": 0.55, "direction": 2 } }
  ]
}
```

CSV columns (header row, stable order):

```
t_relative_ms, kind,
x, y, z, w,
pitch, roll, yaw,
steps, direction, distance, calorie,
standing_phase_duration, swing_phase_duration,
steps_number, value
```

Each sample becomes one row. Columns the kind doesn't populate are blank.

## Validation

- `node --check js/CoreRecorder.js` — OK.
- Round-trip smoke tests in Node:
  - `CoreRecorder.fromJSON(rec.toJSON()).toJSON().samples` equals the original samples (deep equal).
  - `CoreRecorder.fromCSV(rec.toCSV())` reconstructs the same kinds and payloads.
  - `replay({ speed: 0, handlers })` fires every handler with the recorded payload, in order (`acc, gait, stride`).
- `node scripts/check-examples-catalog.js` — `Catalog OK: 48 entries checked`.
- `node scripts/check-examples-static-quality.js` — warnings unchanged from main (19, none introduced by this PR).

## Assumptions

- `t_relative_ms` is the canonical timestamp. Wall-clock `startMs` / `endMs` are persisted but not required for replay.
- Acceleration values can come from either `gotAcc` (normalized) or `gotConvertedAcc` (G). The recorder does not transform them; downstream consumers must know which feed they wired.
- The CSV is for human / spreadsheet consumption. JSON is the authoritative format for replay and analysis tools.
- `replay()` uses `setTimeout` by default, so it fires after the current tick. Tests inject a synthetic scheduler.

## Real-device validation

Not required to merge the draft. Real-device validation belongs in the example PRs that consume this module (`CSV-RECORDER`, `REPLAY-PLAYER`).

## Out of scope

- Modifying `examples/SENSOR-CALIBRATION/recorder.js` or its CSV format. Migration is a separate decision.
- Persistence backends (no IndexedDB, no remote upload).
- BLE-side auto-attach. The example layer wires `feed*` calls explicitly.
- TypeScript port or bundler integration. Plain JS so it can be `<script>`-loaded.

## Questions for human

- JSON schema: is `0.0.1-draft` the right version label, and do we want `schema_compat` ranges for forward compatibility?
- CSV columns: confirm the column set and order before any example pins to them.
- `stepsNumber` vs `gait.steps`: the recorder stores both as separate kinds, but the JSDoc on `feedStepsNumber` does not assume cumulative semantics. Confirm before example UIs depend on either.
- Should `meta` be an opaque blob (current) or a typed structure (device id, mount position, range)?

## Next PR candidates

- `claude/example-csv-recorder-poc`: new `examples/CSV-RECORDER/` PoC that consumes this module and exercises `start/stop/toCSV/toJSON`.
- `claude/example-replay-player-poc`: new `examples/REPLAY-PLAYER/` PoC with a shipped synthetic `sample-session.js` so the page boots without hardware.