### PR TITLE
feat(examples): add STEP-COUNT-DASHBOARD PoC (depends on CoreAnalytics.js draft)

### DIFF
--- a/examples/STEP-COUNT-DASHBOARD/README.md
+++ b/examples/STEP-COUNT-DASHBOARD/README.md
@@ -1,0 +1,125 @@
+# Step Count Dashboard (PoC, draft)
+
+Status: `public-candidate` (planned). **Not yet listed in
+`examples/catalog.json`**. See "Proposed catalog metadata" below.
+
+A small page that renders live steps, rolling cadence, stride statistics, a
+baseline-vs-current comparison panel, and a CMJ readout, all driven by the
+draft `js/CoreAnalytics.js` helper. One device. Pairs with
+[Lesson 01](../../docs/lessons/01-step-count-dashboard.md),
+[Lesson 02](../../docs/lessons/02-stride-and-cadence.md),
+[Lesson 03](../../docs/lessons/03-lr-symmetry.md), and
+[Lesson 06](../../docs/lessons/06-vertical-jump-cmj.md).
+
+## What you can do without a device
+
+- Open the page in Chrome and confirm the layout, the empty-state baseline
+  table ("No baseline captured yet."), the disabled buttons, and the BLE
+  guard message in any browser without Web Bluetooth.
+
+## What you can do with a device
+
+- Connect one ORPHE CORE through the CoreToolkit switch.
+- Press **Start**, walk for 30 s, press **End**.
+- Press **Capture as baseline**, change the session label, **Start** again,
+  walk a different pace, **End**.
+- Compare the rows in the baseline-comparison table.
+- Perform a vertical jump and watch the CMJ panel update.
+
+## Run locally
+
+From the repo root:
+
+```bash
+python3 -m http.server 8767
+```
+
+Then open `http://localhost:8767/examples/STEP-COUNT-DASHBOARD/` in Chrome on
+macOS or Windows. Safari and Firefox cannot use the Web Bluetooth API and will
+show the guard message.
+
+## Notification type
+
+`STEP_ANALYSIS_AND_SENSOR_VALUES`. Steps, stride, pronation, landing impact,
+and step-number events drive the dashboard; converted accelerometer values
+drive the CMJ panel.
+
+## Files
+
+| File | Notes |
+|---|---|
+| `index.html` | Page layout, CoreToolkit placeholder, metric cards, controls. Loads `../../js/CoreAnalytics.js`. |
+| `sketch.js`  | Wires `bles[0]` callbacks to `CoreAnalytics.feed*`. Owns Start / End / Reset / Baseline buttons. |
+| `style.css`  | Light tweaks on top of Bootstrap. |
+| `README.md`  | This file. |
+
+## Dependencies
+
+- `js/ORPHE-CORE.js`, `js/CoreToolkit.js`, `js/BleSharedBridge.js`,
+  `js/quaternion.js` — existing core libraries.
+- `js/CoreAnalytics.js` — new module introduced in PR
+  `claude/core-analytics-api-draft`. **This example only works on top of that
+  PR.**
+
+## Proposed catalog metadata
+
+This example is not yet added to `examples/catalog.json`. Codex owns the
+catalog file. When promoting, the proposed entry is:
+
+```jsonc
+{
+  "id": "step-count-dashboard",
+  "title": "Step Count Dashboard",
+  "path": "examples/STEP-COUNT-DASHBOARD/",
+  "type": "web-app",
+  "status": "public-candidate",
+  "audience": ["education", "sports-science"],
+  "value": "Live steps, cadence, stride stats, CMJ, and baseline comparison driven by the draft CoreAnalytics.js helper.",
+  "topics": ["analytics", "steps", "cadence", "baseline", "cmj"],
+  "data": ["acc", "gait", "stride", "pronation", "landingImpact", "stepsNumber"],
+  "devices": 1,
+  "validation": ["browser-preview", "needs-real-device-validation"],
+  "category": "analysis",
+  "difficulty": "beginner",
+  "featured": false,
+  "thumbnail": "examples/_thumbnails/step-count-dashboard.png",
+  "sort_order": 210,
+  "links": {
+    "demo":   "examples/STEP-COUNT-DASHBOARD/index.html",
+    "source": "examples/STEP-COUNT-DASHBOARD/"
+  },
+  "requires_device": true,
+  "device_count": 1,
+  "needs_real_device_validation": true,
+  "public_navigation": "listed"
+}
+```
+
+Thumbnail (`examples/_thumbnails/step-count-dashboard.png`) is **not yet
+generated** — capture from a real session before promoting to `listed`.
+
+## Real-device validation
+
+Not yet performed. Required before promoting from `public-candidate` to
+`public`:
+
+- One ORPHE CORE connects, steps tick up during a walk.
+- Cadence reads sensible values (60–140 steps/min for normal walking).
+- Stride mean reads sensible values (0.4–1.2 m for normal walking).
+- Baseline capture and comparison rows update correctly after a second
+  session.
+- CMJ readout produces a flight-time and a height after a single jump
+  (height ≈ 10–50 cm depending on the jumper).
+
+## Out of scope
+
+- Multi-device setup. The page wires `bles[0]` only. The L/R Symmetry lesson
+  (Lesson 03) suggests a follow-up dual-device variant.
+- Persistence between page reloads.
+- Editing `examples/catalog.json`. Codex owns the catalog.
+
+## Open questions
+
+- Should the CMJ panel surface every jump (history table) or only the most
+  recent (current behavior)?
+- Cadence window: 10 s (current) or configurable?

