### PR TITLE
feat(examples): add CSV-RECORDER PoC (depends on CoreRecorder.js draft)

### DIFF
--- a/examples/CSV-RECORDER/README.md
+++ b/examples/CSV-RECORDER/README.md
@@ -1,0 +1,121 @@
+# CSV Recorder (PoC, draft)
+
+Status: `public-candidate` (planned). **Not yet listed in
+`examples/catalog.json`**. See "Proposed catalog metadata" below.
+
+A small page that records ORPHE CORE callback payloads to a flat CSV (and to
+JSON for replay) using the draft `js/CoreRecorder.js` helper. One device, one
+session at a time. Pairs with [Lesson 04](../../docs/lessons/04-csv-recorder.md).
+
+## What you can do without a device
+
+- Open the page in Chrome, see the layout, the Start/Stop/Reset/Download
+  buttons, the sample-kind counter table, and the schema-version label.
+- Confirm the BLE switch is disabled with a clear message in any browser
+  without Web Bluetooth (the page calls
+  `guardCoreToolkitBluetooth({ coreIds: [0] })`).
+
+## What you can do with a device
+
+- Connect one ORPHE CORE through the CoreToolkit switch.
+- Press **Start**, walk for 10 s, press **Stop**.
+- Inspect the per-kind counters.
+- Download the CSV and inspect it in any spreadsheet, or download the JSON and
+  replay it later in the planned `REPLAY-PLAYER` example.
+
+## Run locally
+
+From the repo root:
+
+```bash
+python3 -m http.server 8767
+```
+
+Then open `http://localhost:8767/examples/CSV-RECORDER/` in Chrome on macOS or
+Windows. Safari and Firefox cannot use the Web Bluetooth API and will show the
+guard message.
+
+## Notification type
+
+`STEP_ANALYSIS_AND_SENSOR_VALUES`. Both step-analysis events (gait, stride,
+pronation, landing impact, foot angle, steps number) and sensor-rate values
+(acc, gyro, euler, quat) are recorded.
+
+## Files
+
+| File | Notes |
+|---|---|
+| `index.html` | Page layout, CoreToolkit placeholder, controls, counter table. Loads `../../js/CoreRecorder.js`. |
+| `sketch.js`  | Wires `bles[0]` callbacks to `CoreRecorder.feed*`. Owns Start / Stop / Reset / Download buttons. |
+| `style.css`  | Light tweaks on top of Bootstrap. |
+| `README.md`  | This file. |
+
+## Dependencies
+
+- `js/ORPHE-CORE.js`, `js/CoreToolkit.js`, `js/BleSharedBridge.js`,
+  `js/quaternion.js` — existing core libraries.
+- `js/CoreRecorder.js` — new module introduced in
+  PR `claude/core-recorder-api-draft`. **This example only works on top of
+  that PR.**
+
+## Proposed catalog metadata
+
+This example is not yet added to `examples/catalog.json`. Codex owns the
+catalog file. When promoting, the proposed entry is:
+
+```jsonc
+{
+  "id": "csv-recorder",
+  "title": "CSV Recorder",
+  "path": "examples/CSV-RECORDER/",
+  "type": "web-app",
+  "status": "public-candidate",
+  "audience": ["data-collection", "education"],
+  "value": "Record ORPHE CORE callback payloads to a flat CSV and JSON using the draft CoreRecorder.js helper.",
+  "topics": ["recording", "csv", "json", "replay"],
+  "data": ["acc", "gyro", "euler", "quat", "gait", "stride", "pronation", "landingImpact", "footAngle", "stepsNumber"],
+  "devices": 1,
+  "validation": ["browser-preview", "needs-real-device-validation"],
+  "category": "tools-and-recording",
+  "difficulty": "intermediate",
+  "featured": false,
+  "thumbnail": "examples/_thumbnails/csv-recorder.png",
+  "sort_order": 200,
+  "links": {
+    "demo":   "examples/CSV-RECORDER/index.html",
+    "source": "examples/CSV-RECORDER/"
+  },
+  "requires_device": true,
+  "device_count": 1,
+  "needs_real_device_validation": true,
+  "public_navigation": "listed"
+}
+```
+
+Thumbnail (`examples/_thumbnails/csv-recorder.png`) is **not yet
+generated** — capture from a recorded session before promoting to `listed`.
+
+## Real-device validation
+
+Not yet performed. Required before promoting from `public-candidate` to
+`public`:
+
+- One ORPHE CORE connects, sample kinds appear in the counter table.
+- Start / Stop / Reset / Download CSV / Download JSON all work for a 30-second
+  walk.
+- Downloaded CSV opens in Google Sheets and Excel without re-encoding.
+- Downloaded JSON loads cleanly in the planned `REPLAY-PLAYER` example.
+
+## Out of scope
+
+- Persistence (no localStorage, no IndexedDB).
+- Multi-device recording. The page wires `bles[0]` only.
+- Editing `examples/catalog.json` or `examples/SENSOR-CALIBRATION/recorder.js`.
+
+## Open questions
+
+- Should we expose a "max samples" guard so very long sessions don't grow
+  unbounded? `CoreRecorder` defaults are unbounded; the page currently does
+  not cap them.
+- Should the CSV column order be locked to `CoreRecorder.CSV_COLUMNS`, or
+  configurable per page? PoC follows the helper's order.

