### PR TITLE
docs: add Tier 2 lesson plans (07–10)

### DIFF
--- a/docs/lessons/07-signal-processing.md
+++ b/docs/lessons/07-signal-processing.md
@@ -1,0 +1,166 @@
+# Lesson 07: Signal Processing Intro (Filters and Smoothing)
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students who have completed at least one Tier 1 lesson and have
+  written a small JavaScript callback before.
+- Devices: 1 ORPHE CORE per learner pair.
+- Notification: `SENSOR_VALUES`. Range `acc=16`, `gyro=2000` so peaks aren't
+  clipped.
+- Example: any page that exposes `bles[0].gotConvertedAcc` (e.g.
+  `examples/CORETOOLKIT-STARTER/`). The lesson is run from the developer
+  console — no new example is required.
+- Browser: Chrome on macOS or Windows.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Explain why a raw IMU stream needs filtering before most kinds of
+   downstream analysis.
+2. Implement a moving-average filter and a simple low-pass (exponential)
+   filter on `gotConvertedAcc` and describe what each one removes.
+3. Choose a filter (or no filter) given a downstream task — step counting,
+   CMJ peak detection, posture, and one they invent.
+
+## Required materials
+
+- One laptop per pair, charged.
+- One ORPHE CORE per pair, charged, mounted on the dominant foot.
+- A 5 m walking lane.
+- A clear floor area for one short jump.
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm the connection switch works in `CORETOOLKIT-STARTER` and the
+  `gotConvertedAcc` magnitude is sensible while standing (~1 G).
+- Print the table of "filter vs use case" from the discussion section so
+  learners can fill it in during class.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show one raw acceleration trace from a 3 s stand. Ask: "Why is the line never flat?" |
+| 5–15 min | Concept | Walk through three sources of noise: sensor noise, mounting noise, and biological noise. Introduce moving average and exponential smoothing as two different answers. |
+| 15–35 min | Hands-on | Pairs paste two filter snippets into the developer console while standing, walking, and jumping. They report the magnitude before and after each filter. |
+| 35–42 min | Choose | Pairs map four downstream tasks (step count, CMJ peak, posture, one of their own) to "no filter / moving average / low-pass" and justify each choice in one sentence. |
+| 42–45 min | Debrief | Each pair reads one of their filter choices and the justification. |
+
+## Hands-on activity
+
+Open `CORETOOLKIT-STARTER`, turn on the BLE switch, and paste the following
+into the developer console:
+
+```javascript
+// State for the filters.
+window.filterState = {
+  raw: [],
+  movingAvg: [],
+  lowPass: { y: null },
+};
+
+// Moving average over the last N samples.
+function movingAverage(buffer, sample, n) {
+  buffer.push(sample);
+  if (buffer.length > n) buffer.shift();
+  return buffer.reduce((a, b) => a + b, 0) / buffer.length;
+}
+
+// Exponential smoothing (1-pole low-pass). alpha = 1 means no filter.
+function lowPass(state, sample, alpha) {
+  if (state.y == null) state.y = sample;
+  state.y = state.y + alpha * (sample - state.y);
+  return state.y;
+}
+
+bles[0].gotConvertedAcc = function (acc) {
+  const magnitude = Math.hypot(acc.x, acc.y, acc.z);
+  const ma = movingAverage(window.filterState.movingAvg, magnitude, 10);
+  const lp = lowPass(window.filterState.lowPass, magnitude, 0.1);
+  window.filterState.raw.push(magnitude);
+  if (window.filterState.raw.length > 200) window.filterState.raw.shift();
+  console.log(`raw ${magnitude.toFixed(2)} | ma ${ma.toFixed(2)} | lp ${lp.toFixed(2)}`);
+};
+```
+
+Trial table:
+
+| Trial | Activity | raw mean | ma mean | lp mean | raw peak | ma peak | lp peak |
+|---|---|---|---|---|---|---|---|
+| 1 | Stand still 5 s | | | | | | |
+| 2 | Walk 5 s | | | | | | |
+| 3 | One CMJ | | | | | | |
+
+The point of trial 3 is to make the trade-off visible: a long moving average
+will smear the CMJ peak, a low-pass with a small alpha will smooth standing
+noise but lag during the jump.
+
+## Discussion prompts
+
+- "When is `alpha = 0.1` better than a 10-sample moving average?" Use to
+  introduce frequency response intuitively.
+- "If your filter changes the timing of a peak, can you still call it a peak?"
+  Use to introduce phase delay.
+- "If the device sampled at 50 Hz instead of 200 Hz, would the same filter
+  do the same thing?" Use to motivate why filter parameters depend on
+  sampling rate.
+
+## Filter-vs-task table
+
+Have learners fill this in during the "Choose" block:
+
+| Task | Recommended filter | Why |
+|---|---|---|
+| Step count from `gotConvertedAcc` | | |
+| CMJ landing peak | | |
+| Standing posture (mean tilt) | | |
+| _Your own task_ | | |
+
+Reasonable answers:
+- Step count: short moving average or no filter; the gait callback already
+  encapsulates a detector.
+- CMJ landing peak: no filter; smoothing reduces the peak you are trying to
+  measure.
+- Standing posture: long moving average or low-pass; you want the signal that
+  is _not_ moving.
+
+## Assessment ideas
+
+- A short reflection naming one situation where adding a filter would mask a
+  bug rather than fix one.
+- A code review where learners explain the difference between "filter the
+  stream" and "filter what you log."
+
+## Safety and ethics
+
+- No new physical risk. Standard CMJ safety from Lesson 06 applies if you
+  include a jump trial.
+
+## References
+
+- Smith, S. W. _The Scientist and Engineer's Guide to Digital Signal
+  Processing_. California Technical Publishing, 1997. Free online; chapters
+  on moving average and recursive filters are accessible to non-EE majors.
+- Oppenheim, A. V. and Schafer, R. W. _Discrete-Time Signal Processing_. 3rd
+  ed., Pearson, 2010. Reference for instructors who want the formal version.
+
+## Out of scope
+
+- Frequency-domain methods (FFT, spectrograms). Defer to a Tier 3 lesson.
+- Causal vs non-causal filters. Mention only.
+- Filter design from a target frequency response. The lesson teaches two
+  filters by name, not by derivation.
+
+## Open questions for the human owner
+
+- Do we want to ship a small filter helper inside `CoreAnalytics` later
+  (e.g. `CoreAnalytics.movingAverage`) so learners stop pasting console
+  code?
+- Should the lesson include an FFT excursion at the end, or stay strictly
+  time-domain?