--- a/examples/STEP-COUNT-DASHBOARD/index.html
+++ b/examples/STEP-COUNT-DASHBOARD/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Step Count Dashboard — ORPHE CORE.js (PoC, draft)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="./style.css">
+
+  <script src="../../js/quaternion.js"></script>
+  <script src="../../js/ORPHE-CORE.js"></script>
+  <script src="../../js/BleSharedBridge.js"></script>
+  <script src="../../js/CoreToolkit.js"></script>
+  <script src="../../js/CoreAnalytics.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"></script>
+  <script src="../../js/site-analytics.js"></script>
+</head>
+<body class="bg-dark text-light">
+  <div class="container py-4">
+    <header class="mb-4">
+      <h1 class="h3">Step Count Dashboard <span class="badge bg-warning text-dark">PoC · draft</span></h1>
+      <p class="text-secondary mb-1">
+        Live steps, rolling cadence, stride statistics, and a baseline-vs-current panel powered by the draft
+        <code>CoreAnalytics.js</code> helper. One device.
+      </p>
+      <p class="text-secondary small mb-0">
+        Status: <code>public-candidate (planned)</code>. Not yet listed in <code>examples/catalog.json</code>.
+        Proposed catalog metadata is in <a href="./README.md">README.md</a>.
+      </p>
+    </header>
+
+    <section class="mb-4">
+      <div id="toolkit_placeholder"></div>
+      <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome on macOS or Windows to connect ORPHE CORE.
+      </div>
+    </section>
+
+    <section class="row g-3 mb-4">
+      <div class="col-md-4">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h6 text-uppercase text-secondary">Steps</h2>
+            <p class="display-4 mb-0" id="metric-steps">0</p>
+            <p class="small text-secondary mb-0">Cumulative steps in the active session.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h6 text-uppercase text-secondary">Cadence</h2>
+            <p class="display-4 mb-0"><span id="metric-cadence">0</span><span class="h5 text-secondary"> steps/min</span></p>
+            <p class="small text-secondary mb-0">Rolling 10 s window.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h6 text-uppercase text-secondary">Stride</h2>
+            <p class="display-4 mb-0"><span id="metric-stride">0.00</span><span class="h5 text-secondary"> m</span></p>
+            <p class="small text-secondary mb-0">Mean of the last 20 stride events.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="row g-3 mb-4">
+      <div class="col-md-6">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h5">Session</h2>
+            <div class="d-flex flex-wrap gap-2 mb-3">
+              <button id="btn-start" class="btn btn-success" disabled>Start</button>
+              <button id="btn-end"   class="btn btn-warning" disabled>End</button>
+              <button id="btn-reset" class="btn btn-outline-light" disabled>Reset</button>
+            </div>
+            <label for="session-label" class="form-label small">Label</label>
+            <input id="session-label" class="form-control form-control-sm mb-2" type="text" value="warm-up" />
+            <p class="small text-secondary mb-0">Duration: <span id="session-duration">0.0 s</span></p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h5">Baseline</h2>
+            <p class="small text-secondary">
+              Capture the current session as a baseline, then compare future sessions against it.
+            </p>
+            <div class="d-flex flex-wrap gap-2 mb-3">
+              <button id="btn-capture-baseline" class="btn btn-info" disabled>Capture as baseline</button>
+              <button id="btn-clear-baseline"   class="btn btn-outline-light" disabled>Clear baseline</button>
+            </div>
+            <p class="small text-secondary mb-0">Baseline: <span id="baseline-label">—</span></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <div class="card bg-secondary bg-opacity-25 border-0">
+        <div class="card-body">
+          <h2 class="h5">Baseline comparison</h2>
+          <table class="table table-dark table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th scope="col">Metric</th>
+                <th scope="col" class="text-end">Baseline</th>
+                <th scope="col" class="text-end">Current</th>
+                <th scope="col" class="text-end">Δ</th>
+              </tr>
+            </thead>
+            <tbody id="baseline-compare-body">
+              <tr><td colspan="4" class="text-secondary text-center">No baseline captured yet.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <div class="card bg-secondary bg-opacity-25 border-0">
+        <div class="card-body">
+          <h2 class="h5">CMJ (countermovement jump)</h2>
+          <p class="small text-secondary mb-3">
+            Vertical jump events from <code>feedAcc</code>. Acceleration is in G, so wire <code>gotConvertedAcc</code>.
+            See <a href="../../docs/lessons/06-vertical-jump-cmj.md">Lesson 06</a> for the protocol.
+          </p>
+          <dl class="row mb-0 small">
+            <dt class="col-4">Last flight time</dt>
+            <dd class="col-8" id="cmj-flight">—</dd>
+            <dt class="col-4">Estimated height</dt>
+            <dd class="col-8" id="cmj-height">—</dd>
+          </dl>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <details>
+        <summary class="text-secondary">How this page is wired (draft)</summary>
+        <ol class="small text-secondary mt-2">
+          <li><code>CoreToolkit</code> creates <code>bles[0]</code> for one ORPHE CORE.</li>
+          <li><code>guardCoreToolkitBluetooth({ coreIds: [0] })</code> disables the BLE switch on browsers without Web Bluetooth.</li>
+          <li>The page replaces <code>bles[0].gotConvertedAcc</code>, <code>gotGait</code>, <code>gotStride</code>, <code>gotPronation</code>, and <code>gotStepsNumber</code> with handlers that call <code>CoreAnalytics</code>'s opt-in <code>feed*</code> methods.</li>
+          <li>A 250 ms timer reads <code>analytics.getSessionSummary()</code>, <code>getRollingCadence()</code>, <code>getStrideStats()</code>, <code>getLastCMJ()</code>, and <code>compareToBaseline()</code> to refresh the panels.</li>
+        </ol>
+      </details>
+    </section>
+  </div>
+
+  <script src="./sketch.js"></script>
+</body>
+</html>

