### PR TITLE
Virtual Track系ExampleのSDK参照をローカルに統一

### DIFF
--- a/examples/GAME-HURDLE-2D-VS/index.html
+++ b/examples/GAME-HURDLE-2D-VS/index.html
@@ -177,7 +177,7 @@
   </div>
 
   <!-- ORPHE CORE -->
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+  <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
 

--- a/examples/GAME-HURDLE-400M-VS/index.html
+++ b/examples/GAME-HURDLE-400M-VS/index.html
@@ -280,9 +280,9 @@
     }
   </style>
   <!-- ORPHE CORE ライブラリと依存関係 -->
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+  <script src="../../js/float16.min.js" crossorigin="anonymous"></script>
+  <script src="../../js/quaternion.js" crossorigin="anonymous"></script>
+  <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>

--- a/examples/GAME-HURDLE-VS-advance/index.html
+++ b/examples/GAME-HURDLE-VS-advance/index.html
@@ -297,9 +297,9 @@
     }
   </style>
   <!-- ORPHE CORE ライブラリと依存関係 -->
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+  <script src="../../js/float16.min.js" crossorigin="anonymous"></script>
+  <script src="../../js/quaternion.js" crossorigin="anonymous"></script>
+  <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>

--- a/examples/GAME-HURDLE-VS/index.html
+++ b/examples/GAME-HURDLE-VS/index.html
@@ -280,9 +280,9 @@
     }
   </style>
   <!-- ORPHE CORE ライブラリと依存関係 -->
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+  <script src="../../js/float16.min.js" crossorigin="anonymous"></script>
+  <script src="../../js/quaternion.js" crossorigin="anonymous"></script>
+  <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>

--- a/examples/GAME-SPRINT-100M-VS/index.html
+++ b/examples/GAME-SPRINT-100M-VS/index.html
@@ -255,9 +255,9 @@
     }
   </style>
   <!-- ORPHE CORE ライブラリと依存関係 -->
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/float16.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/quaternion.js" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js/js/ORPHE-CORE.js" crossorigin="anonymous"></script>
+  <script src="../../js/float16.min.js" crossorigin="anonymous"></script>
+  <script src="../../js/quaternion.js" crossorigin="anonymous"></script>
+  <script src="../../js/ORPHE-CORE.js" crossorigin="anonymous"></script>
   <script src="../../js/BleSharedBridge.js"></script>
   <script src="../../js/CoreToolkit.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- Change the virtual track / sprint variant pages to load the local repo copies of `float16.min.js`, `quaternion.js`, and `ORPHE-CORE.js` instead of the public jsDelivr main branch.
- Keep BLE/game behavior unchanged.
- Leave third-party CDN dependencies such as Bootstrap and Three.js untouched.

## Validation
- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `node scripts/check-examples-static-quality.js`
- Local server `curl -I`: `GAME-HURDLE-VS`, `GAME-HURDLE-2D-VS`, `GAME-HURDLE-400M-VS`, `GAME-HURDLE-VS-advance`, `GAME-SPRINT-100M-VS` all returned 200 OK.

## Needs real-device validation
- Chrome + two ORPHE CORE devices should still be used before promoting these variants to the public gallery.

## Out of scope
- README creation.
- Catalog promotion.
- Naming/copy cleanup.
- Gameplay or BLE threshold changes.