--- a/docs/lessons/08-gait-variability.md
+++ b/docs/lessons/08-gait-variability.md
@@ -1,0 +1,146 @@
+# Lesson 08: Gait Variability
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students who have completed Lesson 02 (Stride & Cadence) and are
+  comfortable computing a mean and a standard deviation in a spreadsheet or
+  notebook.
+- Devices: 1 ORPHE CORE per learner pair.
+- Notification: `STEP_ANALYSIS`.
+- Example: planned `examples/STEP-COUNT-DASHBOARD/` (PR #83) when it lands;
+  fallback path is `examples/CORETOOLKIT-STARTER/` with a developer-console
+  collector.
+- Browser: Chrome on macOS or Windows.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Define gait variability and explain why a stable mean stride does not
+   imply low variability.
+2. Compute the coefficient of variation (CoV) of stride length and swing
+   time and explain what each tells you about the walker.
+3. Identify two situations where higher variability is healthy and two
+   where it is a warning sign.
+
+## Required materials
+
+- One laptop per pair, charged.
+- One ORPHE CORE per pair, charged.
+- A 20 m walking lane (a corridor works) or a 10 m lane walked twice.
+- A spreadsheet for the post-collection inspection.
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm the data collector path opens cleanly and produces stride and gait
+  events in the console while walking.
+- Print the trial table so learners do not lose data while typing.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show two short clips of walkers (or describe them verbally). Ask: "Which one would you trust to walk down a step in the dark?" Introduce the idea that walking _consistency_ is itself a signal. |
+| 5–15 min | Concept | Define mean, standard deviation (SD), and CoV = SD / mean × 100. Walk through why CoV is unitless and why it is useful when comparing strides across people. |
+| 15–35 min | Hands-on | Pairs walk three trials: normal pace 20 m, dual-task pace (counting backward from 100 by 7s) 20 m, and tired pace (after a 30 s shuttle). They collect at least 12 strides per trial. |
+| 35–42 min | Compute | Pairs compute mean and CoV of stride magnitude and swing time per trial. |
+| 42–45 min | Debrief | Each pair compares the three trials and proposes a hypothesis for the change. |
+
+## Hands-on activity
+
+Each trial yields 12+ strides. The trial table is:
+
+| Trial | Description | Strides collected | Mean stride (m) | SD stride (m) | CoV stride (%) | Mean swing (s) | CoV swing (%) |
+|---|---|---|---|---|---|---|---|
+| 1 | Normal pace 20 m | | | | | | |
+| 2 | Dual-task (count backward) 20 m | | | | | | |
+| 3 | After 30 s shuttle | | | | | | |
+
+Expected pattern: CoV typically increases under dual-task and after fatigue.
+The size of the increase is the discussion, not just the direction.
+
+## Code snippet for the fallback path
+
+If the planned `STEP-COUNT-DASHBOARD` is not yet on `main`, paste the
+following into the developer console of `CORETOOLKIT-STARTER` while walking:
+
+```javascript
+window.gaitLog = { strides: [], gaits: [] };
+bles[0].gotStride = function (stride) {
+  window.gaitLog.strides.push({ t: performance.now(), magnitude: Math.hypot(stride.x, stride.y, stride.z) });
+};
+bles[0].gotGait = function (gait) {
+  window.gaitLog.gaits.push({
+    t: performance.now(),
+    swing: gait.swing_phase_duration,
+    stance: gait.standing_phase_duration,
+  });
+};
+
+function statsFor(values) {
+  const mean = values.reduce((a, b) => a + b, 0) / (values.length || 1);
+  const sd = Math.sqrt(values.reduce((s, v) => s + (v - mean) ** 2, 0) / (values.length || 1));
+  return { n: values.length, mean, sd, covPercent: mean === 0 ? NaN : (sd / mean) * 100 };
+}
+
+function trialReport() {
+  return {
+    stride: statsFor(window.gaitLog.strides.map(s => s.magnitude)),
+    swing: statsFor(window.gaitLog.gaits.map(g => g.swing).filter(v => typeof v === 'number')),
+  };
+}
+```
+
+Reset between trials with `window.gaitLog = { strides: [], gaits: [] };`.
+
+## Discussion prompts
+
+- "Why is CoV better than SD for comparing your stride to a friend's?" Use
+  to introduce normalization.
+- "Name a situation where high stride CoV is a good thing." Examples:
+  navigating obstacles, terrain adaptation. The point is variability is
+  not pathology by default.
+- "Your CoV is 6% in trial 1 and 14% in trial 2. Can you say the dual task
+  caused the change with this data?" Use to introduce the difference between
+  description and inference.
+
+## Assessment ideas
+
+- A short report comparing the three trials with one paragraph on what would
+  have to be true for the difference to be considered clinically meaningful.
+- A code reading exercise where learners explain why CoV uses SD divided by
+  mean and what happens when mean is small.
+
+## Safety and ethics
+
+- The 30 s shuttle should be voluntary; offer an alternative where a partner
+  carries a 5 kg bag instead.
+- Variability data feels personal. Do not require learners to share their
+  numbers.
+
+## References
+
+- Hausdorff, J. M. "Gait Variability: Methods, Modeling and Meaning."
+  _Journal of NeuroEngineering and Rehabilitation_, vol. 2, no. 19, 2005.
+  Authoritative review for the lesson.
+- Hollman, J. H., McDade, E. M., and Petersen, R. C. "Normative Spatiotemporal
+  Gait Parameters in Older Adults." _Gait & Posture_, vol. 34, no. 1, 2011.
+  Use as a reference for typical CoV ranges.
+
+## Out of scope
+
+- Detrended fluctuation analysis or other long-range correlation methods.
+- Inferential statistics across cohorts. Lesson is descriptive.
+
+## Open questions for the human owner
+
+- Should `CoreAnalytics` expose a `getStrideStats` that includes CoV
+  directly? Currently it returns mean and SD only.
+- Do we want a recommended "minimum strides for a meaningful CoV" number to
+  print in the lesson? Literature commonly cites 30+ strides for stable
+  estimates; classroom slots may not allow this.

--- a/docs/lessons/09-foot-angle-at-landing.md
+++ b/docs/lessons/09-foot-angle-at-landing.md
@@ -1,0 +1,160 @@
+# Lesson 09: Foot Angle at Landing
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students with prior gait vocabulary (Lessons 01 and 02) and
+  basic familiarity with the difference between a peak detector and a
+  continuous signal.
+- Devices: 1 ORPHE CORE per learner pair, mounted firmly on the dominant
+  foot.
+- Notification: `STEP_ANALYSIS_AND_SENSOR_VALUES`. The lesson uses
+  `gotFootAngle`, `gotLandingImpact`, and `gotPronation`.
+- Example: planned `examples/FOOT-ANGLE-DASHBOARD/` (sibling PR in this
+  Tier 2 sprint). Fallback: `examples/CORETOOLKIT-STARTER/` with a
+  developer-console collector.
+- Browser: Chrome on macOS or Windows.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Define foot angle at landing (also called foot strike angle) and explain
+   why it is one of several plausible characterizations of "how the foot
+   meets the ground."
+2. Read the three callback payloads relevant to landing (`gotFootAngle`,
+   `gotLandingImpact`, `gotPronation`) and explain what each does and does
+   not capture.
+3. Distinguish three commonly described landing styles (heel, midfoot, fore)
+   from the foot-angle signal and discuss why a bin label is not the same
+   as a measurement.
+
+## Required materials
+
+- One laptop per pair, charged.
+- One ORPHE CORE per pair, charged.
+- A 10 m walking lane and a 10 m jogging lane (the same lane is fine).
+- Optional: a phone with a slow-motion camera for cross-checking landing
+  style.
+
+## Pre-class setup
+
+The instructor should:
+
+- Confirm `gotFootAngle` events fire while walking on the planned dashboard
+  or in the fallback console collector.
+- Decide and announce the heel/midfoot/fore bin thresholds the lesson will
+  use, to keep classroom variability honest. A reasonable starting set is
+  `< 5°` fore, `5–15°` midfoot, `> 15°` heel; the actual numbers depend on
+  mounting and should be re-validated against camera footage when possible.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show one slow-motion clip of a heel landing and one of a forefoot landing. Ask: "What do you think the device is going to disagree with you about?" |
+| 5–15 min | Concept | Walk through the three callbacks. `gotFootAngle.value` is the angle at landing. `gotLandingImpact.value` is a magnitude proxy. `gotPronation` is a 3-axis rotation. Discuss why the device cannot label "heel/midfoot/fore" by itself. |
+| 15–35 min | Hands-on | Pairs perform three sets of 10 walks and 10 jogs each, deliberately changing landing style between sets. They record foot angle, landing impact, and pronation per stride. |
+| 35–42 min | Bin | Pairs assign each stride to one of the three landing-style bins using the announced thresholds. They count agreements and disagreements with their intended style. |
+| 42–45 min | Debrief | Pairs share one stride that the device labeled differently than they intended and propose why. |
+
+## Hands-on activity
+
+| Trial | Activity | n strides | Mean foot angle (°) | Mean landing impact | Mean pronation magnitude | Bin distribution (heel / mid / fore) |
+|---|---|---|---|---|---|---|
+| 1 | Walk, deliberately heel-strike | | | | | |
+| 2 | Walk, deliberately fore-strike | | | | | |
+| 3 | Jog, natural | | | | | |
+
+The point of trial 3 is to surface that "natural" is not a single bin —
+many learners' jog landings are bimodal across the foot.
+
+## Code snippet for the fallback path
+
+If `FOOT-ANGLE-DASHBOARD` is not yet available, paste the following into the
+developer console of `CORETOOLKIT-STARTER`:
+
+```javascript
+window.landingLog = [];
+bles[0].gotFootAngle = function (fa) {
+  window.landingLog.push({ t: performance.now(), angle: fa.value });
+};
+bles[0].gotLandingImpact = function (li) {
+  const last = window.landingLog[window.landingLog.length - 1];
+  if (last && performance.now() - last.t < 100) last.impact = li.value;
+};
+bles[0].gotPronation = function (p) {
+  const last = window.landingLog[window.landingLog.length - 1];
+  if (last && performance.now() - last.t < 100) {
+    last.pronationMagnitude = Math.hypot(p.x, p.y, p.z);
+  }
+};
+
+function binStride(angle) {
+  if (angle < 5)  return 'fore';
+  if (angle < 15) return 'mid';
+  return 'heel';
+}
+
+function trialReport() {
+  const samples = window.landingLog.slice();
+  const bins = { heel: 0, mid: 0, fore: 0 };
+  for (const s of samples) {
+    if (typeof s.angle === 'number') bins[binStride(s.angle)]++;
+  }
+  return { n: samples.length, bins, samples };
+}
+```
+
+Reset between trials with `window.landingLog = [];`.
+
+## Discussion prompts
+
+- "Why is a single threshold table never the right answer for cross-learner
+  comparison?" Use to motivate that mounting and shoe geometry shift the
+  numbers.
+- "If your jog produces a bimodal foot-angle distribution, is that a coaching
+  moment or a measurement moment?"
+- "What would change if the device were on the other foot?"
+
+## Assessment ideas
+
+- A short reflection comparing the bin thresholds the class used to a
+  threshold scheme the learner finds in the literature, with one paragraph
+  on which they would prefer for their own data and why.
+- A code review where learners explain why the snippet attaches `impact`
+  and `pronationMagnitude` to the most recent foot-angle sample within a
+  100 ms window, and what assumption that bakes in.
+
+## Safety and ethics
+
+- Deliberately changing landing style risks discomfort. Allow pairs to opt
+  out and act as recorders. Do not push to fatigue.
+- Slow-motion video, if used, should be deleted at the end of class unless
+  a separate consent has been collected.
+
+## References
+
+- Lieberman, D. E. et al. "Foot Strike Patterns and Collision Forces in
+  Habitually Barefoot Versus Shod Runners." _Nature_, vol. 463, no. 7280,
+  2010. Use to ground the discussion of why landing style is interesting.
+- Altman, A. R. and Davis, I. S. "A Kinematic Method for Footstrike Pattern
+  Detection in Barefoot and Shod Runners." _Gait & Posture_, vol. 35, no. 2,
+  2012. Use as a reference for the angle-based classification scheme that
+  the lesson loosely follows.
+
+## Out of scope
+
+- Force-platform comparisons. ORPHE CORE is an inertial sensor.
+- Coaching or shoe-recommendation conclusions. The lesson is about
+  measurement, not prescription.
+
+## Open questions for the human owner
+
+- The bin thresholds (5° / 15°) are placeholders. Should they be tuned per
+  cohort against camera footage before the lesson is published?
+- Should the planned `FOOT-ANGLE-DASHBOARD` example expose the bin
+  thresholds as a UI control, or hard-code them and let the lesson discuss
+  the trade-off?

--- a/docs/lessons/10-from-recording-to-research.md
+++ b/docs/lessons/10-from-recording-to-research.md
@@ -1,0 +1,156 @@
+# Lesson 10: From Recording to Research
+
+Status: `draft`. Reviewed by: _none yet_.
+
+## At a glance
+
+- Duration: 45 minutes.
+- Audience: students who have completed at least Lessons 04 (CSV Recorder)
+  and 05 (Replay Player), or who arrive with their own recorded session.
+- Devices: 0 (workflow lesson). One ORPHE CORE if the class collects a fresh
+  recording during the session.
+- Notification: any. The lesson is about what happens after the device is
+  put away.
+- Example: planned `examples/CSV-RECORDER/` (PR #82) and
+  `examples/REPLAY-PLAYER/` (PR #84). Until those land, use any existing
+  recorded JSON the instructor has on hand.
+- Browser: Chrome on macOS or Windows for any live BLE work; any browser
+  for replay and analysis.
+
+## Learning objectives
+
+By the end of the session, learners can:
+
+1. Describe the four stages of an end-to-end ORPHE CORE workflow —
+   record, replay, analyze, share — and one decision that lives in each
+   stage.
+2. Distinguish between data wrangling that is documentation
+   (reproducible, version-controlled) and data wrangling that is throwaway
+   (one-off scripts in a notebook).
+3. Outline a small research-style question their cohort could answer with
+   one ORPHE CORE and a 30-minute protocol, and identify where the project
+   would stop in this lesson.
+
+## Required materials
+
+- One laptop per pair, charged.
+- A previously recorded JSON file shared by the instructor, or one collected
+  in the first 5 minutes of class.
+- A blank document (any editor) for the project skeleton activity.
+
+## Pre-class setup
+
+The instructor should:
+
+- Have a 60-second recorded JSON file (synthetic or real) ready to share via
+  a URL or a local file copy.
+- Pick the worked example for the "analyze" stage. Reasonable choices:
+  cadence over time, stride CoV across the recording, or a CMJ event count.
+- Decide whether the cohort is going to share recordings publicly or only
+  inside the room — this changes the "share" stage discussion.
+
+## Schedule
+
+| Time | Block | Activity |
+|---|---|---|
+| 0–5 min | Frame | Show a recording, a derived plot, and one sentence of conclusion. Ask: "What did the analyst _decide_ that you cannot see in the plot?" |
+| 5–15 min | Concept | Walk through the four-stage workflow on the board. For each stage, name one decision and one common failure mode. |
+| 15–30 min | Hands-on | Pairs replay the shared recording in the planned `REPLAY-PLAYER` example (or a developer-console replay), compute the worked example metric, and write down their result. |
+| 30–40 min | Project | Each pair drafts a one-page project skeleton using the supplied template. |
+| 40–45 min | Debrief | Two pairs read their project skeleton aloud and the class flags the one decision that would most change the result. |
+
+## The four-stage workflow
+
+| Stage | One decision | One failure mode |
+|---|---|---|
+| Record | What to record (notification type, device range, session length). | Recording everything, then realizing the per-trial label is missing. |
+| Replay | Replay speed, which handlers to wire. | Treating replayed time as wall time in downstream code. |
+| Analyze | Which metric, which subset, which baseline. | Sliding the analysis until the desired result appears. |
+| Share | Who sees the recording, the metric, or only the conclusion. | Shipping a CSV with identifiers because nobody removed them. |
+
+## Project skeleton template
+
+Pairs fill this in during the 10-minute "Project" block.
+
+```
+Title:
+  (One sentence stating the question.)
+
+Cohort and N:
+  (Who, how many, recruited how.)
+
+Protocol (30 minutes total):
+  Step 1 ........... (e.g. baseline 2 minute walk)
+  Step 2 ...........
+  Step 3 ...........
+
+Recording configuration:
+  Notification type:
+  Range (acc, gyro):
+  Session label:
+  Metadata to attach:
+
+Analysis plan:
+  Metric:
+  Comparison:
+  What would convince you of the answer?
+
+Sharing plan:
+  Who sees the recording:
+  Who sees the derived metric:
+  Who sees only the conclusion:
+
+Where this project stops in this lesson:
+  (Be honest about what is doable in 30 minutes vs what becomes a follow-up.)
+```
+
+## Discussion prompts
+
+- "If two researchers analyze the same recording and report different
+  numbers, where in the four stages did they diverge?"
+- "Which stage do you think is the most reproducible, and which the least?"
+- "What is the smallest change to the recording stage that would force a
+  change in the sharing stage?" Use to surface that consent and identifiers
+  must be decided up front, not at publication.
+
+## Assessment ideas
+
+- A one-page reflection turning the project skeleton into a paragraph the
+  learner could send to a mentor for feedback.
+- A code review where learners trace one analysis script (their own or
+  shared) and annotate which choices are documented and which are
+  throwaway.
+
+## Safety and ethics
+
+- This is the lesson where the cohort confronts data ethics directly.
+  Reserve at least 5 minutes of the share-stage discussion for real consent,
+  not abstract consent. If the class is going to share recordings outside
+  the room, walk through the explicit decision before the recording starts,
+  not after.
+
+## References
+
+- Wickham, H. and Grolemund, G. _R for Data Science_. 2nd ed., O'Reilly,
+  2023. Free online; the chapters on workflow and reproducibility translate
+  cleanly to JavaScript notebooks.
+- Sandve, G. K. et al. "Ten Simple Rules for Reproducible Computational
+  Research." _PLOS Computational Biology_, vol. 9, no. 10, 2013. Short and
+  classroom-friendly.
+- Wilkinson, M. D. et al. "The FAIR Guiding Principles for Scientific Data
+  Management and Stewardship." _Scientific Data_, vol. 3, 2016. Use the
+  one-paragraph summary, not the full article, in class.
+
+## Out of scope
+
+- Statistical inference, hypothesis testing, or sample-size justification.
+- Choice of programming language for the analysis stage. The lesson is
+  language-agnostic on purpose.
+- Publication strategy and authorship.
+
+## Open questions for the human owner
+
+- Should this lesson live as Lesson 10 in the Tier 1 ladder, or be moved
+  into a separate "research workflow" track once we add Tier 3 lessons?
+- Do we want to ship a worked-example notebook (Python or JS) alongside
+  this lesson? It would anchor the "analyze" stage in code.

--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -29,6 +29,24 @@ this sprint. Until those land, instructors can run the lesson against
 `examples/CORETOOLKIT-STARTER/` for steps 1–3 and `examples/SENSOR-CALIBRATION/`
 for step 4 — the lesson plans call this out explicitly.
 
+## Tier 2 Lessons
+
+The Tier 2 plans extend the Tier 1 ladder. They share the same 45-minute
+shape and the same "Status: draft" caveat. Each one names the example it
+pairs with and a fallback path that uses an existing example.
+
+| # | Lesson | Example | Notification | Devices |
+|---|---|---|---|---|
+| 7  | [Signal Processing Intro](./07-signal-processing.md) | any page exposing `gotConvertedAcc` (e.g. `CORETOOLKIT-STARTER`) | `SENSOR_VALUES` | 1 |
+| 8  | [Gait Variability](./08-gait-variability.md) | `examples/STEP-COUNT-DASHBOARD/` _(planned)_ or `CORETOOLKIT-STARTER` fallback | `STEP_ANALYSIS` | 1 |
+| 9  | [Foot Angle at Landing](./09-foot-angle-at-landing.md) | `examples/FOOT-ANGLE-DASHBOARD/` _(planned)_ or `CORETOOLKIT-STARTER` fallback | `STEP_ANALYSIS_AND_SENSOR_VALUES` | 1 |
+| 10 | [From Recording to Research](./10-from-recording-to-research.md) | planned `CSV-RECORDER` + `REPLAY-PLAYER`, or any prior recording | any | 0–1 |
+
+Tier 2 assumes Tier 1 vocabulary. Lessons 07 and 08 stand alone; Lesson 09
+pairs with the Tier 2 `FOOT-ANGLE-DASHBOARD` example introduced in this
+sprint; Lesson 10 is a workflow / meta-lesson that ties recording, replay,
+analysis, and sharing together.
+
 ## Educator framing
 
 All Tier 1 lessons assume:


### PR DESCRIPTION
## Summary

Four 45-minute Tier 2 lesson plans that extend the Tier 1 ladder with signal processing, gait variability, foot angle at landing, and an end-to-end research-workflow lesson. Same draft shape as Tier 1 (learning objectives, schedule, hands-on activity, fallback console snippet, discussion prompts, assessment ideas, references, out of scope, open questions for the human owner).

| # | Lesson | Pairs with |
|---|---|---|
| 07 | Signal Processing Intro (filters and smoothing on `gotConvertedAcc`) | Any page exposing `gotConvertedAcc`; standalone |
| 08 | Gait Variability (CoV of stride and swing time) | Planned `STEP-COUNT-DASHBOARD` (PR #83) or `CORETOOLKIT-STARTER` fallback |
| 09 | Foot Angle at Landing (`gotFootAngle` + `gotLandingImpact` + `gotPronation`) | Planned `FOOT-ANGLE-DASHBOARD` (sibling Tier 2 PR) or `CORETOOLKIT-STARTER` fallback |
| 10 | From Recording to Research (record → replay → analyze → share) | Planned `CSV-RECORDER` (PR #82) + `REPLAY-PLAYER` (PR #84), or any prior recording |

`docs/lessons/README.md` is updated with the Tier 2 table and a one-line note that Tier 2 assumes Tier 1 vocabulary. The Tier 1 entries are unchanged.

## Validation

- `node scripts/check-examples-catalog.js` — `Catalog OK: 48 entries checked`.
- `node scripts/check-examples-static-quality.js` — 0 errors, 0 warnings, 0 info.
- No JS files added or modified.
- Diff scope is `docs/lessons/07-*.md`, `docs/lessons/08-*.md`, `docs/lessons/09-*.md`, `docs/lessons/10-*.md`, and `docs/lessons/README.md`.

## Assumptions

- Tier 2 reuses the Tier 1 lesson shape (Status: draft, References, Out of scope, Open questions for the human owner).
- The Lesson 09 example (`FOOT-ANGLE-DASHBOARD`) is being introduced in a sibling PR in this Tier 2 sprint. Lessons 08 and 10 reference Tier 1 helper PRs (#83, #82, #84) and are usable today via fallback paths.
- Citations were chosen for accessibility to non-EE / non-clinical instructors (Smith DSP, Hausdorff gait variability review, Lieberman foot strike).

## Real-device validation

Not required to merge the drafts. Each lesson should be classroom-tested before being linked from the public LP.

## Out of scope

- Translation, slides, printable handouts.
- Linking lessons from `index.html` or the README.
- Editing existing examples or `examples/catalog.json`.
- Frequency-domain methods (FFT) and inferential statistics — explicitly deferred from Lessons 07 and 08 to keep the 45-minute slot honest.

## Questions for human

- Should Lessons 09 and 10 wait for their dependent example PRs (#82, #84, and the sibling `FOOT-ANGLE-DASHBOARD` PR) before publication, or land as drafts now?
- Lesson 09 uses placeholder bin thresholds (5° / 15°) for heel/midfoot/fore. Tune per cohort against camera footage before classroom use.
- Lesson 10 is a workflow / meta-lesson. Should it stay as Lesson 10 in the Tier 1 ladder, or move into a separate "research workflow" track when Tier 3 lands?

## Next PR candidates

- `claude/example-foot-angle-dashboard-poc` (sibling Tier 2 example for Lesson 09).
- `claude/core-analytics-tests` and `claude/core-recorder-tests` (test harnesses for the in-flight helper PRs).
- `claude/research-imu-step-detection` (literature note that supports Lesson 01).