### PR TITLE
feat(examples): add FOOT-ANGLE-DASHBOARD PoC (Tier 2, no helper deps)

### DIFF
--- a/examples/FOOT-ANGLE-DASHBOARD/README.md
+++ b/examples/FOOT-ANGLE-DASHBOARD/README.md
@@ -1,0 +1,124 @@
+# Foot Angle Dashboard (PoC, draft)
+
+Status: `public-candidate` (planned). **Not yet listed in
+`examples/catalog.json`**. See "Proposed catalog metadata" below.
+
+A small page that surfaces foot angle at landing, landing impact, and
+pronation magnitude from one ORPHE CORE, and bins each landing into
+*fore / mid / heel* using configurable thresholds. Reads the SDK callbacks
+directly — no analytics or recorder helper required, so it ships
+independently of any in-flight helper PR. Pairs with
+[Lesson 09](../../docs/lessons/09-foot-angle-at-landing.md).
+
+## What you can do without a device
+
+- Open the page in Chrome and confirm the layout, the empty bin table,
+  the threshold inputs, and the BLE guard message in browsers without Web
+  Bluetooth.
+
+## What you can do with a device
+
+- Connect one ORPHE CORE through the CoreToolkit switch.
+- Walk a 5 m lane and watch the bin counts populate.
+- Adjust the **Fore &lt;** and **Mid &lt;** threshold inputs and watch the
+  recent-landings table re-bin in place.
+- Press **Reset counts** to clear the bin table without disconnecting.
+
+## Run locally
+
+From the repo root:
+
+```bash
+python3 -m http.server 8767
+```
+
+Then open `http://localhost:8767/examples/FOOT-ANGLE-DASHBOARD/` in Chrome on
+macOS or Windows.
+
+## Notification type
+
+`STEP_ANALYSIS_AND_SENSOR_VALUES`. The dashboard uses `gotFootAngle`,
+`gotLandingImpact`, and `gotPronation` only. Acceleration / gyro callbacks
+are not wired.
+
+## Files
+
+| File | Notes |
+|---|---|
+| `index.html` | Page layout, CoreToolkit placeholder, metric cards, threshold inputs, bin and recent-landing tables. |
+| `sketch.js`  | Wires `bles[0].gotFootAngle` / `gotLandingImpact` / `gotPronation`. Joins the three callbacks into one landing row using a 100 ms window. |
+| `style.css`  | Light tweaks on top of Bootstrap. |
+| `README.md`  | This file. |
+
+## Dependencies
+
+- `js/ORPHE-CORE.js`, `js/CoreToolkit.js`, `js/BleSharedBridge.js`,
+  `js/quaternion.js` — existing core libraries.
+- **No new helper module is required.** This example deliberately reads the
+  SDK callbacks directly so it is independent of the in-flight
+  `CoreAnalytics.js` and `CoreRecorder.js` PRs.
+
+## Proposed catalog metadata
+
+```jsonc
+{
+  "id": "foot-angle-dashboard",
+  "title": "Foot Angle Dashboard",
+  "path": "examples/FOOT-ANGLE-DASHBOARD/",
+  "type": "web-app",
+  "status": "public-candidate",
+  "audience": ["education", "sports-science"],
+  "value": "Live foot angle, landing impact, and pronation from one ORPHE CORE, with configurable fore/mid/heel binning.",
+  "topics": ["foot-angle", "landing-impact", "pronation", "binning"],
+  "data": ["footAngle", "landingImpact", "pronation"],
+  "devices": 1,
+  "validation": ["browser-preview", "needs-real-device-validation"],
+  "category": "analysis",
+  "difficulty": "intermediate",
+  "featured": false,
+  "thumbnail": "examples/_thumbnails/foot-angle-dashboard.png",
+  "sort_order": 230,
+  "links": {
+    "demo":   "examples/FOOT-ANGLE-DASHBOARD/index.html",
+    "source": "examples/FOOT-ANGLE-DASHBOARD/"
+  },
+  "requires_device": true,
+  "device_count": 1,
+  "needs_real_device_validation": true,
+  "public_navigation": "listed"
+}
+```
+
+Thumbnail (`examples/_thumbnails/foot-angle-dashboard.png`) is **not yet
+generated** — capture from a real walking session before promoting to
+`listed`.
+
+## Real-device validation
+
+Not yet performed. Required before promoting from `public-candidate` to
+`public`:
+
+- One ORPHE CORE connects, foot-angle / landing-impact / pronation values
+  populate during walking.
+- Bin counts increment and the recent-landing table fills out.
+- Adjusting the threshold inputs re-bins the table in place.
+- Reset clears the bin counts and the recent-landing table.
+
+## Out of scope
+
+- Comparing to camera footage. Lesson 09 covers that as a discussion
+  prompt; the example does not include video.
+- Editing `examples/catalog.json`. Codex owns the catalog.
+- Persistence between page reloads.
+- A force-platform-style impact metric. The dashboard reports the
+  device-defined `gotLandingImpact.value` only.
+
+## Open questions
+
+- Default bin thresholds (5° / 15°) are placeholders. Should they ship
+  per-mount or per-shoe?
+- Should the bin table retain history beyond the 12-row recent-landing
+  buffer? Currently recomputing bins after a threshold change uses only
+  the recent buffer.
+- Should this PoC also surface a per-bin landing-impact mean? Possible
+  follow-up.