--- a/examples/CSV-RECORDER/index.html
+++ b/examples/CSV-RECORDER/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>CSV Recorder — ORPHE CORE.js (PoC, draft)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="./style.css">
+
+  <script src="../../js/quaternion.js"></script>
+  <script src="../../js/ORPHE-CORE.js"></script>
+  <script src="../../js/BleSharedBridge.js"></script>
+  <script src="../../js/CoreToolkit.js"></script>
+  <script src="../../js/CoreRecorder.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"></script>
+  <script src="../../js/site-analytics.js"></script>
+</head>
+<body class="bg-dark text-light">
+  <div class="container py-4">
+    <header class="mb-4">
+      <h1 class="h3">CSV Recorder <span class="badge bg-warning text-dark">PoC · draft</span></h1>
+      <p class="text-secondary mb-1">
+        Record ORPHE CORE callback payloads to a flat CSV (and to JSON for replay) using the draft
+        <code>CoreRecorder.js</code> helper. One device, one session at a time.
+      </p>
+      <p class="text-secondary small mb-0">
+        Status: <code>public-candidate (planned)</code>. Not yet listed in <code>examples/catalog.json</code>.
+        Proposed catalog metadata is in <a href="./README.md">README.md</a>.
+      </p>
+    </header>
+
+    <section class="mb-4">
+      <div id="toolkit_placeholder"></div>
+      <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome on macOS or Windows to connect ORPHE CORE.
+      </div>
+    </section>
+
+    <section class="row g-3 mb-4">
+      <div class="col-md-6">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h5">Recording controls</h2>
+            <div class="d-flex flex-wrap gap-2 mb-3">
+              <button id="btn-start" class="btn btn-success" disabled>Start</button>
+              <button id="btn-stop"  class="btn btn-warning" disabled>Stop</button>
+              <button id="btn-reset" class="btn btn-outline-light" disabled>Reset</button>
+            </div>
+            <label for="session-label" class="form-label small">Session label</label>
+            <input id="session-label" class="form-control form-control-sm mb-3" type="text" value="lesson-04" />
+            <label for="meta-device" class="form-label small">Device note (saved into JSON <code>meta</code>)</label>
+            <input id="meta-device" class="form-control form-control-sm" type="text" value="left-instep" />
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h5">Recording state</h2>
+            <dl class="row mb-3 small">
+              <dt class="col-5">Status</dt>           <dd class="col-7" id="state-status">idle</dd>
+              <dt class="col-5">Samples buffered</dt> <dd class="col-7" id="state-count">0</dd>
+              <dt class="col-5">Duration</dt>         <dd class="col-7" id="state-duration">0.0 s</dd>
+              <dt class="col-5">Last kind</dt>        <dd class="col-7" id="state-last">—</dd>
+            </dl>
+            <div class="d-flex flex-wrap gap-2">
+              <button id="btn-download-csv"  class="btn btn-primary"     disabled>Download CSV</button>
+              <button id="btn-download-json" class="btn btn-outline-info" disabled>Download JSON</button>
+            </div>
+            <p class="small text-secondary mt-3 mb-0">
+              CSV columns and JSON schema follow <code>CoreRecorder.SCHEMA_VERSION</code> = <code id="schema-version">…</code>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <div class="card bg-secondary bg-opacity-25 border-0">
+        <div class="card-body">
+          <h2 class="h5">Sample-kind counters</h2>
+          <p class="small text-secondary">
+            One row per sample kind. Useful while you walk the trial table from
+            <a href="../../docs/lessons/04-csv-recorder.md">Lesson 04</a>.
+          </p>
+          <table class="table table-dark table-sm align-middle mb-0">
+            <thead>
+              <tr><th scope="col">kind</th><th scope="col" class="text-end">count</th></tr>
+            </thead>
+            <tbody id="counters-body"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <details>
+        <summary class="text-secondary">How this page is wired (draft)</summary>
+        <ol class="small text-secondary mt-2">
+          <li><code>CoreToolkit</code> creates <code>bles[0]</code> for one ORPHE CORE.</li>
+          <li><code>guardCoreToolkitBluetooth({ coreIds: [0] })</code> disables the BLE switch on browsers without Web Bluetooth.</li>
+          <li>The page replaces <code>bles[0].gotConvertedAcc</code>, <code>gotConvertedGyro</code>, <code>gotEuler</code>, <code>gotQuat</code>, <code>gotGait</code>, <code>gotStride</code>, <code>gotPronation</code>, <code>gotLandingImpact</code>, <code>gotFootAngle</code>, and <code>gotStepsNumber</code> with handlers that call <code>CoreRecorder</code>'s <code>feed*</code> methods. No other example shares this page, so the callback ownership is unambiguous.</li>
+          <li>Start / Stop manage one <code>CoreRecorder</code> instance. Reset clears its buffer.</li>
+        </ol>
+      </details>
+    </section>
+  </div>
+
+  <script src="./sketch.js"></script>
+</body>
+</html>