--- a/examples/STEP-COUNT-DASHBOARD/sketch.js
+++ b/examples/STEP-COUNT-DASHBOARD/sketch.js
@@ -1,0 +1,181 @@
+/* Step Count Dashboard — PoC (draft).
+ *
+ * Wires CoreToolkit's bles[0] callbacks to the draft CoreAnalytics
+ * (js/CoreAnalytics.js) and renders steps / cadence / stride / CMJ /
+ * baseline-comparison panels.
+ */
+
+(function () {
+    'use strict';
+
+    var NOTIFICATION = 'STEP_ANALYSIS_AND_SENSOR_VALUES';
+    var refreshTimer = null;
+
+    function $(id) { return document.getElementById(id); }
+
+    function fmtNum(value, digits) {
+        if (value == null || isNaN(value)) return '—';
+        return Number(value).toFixed(digits != null ? digits : 0);
+    }
+
+    function fmtSigned(value, digits) {
+        if (value == null || isNaN(value)) return '—';
+        var formatted = Number(value).toFixed(digits != null ? digits : 2);
+        return Number(value) > 0 ? '+' + formatted : formatted;
+    }
+
+    function init() {
+        buildCoreToolkit(
+            $('toolkit_placeholder'),
+            'Step Dashboard',
+            0,
+            NOTIFICATION
+        );
+        guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
+
+        if (typeof bles === 'undefined' || !bles[0]) {
+            console.warn('STEP-COUNT-DASHBOARD: bles[0] is not available; CoreToolkit init failed.');
+            return;
+        }
+
+        var ble = bles[0];
+        ble.setup();
+
+        var analytics = new CoreAnalytics();
+
+        ble.gotConvertedAcc = function (acc) { analytics.feedAcc(acc); };
+        ble.gotGait = function (gait) { analytics.feedGait(gait); };
+        ble.gotStride = function (stride) { analytics.feedStride(stride); };
+        ble.gotPronation = function (pronation) { analytics.feedPronation(pronation); };
+        ble.gotStepsNumber = function (steps) { analytics.feedStepsNumber(steps); };
+        ble.gotLandingImpact = function (impact) { analytics.feedLandingImpact(impact); };
+
+        var btnStart = $('btn-start');
+        var btnEnd = $('btn-end');
+        var btnReset = $('btn-reset');
+        var btnCaptureBaseline = $('btn-capture-baseline');
+        var btnClearBaseline = $('btn-clear-baseline');
+        var sessionLabel = $('session-label');
+
+        var sessionActive = false;
+
+        function refreshButtons() {
+            var hasBaseline = analytics.getBaseline() != null;
+            var hasSummary = analytics.getSessionSummary() != null;
+            btnStart.disabled = sessionActive;
+            btnEnd.disabled = !sessionActive;
+            btnReset.disabled = sessionActive;
+            btnCaptureBaseline.disabled = !hasSummary;
+            btnClearBaseline.disabled = !hasBaseline;
+        }
+
+        function renderMetrics() {
+            var summary = analytics.getSessionSummary();
+            var cadence = analytics.getRollingCadence(10);
+            var stride = analytics.getStrideStats(20);
+            var cmj = analytics.getLastCMJ();
+
+            $('metric-steps').textContent = summary ? summary.steps : analytics.getStepsAccumulated().steps;
+            $('metric-cadence').textContent = fmtNum(cadence, 0);
+            $('metric-stride').textContent = stride ? fmtNum(stride.meanMeters, 2) : '0.00';
+            $('session-duration').textContent = (summary ? (summary.durationSec).toFixed(1) : '0.0') + ' s';
+            $('cmj-flight').textContent = cmj ? fmtNum(cmj.flightSec, 3) + ' s' : '—';
+            $('cmj-height').textContent = cmj ? fmtNum(cmj.heightMeters * 100, 1) + ' cm' : '—';
+
+            var compare = analytics.compareToBaseline();
+            var body = $('baseline-compare-body');
+            if (!compare) {
+                body.innerHTML = '<tr><td colspan="4" class="text-secondary text-center">No baseline captured yet.</td></tr>';
+            } else {
+                var rows = [
+                    {
+                        label: 'Steps',
+                        baseline: compare.baseline.steps,
+                        current: compare.current.steps,
+                        delta: compare.delta.steps,
+                        digits: 0,
+                    },
+                    {
+                        label: 'Cadence (steps/min)',
+                        baseline: compare.baseline.cadenceStepsPerMin,
+                        current: compare.current.cadenceStepsPerMin,
+                        delta: compare.delta.cadenceStepsPerMin,
+                        digits: 1,
+                    },
+                    {
+                        label: 'Stride mean (m)',
+                        baseline: compare.baseline.stride && compare.baseline.stride.meanMeters,
+                        current: compare.current.stride && compare.current.stride.meanMeters,
+                        delta: compare.delta.strideMeanMeters,
+                        digits: 2,
+                    },
+                    {
+                        label: 'Acc max (G)',
+                        baseline: compare.baseline.acc && compare.baseline.acc.maxG,
+                        current: compare.current.acc && compare.current.acc.maxG,
+                        delta: compare.delta.accMaxG,
+                        digits: 2,
+                    },
+                ];
+                body.innerHTML = rows.map(function (row) {
+                    return '<tr>' +
+                        '<td>' + row.label + '</td>' +
+                        '<td class="text-end">' + fmtNum(row.baseline, row.digits) + '</td>' +
+                        '<td class="text-end">' + fmtNum(row.current, row.digits) + '</td>' +
+                        '<td class="text-end">' + fmtSigned(row.delta, row.digits) + '</td>' +
+                        '</tr>';
+                }).join('');
+            }
+        }
+
+        btnStart.addEventListener('click', function () {
+            analytics.startSession(sessionLabel.value || 'session');
+            sessionActive = true;
+            refreshButtons();
+            renderMetrics();
+        });
+
+        btnEnd.addEventListener('click', function () {
+            analytics.endSession();
+            sessionActive = false;
+            refreshButtons();
+            renderMetrics();
+        });
+
+        btnReset.addEventListener('click', function () {
+            analytics.reset();
+            sessionActive = false;
+            $('baseline-label').textContent = '—';
+            refreshButtons();
+            renderMetrics();
+        });
+
+        btnCaptureBaseline.addEventListener('click', function () {
+            var baseline = analytics.captureBaseline();
+            $('baseline-label').textContent = baseline ? (baseline.label + ' · ' + baseline.steps + ' steps') : '—';
+            refreshButtons();
+            renderMetrics();
+        });
+
+        btnClearBaseline.addEventListener('click', function () {
+            analytics.setBaseline(null);
+            $('baseline-label').textContent = '—';
+            refreshButtons();
+            renderMetrics();
+        });
+
+        refreshTimer = setInterval(function () {
+            renderMetrics();
+            refreshButtons();
+        }, 250);
+
+        renderMetrics();
+        refreshButtons();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+}());

--- a/examples/STEP-COUNT-DASHBOARD/style.css
+++ b/examples/STEP-COUNT-DASHBOARD/style.css
@@ -1,0 +1,5 @@
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+.card { border-radius: 0.75rem; }
+.display-4 { line-height: 1.1; }
+table.table-dark code { color: #80deea; }
+details summary { cursor: pointer; }


### PR DESCRIPTION
## Summary

New example `examples/STEP-COUNT-DASHBOARD/` that renders live steps, rolling cadence, stride statistics, a baseline-vs-current comparison panel, and a CMJ readout from one ORPHE CORE. Uses the draft `js/CoreAnalytics.js` helper. Status: `public-candidate (planned)`, **not yet listed in `examples/catalog.json`** — the README proposes the catalog entry so Codex can reconcile when promoting.

Pairs with [Lesson 01](https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/claude/lessons-tier1-draft/docs/lessons/01-step-count-dashboard.md), [02](https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/claude/lessons-tier1-draft/docs/lessons/02-stride-and-cadence.md), [03](https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/claude/lessons-tier1-draft/docs/lessons/03-lr-symmetry.md) (single-foot view), and [06](https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/claude/lessons-tier1-draft/docs/lessons/06-vertical-jump-cmj.md).

This PR is **based on `claude/core-analytics-api-draft`** (PR #79). After PR #79 merges, please rebase this onto `main`.

## Page wiring

- CoreToolkit creates `bles[0]` for one ORPHE CORE.
- `guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' })` is called immediately after `buildCoreToolkit`.
- Notification: `STEP_ANALYSIS_AND_SENSOR_VALUES`.
- The page explicitly owns `bles[0].gotConvertedAcc` / `gotGait` / `gotStride` / `gotPronation` / `gotStepsNumber` / `gotLandingImpact` and forwards each into the matching `CoreAnalytics.feed*`.
- A 250 ms timer reads `analytics.getSessionSummary()`, `getRollingCadence(10)`, `getStrideStats(20)`, `getLastCMJ()`, and `compareToBaseline()` and refreshes the panels.
- Start / End / Reset / Capture-as-baseline / Clear-baseline.

## Validation

- `node --check examples/STEP-COUNT-DASHBOARD/sketch.js` — OK.
- `node scripts/check-examples-catalog.js` — `Catalog OK: 48 entries checked`.
- `node scripts/check-examples-static-quality.js` — 19 warnings, unchanged from main. The new example is not yet in the catalog, so the static check does not exercise it; that is intentional until Codex reconciles the catalog entry.

## Real-device validation

Not yet performed. Required before promoting from `public-candidate` to `public`:

- One ORPHE CORE connects, steps tick up during a walk.
- Cadence reads sensible values (60–140 steps/min for normal walking).
- Stride mean reads sensible values (0.4–1.2 m for normal walking).
- Baseline capture and comparison rows update correctly after a second session.
- CMJ readout produces a flight time and a height after a single jump (height ≈ 10–50 cm).

## Out of scope

- Editing `examples/catalog.json`. Codex owns the catalog. Proposed entry is in the README.
- Multi-device setup. The page wires `bles[0]` only.
- Persistence between page reloads.
- Thumbnail generation. Capture from a real session before promoting.

## Questions for human

- CMJ panel: surface the most recent jump only (current) or a history table?
- Cadence window: locked at 10 s (current) or configurable?
- Baseline label rendering: show the captured session's `label` plus its step count (current) or a richer summary?

## Next PR candidates

- After PR #79 merges, rebase this onto main.
- Codex reconciles the proposed catalog entry into `examples/catalog.json` and generates the thumbnail.
- Optional follow-up: dual-device variant for the L/R Symmetry lesson.