--- a/examples/FOOT-ANGLE-DASHBOARD/index.html
+++ b/examples/FOOT-ANGLE-DASHBOARD/index.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Foot Angle Dashboard — ORPHE CORE.js (PoC, draft)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="./style.css">
+
+  <script src="../../js/quaternion.js"></script>
+  <script src="../../js/ORPHE-CORE.js"></script>
+  <script src="../../js/BleSharedBridge.js"></script>
+  <script src="../../js/CoreToolkit.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js"></script>
+  <script src="../../js/site-analytics.js"></script>
+</head>
+<body class="bg-dark text-light">
+  <div class="container py-4">
+    <header class="mb-4">
+      <h1 class="h3">Foot Angle Dashboard <span class="badge bg-warning text-dark">PoC · draft</span></h1>
+      <p class="text-secondary mb-1">
+        Live foot angle at landing, landing impact, and pronation magnitude from one ORPHE CORE. Bins each
+        landing into <em>fore</em>, <em>mid</em>, or <em>heel</em> using configurable thresholds.
+      </p>
+      <p class="text-secondary small mb-0">
+        Status: <code>public-candidate (planned)</code>. Not yet listed in <code>examples/catalog.json</code>.
+        Proposed catalog metadata is in <a href="./README.md">README.md</a>.
+      </p>
+    </header>
+
+    <section class="mb-4">
+      <div id="toolkit_placeholder"></div>
+      <div id="ble-support-message" class="alert alert-warning my-3" style="display:none;">
+        Web Bluetooth is disabled in this browser. Open this page in Chrome on macOS or Windows to connect ORPHE CORE.
+      </div>
+    </section>
+
+    <section class="row g-3 mb-4">
+      <div class="col-md-4">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h6 text-uppercase text-secondary">Last foot angle</h2>
+            <p class="display-4 mb-0"><span id="metric-angle">—</span><span class="h5 text-secondary"> °</span></p>
+            <p class="small text-secondary mb-0">From <code>gotFootAngle</code>.</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h6 text-uppercase text-secondary">Last landing impact</h2>
+            <p class="display-4 mb-0" id="metric-impact">—</p>
+            <p class="small text-secondary mb-0">From <code>gotLandingImpact</code> (device-defined units).</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card bg-secondary bg-opacity-25 border-0 h-100">
+          <div class="card-body">
+            <h2 class="h6 text-uppercase text-secondary">Last pronation</h2>
+            <p class="display-4 mb-0" id="metric-pronation">—</p>
+            <p class="small text-secondary mb-0">Magnitude from <code>gotPronation</code>.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <div class="card bg-secondary bg-opacity-25 border-0">
+        <div class="card-body">
+          <h2 class="h5">Bin distribution</h2>
+          <p class="small text-secondary mb-3">
+            Landing-style bins from foot angle. Default thresholds:
+            <code>&lt; <span id="threshold-fore-label">5</span>° fore</code>,
+            <code>&lt; <span id="threshold-mid-label">15</span>° mid</code>, otherwise <code>heel</code>.
+          </p>
+          <div class="row g-3 mb-3">
+            <div class="col">
+              <label class="form-label small">Fore &lt;</label>
+              <input id="threshold-fore" class="form-control form-control-sm" type="number" step="1" min="0" max="60" value="5">
+            </div>
+            <div class="col">
+              <label class="form-label small">Mid &lt;</label>
+              <input id="threshold-mid" class="form-control form-control-sm" type="number" step="1" min="1" max="60" value="15">
+            </div>
+            <div class="col d-flex align-items-end">
+              <button id="btn-reset-bins" class="btn btn-outline-light btn-sm">Reset counts</button>
+            </div>
+          </div>
+          <table class="table table-dark table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th scope="col">bin</th>
+                <th scope="col" class="text-end">count</th>
+                <th scope="col" class="text-end">last angle</th>
+                <th scope="col" class="text-end">mean angle</th>
+              </tr>
+            </thead>
+            <tbody id="bin-body">
+              <tr><td colspan="4" class="text-secondary text-center">No landings yet.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <div class="card bg-secondary bg-opacity-25 border-0">
+        <div class="card-body">
+          <h2 class="h5">Recent landings</h2>
+          <p class="small text-secondary mb-2">
+            Most-recent first. Pronation is shown as the magnitude
+            <code>√(x² + y² + z²)</code>.
+          </p>
+          <table class="table table-dark table-sm mb-0">
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col" class="text-end">angle (°)</th>
+                <th scope="col" class="text-end">impact</th>
+                <th scope="col" class="text-end">pronation mag</th>
+                <th scope="col">bin</th>
+              </tr>
+            </thead>
+            <tbody id="recent-body">
+              <tr><td colspan="5" class="text-secondary text-center">Walk to populate.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-4">
+      <details>
+        <summary class="text-secondary">How this page is wired (draft)</summary>
+        <ol class="small text-secondary mt-2">
+          <li><code>CoreToolkit</code> creates <code>bles[0]</code> for one ORPHE CORE.</li>
+          <li><code>guardCoreToolkitBluetooth({ coreIds: [0] })</code> disables the BLE switch on browsers without Web Bluetooth.</li>
+          <li>The page replaces <code>bles[0].gotFootAngle</code>, <code>gotLandingImpact</code>, and <code>gotPronation</code> with handlers that update the metric cards, bin counters, and a 12-row recent-landing log. The three callbacks are timestamped and joined into a single landing row when they land within a 100 ms window.</li>
+          <li>No analytics or recorder helper is required. The page reads the SDK callbacks directly so it can ship independently of any in-flight helper PR.</li>
+        </ol>
+      </details>
+    </section>
+  </div>
+
+  <script src="./sketch.js"></script>
+</body>
+</html>

