### PR TITLE
Example公開判断とVirtual Trackカテゴリ方針を追加

### DIFF
--- a/docs/examples-publication-decisions.md
+++ b/docs/examples-publication-decisions.md
@@ -1,0 +1,169 @@
+# Examples Publication Decisions
+
+This document records publication decisions that are not purely mechanical.
+It is for humans, Codex, and Claude when deciding what should appear as a
+maintained public example, what should be a workshop/tool entry, and what
+should stay archived.
+
+Static quality is currently passing. The remaining work is validation and
+positioning.
+
+## Current Queue
+
+| Group | Entries | Decision |
+|---|---|---|
+| Playable public-candidates | `GAME-PK`, `GAME-SHOOTING`, `GAME-FIREBALL-MARIO` | Keep as public-candidate until owner real-device checks pass. |
+| Technical public-candidate | `DTW` | Keep as public-candidate until technical clarity and device-input path are confirmed. |
+| Utility public-candidate | `CORE_TIME_SYNC` | Keep hidden from public gallery until DateTime behavior is validated. |
+| Workshop entries | `WORKSHOP_07`, `ws/tmu2025` | Keep under `workshop-archive`; do not feature in the beginner Examples section. |
+| Developer tool | `apps/ORPHE-TERMINAL` | Keep under `developer-tool`; link from future Tools / Developer Utilities navigation. |
+
+## Candidate Decisions
+
+### `examples/GAME-PK/`
+
+Decision: keep as `public-candidate`.
+
+Why:
+
+- Clear gameplay value: kick motion maps to a penalty kick.
+- Already uses CoreToolkit and one ORPHE CORE.
+- Needs owner validation for kick detection, restart flow, and BLE chooser behavior.
+
+Promotion condition:
+
+- One-device Chrome test passes.
+- Restart does not break connection or scoring.
+- README remains accurate after validation.
+
+### `examples/GAME-SHOOTING/`
+
+Decision: keep as `public-candidate`.
+
+Why:
+
+- Good simple 2D shooting example using tilt/acceleration.
+- It can coexist with `GAME-SHOOTING2` if positioned as the simpler 2D version.
+- Needs owner validation for movement, fire input, and restart.
+
+Promotion condition:
+
+- One-device Chrome test passes.
+- Decide title/copy as "2D Shooting" if `GAME-SHOOTING2` remains public as the 3D variant.
+
+### `examples/GAME-FIREBALL-MARIO/`
+
+Decision: keep as `public-candidate`.
+
+Why:
+
+- Strong action-game concept with step, kick, and jump gestures.
+- Public title has been changed to `Fireball Action`; directory name remains for compatibility.
+- Needs owner validation for gesture mapping and restart.
+
+Promotion condition:
+
+- One-device Chrome test passes.
+- No remaining public-facing protected-character naming appears in the UI.
+
+### `examples/DTW/`
+
+Decision: keep as `public-candidate`.
+
+Why:
+
+- Valuable technical example for time-series matching.
+- Has a no-device mouse/demo path, so it can teach the algorithm even before BLE validation.
+- Needs a short clarity pass after a technical user opens it.
+
+Promotion condition:
+
+- Mouse demo is understandable.
+- One-device sensor input path is confirmed.
+- The page copy clearly says what DTW is useful for.
+
+### `examples/CORE_TIME_SYNC/`
+
+Decision: move to hidden `public-candidate`.
+
+Why:
+
+- Useful for recording integrity and timestamp debugging.
+- Not a beginner example and should not be featured in the main gallery yet.
+- Needs owner validation for `getDateTime()` and `syncCoreTime()`.
+
+Promotion condition:
+
+- DateTime read/sync behavior is confirmed with one ORPHE CORE.
+- Decide whether it should be visible in the public gallery or only linked from recording/debugging docs.
+
+### `examples/WORKSHOP_07/`
+
+Decision: keep as workshop material.
+
+Why:
+
+- It has educational value, but it is a workshop asset rather than a first-run app.
+- It should live under `workshop-archive`, not the beginner Examples section.
+
+Promotion condition:
+
+- Page opens and links are intact.
+- Workshop purpose is clear.
+- Optional: add a workshop index page later.
+
+### `ws/tmu2025/`
+
+Decision: keep as workshop gallery.
+
+Why:
+
+- The page is meaningful as a collection of student works.
+- It should not imply every linked work is a maintained official example.
+- Strong individual works can later become separate catalog entries.
+
+Promotion condition:
+
+- Gallery and links are intact.
+- A future curation pass selects individual works for maintained examples.
+
+### `apps/ORPHE-TERMINAL/`
+
+Decision: keep as developer tool.
+
+Why:
+
+- It is useful, but it is not a learning example for beginners.
+- It belongs under `developer-tool` and future Tools / Developer Utilities navigation.
+
+Promotion condition:
+
+- One-device Chrome test confirms connection and basic data read/write.
+- Tool copy explains the intended developer workflow.
+
+## Needs-Review Decisions
+
+| Entry | Decision | Reason | Next action |
+|---|---|---|---|
+| `examples/GAME-RHYTHM/` | rewrite | Potentially valuable rhythm game, but it carries an old local SDK copy and needs modernization. | Keep unlisted; rewrite as a maintained rhythm example later. |
+| `examples/ICC2022Sep/` | archive | Historical event/demo artifact with large vendored dependencies. | Keep as archive unless a modern creative example is extracted. |
+| `examples/p5.ORPHE.FSR_visualise_0327_submit/` | domain review | May be FSR / ORPHE INSOLE specific rather than general ORPHE CORE.js. | Keep unlisted until product scope is decided. |
+| `ws/tmu2022/` | archive | Old workshop archive with zip content and older demo conventions. | Keep unlisted; clean archive metadata only if needed. |
+
+## Claude Tier 1 PR Intake
+
+Claude's new Tier 1 work should enter the catalog only after helper API review.
+
+| PR | Entry | Current intake decision |
+|---|---|---|
+| `#79` | `js/CoreAnalytics.js` | Review API naming and gait step semantics before examples depend on it. |
+| `#81` | `js/CoreRecorder.js` | Review JSON/CSV schema and replay semantics before examples depend on it. |
+| `#82` | `CSV-RECORDER` | Good target for `recording-analysis`; wait for `CoreRecorder.js` review and real-device check. |
+| `#83` | `STEP-COUNT-DASHBOARD` | Good target for `gait-analysis`; wait for `CoreAnalytics.js` review and real-device check. |
+| `#84` | `REPLAY-PLAYER` | Good target for `recording-analysis`; can be reviewed without hardware because it ships sample data. |
+
+Catalog policy:
+
+- Claude PR READMEs may propose metadata.
+- Codex should reconcile `examples/catalog.json` after helper PRs are accepted.
+- Do not mark new examples `public` until they have browser validation and, where needed, ORPHE CORE validation.