--- a/examples/CSV-RECORDER/sketch.js
+++ b/examples/CSV-RECORDER/sketch.js
@@ -1,0 +1,181 @@
+/* CSV Recorder — PoC (draft).
+ *
+ * Wires CoreToolkit's bles[0] callbacks to the draft CoreRecorder (js/CoreRecorder.js).
+ * Status: 0.0.1-draft. Not yet listed in examples/catalog.json.
+ */
+
+(function () {
+    'use strict';
+
+    var NOTIFICATION = 'STEP_ANALYSIS_AND_SENSOR_VALUES';
+    var counters = {};
+    var lastKind = '—';
+    var stateTimer = null;
+
+    function $(id) { return document.getElementById(id); }
+
+    function setSchemaVersionLabel() {
+        var label = $('schema-version');
+        if (label && typeof CoreRecorder !== 'undefined') {
+            label.textContent = CoreRecorder.SCHEMA_VERSION;
+        }
+    }
+
+    function bumpCounter(kind) {
+        counters[kind] = (counters[kind] || 0) + 1;
+        lastKind = kind;
+    }
+
+    function renderCounters() {
+        var body = $('counters-body');
+        if (!body) return;
+        var kinds = Object.keys(counters).sort();
+        if (kinds.length === 0) {
+            body.innerHTML = '<tr><td colspan="2" class="text-secondary text-center">No samples yet.</td></tr>';
+            return;
+        }
+        body.innerHTML = kinds.map(function (kind) {
+            return '<tr><td><code>' + kind + '</code></td><td class="text-end">' + counters[kind] + '</td></tr>';
+        }).join('');
+    }
+
+    function updateState(recorder) {
+        $('state-count').textContent = recorder.size();
+        $('state-duration').textContent = (recorder.durationMs() / 1000).toFixed(1) + ' s';
+        $('state-status').textContent = recorder.isRecording() ? 'recording' : (recorder.size() > 0 ? 'stopped' : 'idle');
+        $('state-last').textContent = lastKind;
+        renderCounters();
+    }
+
+    function downloadBlob(filename, mime, content) {
+        var blob = new Blob([content], { type: mime });
+        var url = URL.createObjectURL(blob);
+        var a = Object.assign(document.createElement('a'), { href: url, download: filename });
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    function timestampSuffix() {
+        var d = new Date();
+        var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+        return d.getFullYear() + pad(d.getMonth() + 1) + pad(d.getDate()) + '-' +
+            pad(d.getHours()) + pad(d.getMinutes()) + pad(d.getSeconds());
+    }
+
+    function init() {
+        setSchemaVersionLabel();
+
+        buildCoreToolkit(
+            $('toolkit_placeholder'),
+            'CSV Recorder',
+            0,
+            NOTIFICATION
+        );
+        guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
+
+        if (typeof bles === 'undefined' || !bles[0]) {
+            console.warn('CSV-RECORDER: bles[0] is not available; CoreToolkit init failed.');
+            return;
+        }
+
+        var ble = bles[0];
+        ble.setup();
+
+        var recorder = new CoreRecorder({ session: 'lesson-04' });
+
+        // Wire ORPHE CORE callbacks → recorder feeds. We intentionally own these
+        // callbacks because this PoC is a single-purpose page.
+        ble.gotConvertedAcc = function (acc) { bumpCounter('acc'); recorder.feedAcc(acc); };
+        ble.gotConvertedGyro = function (gyro) { bumpCounter('gyro'); recorder.feedGyro(gyro); };
+        ble.gotEuler = function (euler) { bumpCounter('euler'); recorder.feedEuler(euler); };
+        ble.gotQuat = function (quat) { bumpCounter('quat'); recorder.feedQuat(quat); };
+        ble.gotGait = function (gait) { bumpCounter('gait'); recorder.feedGait(gait); };
+        ble.gotStride = function (stride) { bumpCounter('stride'); recorder.feedStride(stride); };
+        ble.gotPronation = function (pronation) { bumpCounter('pronation'); recorder.feedPronation(pronation); };
+        ble.gotLandingImpact = function (impact) { bumpCounter('landingImpact'); recorder.feedLandingImpact(impact); };
+        ble.gotFootAngle = function (footAngle) { bumpCounter('footAngle'); recorder.feedFootAngle(footAngle); };
+        ble.gotStepsNumber = function (steps) { bumpCounter('stepsNumber'); recorder.feedStepsNumber(steps); };
+
+        var btnStart = $('btn-start');
+        var btnStop = $('btn-stop');
+        var btnReset = $('btn-reset');
+        var btnCsv = $('btn-download-csv');
+        var btnJson = $('btn-download-json');
+        var sessionLabel = $('session-label');
+        var metaDevice = $('meta-device');
+
+        function refreshButtons() {
+            var hasSamples = recorder.size() > 0;
+            btnStart.disabled = recorder.isRecording();
+            btnStop.disabled = !recorder.isRecording();
+            btnReset.disabled = recorder.isRecording() || !hasSamples;
+            btnCsv.disabled = recorder.isRecording() || !hasSamples;
+            btnJson.disabled = recorder.isRecording() || !hasSamples;
+        }
+
+        btnStart.addEventListener('click', function () {
+            counters = {};
+            lastKind = '—';
+            recorder = new CoreRecorder({
+                session: sessionLabel.value || 'session',
+                meta: { device: metaDevice.value || 'unspecified', notification: NOTIFICATION },
+            });
+            // Re-bind feeds because we swapped the recorder instance.
+            ble.gotConvertedAcc = function (acc) { bumpCounter('acc'); recorder.feedAcc(acc); };
+            ble.gotConvertedGyro = function (gyro) { bumpCounter('gyro'); recorder.feedGyro(gyro); };
+            ble.gotEuler = function (euler) { bumpCounter('euler'); recorder.feedEuler(euler); };
+            ble.gotQuat = function (quat) { bumpCounter('quat'); recorder.feedQuat(quat); };
+            ble.gotGait = function (gait) { bumpCounter('gait'); recorder.feedGait(gait); };
+            ble.gotStride = function (stride) { bumpCounter('stride'); recorder.feedStride(stride); };
+            ble.gotPronation = function (pronation) { bumpCounter('pronation'); recorder.feedPronation(pronation); };
+            ble.gotLandingImpact = function (impact) { bumpCounter('landingImpact'); recorder.feedLandingImpact(impact); };
+            ble.gotFootAngle = function (footAngle) { bumpCounter('footAngle'); recorder.feedFootAngle(footAngle); };
+            ble.gotStepsNumber = function (steps) { bumpCounter('stepsNumber'); recorder.feedStepsNumber(steps); };
+
+            recorder.start();
+            refreshButtons();
+        });
+
+        btnStop.addEventListener('click', function () {
+            recorder.stop();
+            refreshButtons();
+        });
+
+        btnReset.addEventListener('click', function () {
+            counters = {};
+            lastKind = '—';
+            recorder = new CoreRecorder({
+                session: sessionLabel.value || 'session',
+                meta: { device: metaDevice.value || 'unspecified', notification: NOTIFICATION },
+            });
+            updateState(recorder);
+            refreshButtons();
+        });
+
+        btnCsv.addEventListener('click', function () {
+            var name = (sessionLabel.value || 'session') + '-' + timestampSuffix() + '.csv';
+            downloadBlob(name, 'text/csv', recorder.toCSV());
+        });
+
+        btnJson.addEventListener('click', function () {
+            var name = (sessionLabel.value || 'session') + '-' + timestampSuffix() + '.json';
+            downloadBlob(name, 'application/json', JSON.stringify(recorder.toJSON(), null, 2));
+        });
+
+        stateTimer = setInterval(function () {
+            updateState(recorder);
+            refreshButtons();
+        }, 250);
+
+        updateState(recorder);
+        refreshButtons();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+}());

--- a/examples/CSV-RECORDER/style.css
+++ b/examples/CSV-RECORDER/style.css
@@ -1,0 +1,6 @@
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+.card { border-radius: 0.75rem; }
+dl dt { color: #cfd8dc; font-weight: 500; }
+dl dd { color: #fff; margin-bottom: 0.25rem; }
+table.table-dark code { color: #80deea; }
+details summary { cursor: pointer; }


### PR DESCRIPTION
## Summary

New example `examples/CSV-RECORDER/` that records ORPHE CORE callback payloads to a flat CSV (and to JSON for replay) using the draft `js/CoreRecorder.js` helper. Status: `public-candidate (planned)`, **not yet listed in `examples/catalog.json`** — the README proposes the catalog entry so Codex can reconcile when promoting.

Pairs with [`docs/lessons/04-csv-recorder.md`](https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/claude/lessons-tier1-draft/docs/lessons/04-csv-recorder.md).

This PR is **based on `claude/core-recorder-api-draft`** (PR #81) so the CoreRecorder helper is available. After PR #81 merges, please rebase this onto `main`.

## Page wiring

- CoreToolkit creates `bles[0]` for one ORPHE CORE.
- `guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' })` is called immediately after `buildCoreToolkit` so non-Web-Bluetooth browsers get a clean message instead of a broken switch.
- Notification: `STEP_ANALYSIS_AND_SENSOR_VALUES`.
- The page explicitly owns `bles[0].gotConvertedAcc` / `gotConvertedGyro` / `gotEuler` / `gotQuat` / `gotGait` / `gotStride` / `gotPronation` / `gotLandingImpact` / `gotFootAngle` / `gotStepsNumber` and forwards each into `CoreRecorder.feed*`.
- Start / Stop / Reset / Download CSV / Download JSON buttons; per-kind sample counter table.

## Validation

- `node --check examples/CSV-RECORDER/sketch.js` — OK.
- `node scripts/check-examples-catalog.js` — `Catalog OK: 48 entries checked`.
- `node scripts/check-examples-static-quality.js` — 19 warnings, unchanged from main. The new example is not yet in the catalog, so the static check does not exercise it; that is intentional until Codex reconciles the catalog entry.

## Real-device validation

Not yet performed. Required before promoting from `public-candidate` to `public`:

- One ORPHE CORE connects, sample kinds appear in the counter table.
- Start / Stop / Reset / Download CSV / Download JSON all work for a 30-second walk.
- Downloaded CSV opens in Google Sheets and Excel without re-encoding.
- Downloaded JSON loads cleanly in the planned `REPLAY-PLAYER` example.

## Out of scope

- Editing `examples/catalog.json` — proposed entry lives in the README; Codex owns reconciliation.
- Editing `examples/SENSOR-CALIBRATION/recorder.js` — left untouched on purpose.
- Persistence (no localStorage, no IndexedDB).
- Multi-device recording. The page wires `bles[0]` only.
- Thumbnail generation. Capture from a real session before promoting.

## Questions for human

- Sample-cap behavior: should the recorder enforce a max-samples guard for very long sessions? Current PoC and helper both default to unbounded.
- CSV column order: lock to `CoreRecorder.CSV_COLUMNS` (current) or make per-page configurable?

## Next PR candidates

- `claude/example-replay-player-poc`: consume the same JSON to play recordings back without a device.
- After human review, Codex reconciles the proposed catalog entry into `examples/catalog.json`.