--- a/examples/FOOT-ANGLE-DASHBOARD/sketch.js
+++ b/examples/FOOT-ANGLE-DASHBOARD/sketch.js
@@ -1,0 +1,186 @@
+/* Foot Angle Dashboard — PoC (draft).
+ *
+ * Reads ORPHE CORE callbacks directly (no analytics or recorder helper).
+ * Bins each landing into fore / mid / heel using configurable thresholds.
+ */
+
+(function () {
+    'use strict';
+
+    var NOTIFICATION = 'STEP_ANALYSIS_AND_SENSOR_VALUES';
+    var JOIN_WINDOW_MS = 100;
+    var MAX_RECENT_ROWS = 12;
+
+    var thresholds = { fore: 5, mid: 15 };
+    var bins = { fore: { count: 0, sumAngle: 0, lastAngle: null },
+                 mid:  { count: 0, sumAngle: 0, lastAngle: null },
+                 heel: { count: 0, sumAngle: 0, lastAngle: null } };
+    var recent = [];
+    var pendingLanding = null;
+
+    function $(id) { return document.getElementById(id); }
+
+    function fmtNum(value, digits) {
+        if (value == null || isNaN(value)) return '—';
+        return Number(value).toFixed(digits != null ? digits : 0);
+    }
+
+    function binFor(angle) {
+        if (typeof angle !== 'number' || isNaN(angle)) return 'mid';
+        if (angle < thresholds.fore) return 'fore';
+        if (angle < thresholds.mid) return 'mid';
+        return 'heel';
+    }
+
+    function commitLanding(landing) {
+        if (!landing || typeof landing.angle !== 'number') return;
+        var bin = binFor(landing.angle);
+        bins[bin].count += 1;
+        bins[bin].sumAngle += landing.angle;
+        bins[bin].lastAngle = landing.angle;
+        landing.bin = bin;
+        recent.unshift(landing);
+        if (recent.length > MAX_RECENT_ROWS) recent.length = MAX_RECENT_ROWS;
+        renderBins();
+        renderRecent();
+        renderMetrics(landing);
+    }
+
+    function maybeFlushPending(now) {
+        if (pendingLanding && (now - pendingLanding.t) >= JOIN_WINDOW_MS) {
+            commitLanding(pendingLanding);
+            pendingLanding = null;
+        }
+    }
+
+    function attachToPending(now, patch) {
+        maybeFlushPending(now);
+        if (!pendingLanding) {
+            pendingLanding = { t: now };
+        }
+        Object.assign(pendingLanding, patch);
+    }
+
+    function renderMetrics(landing) {
+        $('metric-angle').textContent = landing && landing.angle != null ? fmtNum(landing.angle, 1) : '—';
+        $('metric-impact').textContent = landing && landing.impact != null ? fmtNum(landing.impact, 2) : '—';
+        $('metric-pronation').textContent = landing && landing.pronationMagnitude != null ? fmtNum(landing.pronationMagnitude, 2) : '—';
+    }
+
+    function renderBins() {
+        var body = $('bin-body');
+        var entries = ['fore', 'mid', 'heel'];
+        var total = entries.reduce(function (sum, bin) { return sum + bins[bin].count; }, 0);
+        if (total === 0) {
+            body.innerHTML = '<tr><td colspan="4" class="text-secondary text-center">No landings yet.</td></tr>';
+            return;
+        }
+        body.innerHTML = entries.map(function (bin) {
+            var record = bins[bin];
+            var mean = record.count > 0 ? (record.sumAngle / record.count) : null;
+            return '<tr>' +
+                '<td><code>' + bin + '</code></td>' +
+                '<td class="text-end">' + record.count + '</td>' +
+                '<td class="text-end">' + fmtNum(record.lastAngle, 1) + '</td>' +
+                '<td class="text-end">' + fmtNum(mean, 1) + '</td>' +
+                '</tr>';
+        }).join('');
+    }
+
+    function renderRecent() {
+        var body = $('recent-body');
+        if (recent.length === 0) {
+            body.innerHTML = '<tr><td colspan="5" class="text-secondary text-center">Walk to populate.</td></tr>';
+            return;
+        }
+        body.innerHTML = recent.map(function (landing, index) {
+            return '<tr>' +
+                '<td>' + (index + 1) + '</td>' +
+                '<td class="text-end">' + fmtNum(landing.angle, 1) + '</td>' +
+                '<td class="text-end">' + fmtNum(landing.impact, 2) + '</td>' +
+                '<td class="text-end">' + fmtNum(landing.pronationMagnitude, 2) + '</td>' +
+                '<td><code>' + landing.bin + '</code></td>' +
+                '</tr>';
+        }).join('');
+    }
+
+    function init() {
+        buildCoreToolkit(
+            $('toolkit_placeholder'),
+            'Foot Angle Dashboard',
+            0,
+            NOTIFICATION
+        );
+        guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' });
+
+        if (typeof bles === 'undefined' || !bles[0]) {
+            console.warn('FOOT-ANGLE-DASHBOARD: bles[0] is not available; CoreToolkit init failed.');
+            return;
+        }
+
+        var ble = bles[0];
+        ble.setup();
+
+        ble.gotFootAngle = function (fa) {
+            attachToPending(performance.now(), { angle: fa && typeof fa.value === 'number' ? fa.value : null });
+        };
+        ble.gotLandingImpact = function (li) {
+            attachToPending(performance.now(), { impact: li && typeof li.value === 'number' ? li.value : null });
+        };
+        ble.gotPronation = function (p) {
+            var magnitude = p ? Math.hypot(p.x || 0, p.y || 0, p.z || 0) : null;
+            attachToPending(performance.now(), { pronationMagnitude: magnitude });
+        };
+
+        var foreInput = $('threshold-fore');
+        var midInput = $('threshold-mid');
+        function syncThresholds() {
+            var fore = Number(foreInput.value);
+            var mid = Number(midInput.value);
+            if (!isNaN(fore)) thresholds.fore = fore;
+            if (!isNaN(mid)) thresholds.mid = mid;
+            $('threshold-fore-label').textContent = thresholds.fore;
+            $('threshold-mid-label').textContent = thresholds.mid;
+            // Re-bin existing recent rows so the table reflects the new thresholds.
+            recent.forEach(function (landing) { landing.bin = binFor(landing.angle); });
+            // Recompute bin counts from the recent buffer only (best-effort: counts
+            // older than MAX_RECENT_ROWS are not retained).
+            bins = { fore: { count: 0, sumAngle: 0, lastAngle: null },
+                     mid:  { count: 0, sumAngle: 0, lastAngle: null },
+                     heel: { count: 0, sumAngle: 0, lastAngle: null } };
+            recent.forEach(function (landing) {
+                if (typeof landing.angle === 'number') {
+                    bins[landing.bin].count += 1;
+                    bins[landing.bin].sumAngle += landing.angle;
+                    bins[landing.bin].lastAngle = landing.angle;
+                }
+            });
+            renderBins();
+            renderRecent();
+        }
+        foreInput.addEventListener('change', syncThresholds);
+        midInput.addEventListener('change', syncThresholds);
+
+        $('btn-reset-bins').addEventListener('click', function () {
+            bins = { fore: { count: 0, sumAngle: 0, lastAngle: null },
+                     mid:  { count: 0, sumAngle: 0, lastAngle: null },
+                     heel: { count: 0, sumAngle: 0, lastAngle: null } };
+            recent = [];
+            renderBins();
+            renderRecent();
+            renderMetrics(null);
+        });
+
+        // 50 ms tick to flush pending landing rows when the join window expires.
+        setInterval(function () { maybeFlushPending(performance.now()); }, 50);
+
+        renderBins();
+        renderRecent();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+}());

--- a/examples/FOOT-ANGLE-DASHBOARD/style.css
+++ b/examples/FOOT-ANGLE-DASHBOARD/style.css
@@ -1,0 +1,5 @@
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+.card { border-radius: 0.75rem; }
+.display-4 { line-height: 1.1; }
+table.table-dark code { color: #80deea; }
+details summary { cursor: pointer; }


### PR DESCRIPTION
## Summary

New example `examples/FOOT-ANGLE-DASHBOARD/` that surfaces foot angle at landing, landing impact, and pronation magnitude from one ORPHE CORE, and bins each landing into *fore* / *mid* / *heel* using configurable thresholds. Status: `public-candidate (planned)`, **not yet listed in `examples/catalog.json`** — README proposes the entry.

This example is **independent of every in-flight helper PR** (#79 / #81 / #82 / #83 / #84). It reads the SDK callbacks directly so it can ship and be reviewed on its own.

Pairs with [Lesson 09](https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/claude/lessons-tier2-draft/docs/lessons/09-foot-angle-at-landing.md) (in PR #86).

## Page wiring

- CoreToolkit creates `bles[0]`. `guardCoreToolkitBluetooth({ coreIds: [0], messageElement: '#ble-support-message' })` is called immediately after `buildCoreToolkit`.
- Notification: `STEP_ANALYSIS_AND_SENSOR_VALUES`.
- The page explicitly owns `bles[0].gotFootAngle`, `gotLandingImpact`, and `gotPronation`. The three callbacks are joined into one landing row using a 100 ms window so the metric cards and the recent-landing table stay coherent.
- Threshold inputs (`Fore <`, `Mid <`) re-bin the recent-landing buffer in place. `Reset counts` clears the bin counts and the recent-landing table.
- A 50 ms tick flushes pending landing rows when the join window expires.

## Validation

- `node --check examples/FOOT-ANGLE-DASHBOARD/sketch.js` — OK.
- `node scripts/check-examples-catalog.js` — `Catalog OK: 48 entries checked`.
- `node scripts/check-examples-static-quality.js` — 0 errors, 0 warnings, 0 info.

## Real-device validation

Not yet performed. Required before promoting from `public-candidate` to `public`:

- One ORPHE CORE connects, foot-angle / landing-impact / pronation values populate during walking.
- Bin counts increment and the recent-landing table fills out.
- Adjusting threshold inputs re-bins the table in place.
- Reset clears the bin counts and the recent-landing table.

## Out of scope

- Editing `examples/catalog.json`. Codex owns the catalog. Proposed entry is in the README.
- Camera-based cross-checks. Lesson 09 covers that as a discussion prompt; the example does not include video.
- Persistence across page reloads.
- A force-platform-style impact metric. The dashboard reports the device-defined `gotLandingImpact.value` only.
- Thumbnail generation. Capture from a real session before promoting.

## Questions for human

- Default bin thresholds (5° / 15°): keep configurable in the UI (current) or lock per mount/shoe?
- Should the bin table retain history beyond the 12-row recent-landing buffer? Currently re-binning after a threshold change uses only the recent buffer.
- Should this PoC also surface a per-bin landing-impact mean? Possible follow-up.

## Next PR candidates

- After review, Codex reconciles the proposed catalog entry into `examples/catalog.json` and generates the thumbnail.
- Optional follow-up: add a small per-bin impact-mean panel.