--- a/docs/virtual-track-games-audit.md
+++ b/docs/virtual-track-games-audit.md
@@ -1,0 +1,95 @@
+# Virtual Track Games Audit
+
+ORPHE-CORE.js has enough running / hurdle material to support a distinct
+"Virtual Track" category. The repository should treat these as a meaningful
+sports-game family rather than one-off duplicates.
+
+This audit is static. It checks files, titles, dependencies, and the apparent
+game concept. It does not claim real-device validation.
+
+## Family Summary
+
+| Path | Proposed public name | Concept | Devices | Current publication decision |
+|---|---|---|---:|---|
+| `examples/GAME-HURDLE/` | 110m Hurdles | Single-player 3D 110m hurdle race. | 2 | Already public; should be the flagship virtual track example. |
+| `examples/GAME-HURDLE-VS/` | 110m Hurdles VS | Two-player 3D 110m hurdle race. | 2 | Prepare as public-candidate after README, thumbnail, and real-device check. |
+| `examples/GAME-HURDLE-2D-VS/` | 2D 110m Hurdles VS | Two-player 2D 110m hurdle race. | 2 | Prepare only after naming/copy cleanup; current "Hyper Olympic" wording should be removed before public listing. |
+| `examples/GAME-HURDLE-400M-VS/` | 400m Hurdles VS | Two-player 3D 400m hurdle race. | 2 | Prepare as public-candidate; distinct course length makes it meaningful. |
+| `examples/GAME-HURDLE-VS-advance/` | 110m Hurdles VS Advanced | Two-player 3D 110m hurdle race with richer effects/audio. | 2 | Keep as advanced variant; publish only if it is meaningfully better than `GAME-HURDLE-VS`. |
+| `examples/GAME-SPRINT-100M-VS/` | 100m Sprint VS | Two-player 100m sprint without hurdles. | 2 | Prepare as public-candidate; distinct from hurdles and useful for sports category breadth. |
+
+## Static Findings
+
+All six pages:
+
+- Have an `index.html`.
+- Load `CoreToolkit.js`.
+- Include `BleSharedBridge.js`.
+- Call `guardCoreToolkitBluetooth({ coreIds: [0, 1], ... })`.
+- Use two ORPHE CORE devices for sensor play.
+
+Current differences:
+
+- `GAME-HURDLE/` already uses local `../../js/ORPHE-CORE.js`.
+- The five VS / sprint variants still load `ORPHE-CORE.js` from the public CDN.
+- The five VS / sprint variants have no README.
+- Each variant has an empty `claud` file that should not be treated as public documentation.
+
+## Recommended Preparation PRs
+
+### PR 1: Localize SDK script references
+
+Change the five unlisted variants from the public CDN to local
+`../../js/ORPHE-CORE.js`, matching `GAME-HURDLE/` and the already-cleaned
+public games.
+
+Targets:
+
+- `GAME-HURDLE-VS`
+- `GAME-HURDLE-2D-VS`
+- `GAME-HURDLE-400M-VS`
+- `GAME-HURDLE-VS-advance`
+- `GAME-SPRINT-100M-VS`
+
+### PR 2: Add README files for each variant
+
+Each README should state:
+
+- What is different from `GAME-HURDLE/`.
+- Required ORPHE CORE count.
+- Keyboard fallback controls.
+- Real-device validation checklist.
+- Whether it is intended for public gallery or family sub-navigation.
+
+### PR 3: Catalog family design
+
+Do not add all variants to the LP immediately. Instead:
+
+- Keep `GAME-HURDLE/` as the flagship public card.
+- Add a "Virtual Track" category or family page later.
+- Promote `GAME-SPRINT-100M-VS` and `GAME-HURDLE-400M-VS` first because they
+  clearly add new race formats.
+- Promote either `GAME-HURDLE-VS` or `GAME-HURDLE-VS-advance`, not both, unless
+  real-device playtesting shows a clear reason to keep both.
+- Keep `GAME-HURDLE-2D-VS` as a candidate only after naming cleanup.
+
+## Human Validation Checklist
+
+For each candidate:
+
+1. Open in Chrome from a local server.
+2. Confirm the keyboard fallback starts and can finish a race.
+3. Connect two ORPHE CORE modules.
+4. Confirm both players receive independent sensor input.
+5. Confirm restart keeps or cleanly resets BLE connection.
+6. Confirm the game is visually understandable without reading code.
+7. Capture a thumbnail only after the public name and UI are acceptable.
+
+## Publication Position
+
+Virtual track should be a visible strength of ORPHE-CORE.js, but it should be
+presented as a family:
+
+- Main LP: one or two best examples, not every variant.
+- Examples gallery: searchable `playable-app` entries.
+- Future category page: all track variants with differences clearly explained.


### PR DESCRIPTION
## Summary
- Add `docs/examples-publication-decisions.md` to record publication decisions for public-candidate, workshop, developer-tool, and needs-review entries.
- Add `docs/virtual-track-games-audit.md` to define the virtual track / sprint / hurdle game family and the preparation sequence.
- Clarify that virtual track should become a visible category, while still avoiding unvalidated public promotion.

## Validation
- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `node scripts/check-examples-static-quality.js`

## Needs real-device validation
- None for this documentation PR.
- The docs explicitly list which pages still need human Chrome + ORPHE CORE checks.

## Out of scope
- Changing catalog status.
- Adding track variants to the public gallery.
- Changing game behavior or BLE logic.

## Questions for human
- Should "Virtual Track" become a first-class category in the examples gallery, or a family page linked from playable apps?
- Should `GAME-HURDLE-VS` or `GAME-HURDLE-VS-advance` be the maintained 110m VS variant?

## Next PR candidates
- Localize ORPHE-CORE.js references in the virtual track variants.
- Add README files for virtual track variants.
- Reconcile Claude Tier 1 example catalog entries after helper PR review.
