### PR TITLE
Virtual Track系バリアントのREADMEを追加

### DIFF
--- a/examples/GAME-HURDLE-2D-VS/README.md
+++ b/examples/GAME-HURDLE-2D-VS/README.md
@@ -1,0 +1,42 @@
+# 2D Hurdle VS
+
+Two-player 2D hurdle race using ORPHE CORE motion input.
+
+## What this example shows
+
+- Present a simpler 2D version of the virtual track race concept.
+- Use two ORPHE CORE modules as competitive player inputs.
+- Compare whether a lightweight 2D game is easier to use in workshops than the 3D variants.
+
+## Required devices
+
+- 2 ORPHE CORE modules for sensor play
+- Keyboard fallback may be useful for screen/layout checks, but promotion needs a two-device check.
+
+## How to run
+
+Open the page from a local server or GitHub Pages:
+
+```text
+examples/GAME-HURDLE-2D-VS/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome. Connect both ORPHE CORE modules from the CoreToolkit UI before starting a sensor-based play test.
+
+## Data
+
+- Expected notify type: `SENSOR_VALUES`
+- Main input: motion values converted into running / jumping controls
+
+## Publication notes
+
+The public title and in-page copy should avoid third-party sports game names before this page is promoted. Use a generic name such as "2D Hurdle VS" or "2D Track Hurdles".
+
+## Validation status
+
+Static page/link checks only. Before public promotion, confirm two-device connection, running, jumping, finish/retry flow, and disconnect/reconnect behavior on Chrome.
+
+## Related examples
+
+- [`examples/GAME-HURDLE/`](../GAME-HURDLE/README.md) — current public flagship 110m hurdle game
+- [`examples/GAME-HURDLE-VS/`](../GAME-HURDLE-VS/) — 3D 110m hurdle VS variant

--- a/examples/GAME-HURDLE-400M-VS/README.md
+++ b/examples/GAME-HURDLE-400M-VS/README.md
@@ -1,0 +1,39 @@
+# 400m Hurdle VS
+
+Two-player 400m hurdle race using ORPHE CORE motion input.
+
+## What this example shows
+
+- Extend the virtual track concept to a longer hurdle race.
+- Use two ORPHE CORE modules as player inputs.
+- Compare pacing and endurance-style play against the 110m hurdle variants.
+
+## Required devices
+
+- 2 ORPHE CORE modules for sensor play
+- Keyboard fallback may be useful for screen/layout checks, but promotion needs a two-device check.
+
+## How to run
+
+Open the page from a local server or GitHub Pages:
+
+```text
+examples/GAME-HURDLE-400M-VS/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome. Connect both ORPHE CORE modules from the CoreToolkit UI before starting a sensor-based play test.
+
+## Data
+
+- Expected notify type: `SENSOR_VALUES`
+- Main input: motion values converted into running / jumping controls
+
+## Validation status
+
+Static page/link checks only. Before public promotion, confirm two-device connection, race distance feel, running, jumping, finish/retry flow, and disconnect/reconnect behavior on Chrome.
+
+## Related examples
+
+- [`examples/GAME-HURDLE/`](../GAME-HURDLE/README.md) — current public flagship 110m hurdle game
+- [`examples/GAME-HURDLE-VS/`](../GAME-HURDLE-VS/) — 110m hurdle VS variant
+- [`examples/GAME-SPRINT-100M-VS/`](../GAME-SPRINT-100M-VS/) — sprint variant without hurdles

--- a/examples/GAME-HURDLE-VS-advance/README.md
+++ b/examples/GAME-HURDLE-VS-advance/README.md
@@ -1,0 +1,42 @@
+# Advanced Hurdle VS
+
+Advanced two-player hurdle race prototype using ORPHE CORE motion input.
+
+## What this example shows
+
+- Explore a more elaborate version of the two-player hurdle race concept.
+- Use two ORPHE CORE modules as player inputs.
+- Compare whether this version adds enough value over `GAME-HURDLE-VS` to keep both pages public.
+
+## Required devices
+
+- 2 ORPHE CORE modules for sensor play
+- Keyboard fallback may be useful for screen/layout checks, but promotion needs a two-device check.
+
+## How to run
+
+Open the page from a local server or GitHub Pages:
+
+```text
+examples/GAME-HURDLE-VS-advance/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome. Connect both ORPHE CORE modules from the CoreToolkit UI before starting a sensor-based play test.
+
+## Data
+
+- Expected notify type: `SENSOR_VALUES`
+- Main input: motion values converted into running / jumping controls
+
+## Publication notes
+
+This page should stay unlisted unless it has a clear difference from `GAME-HURDLE-VS`. If the gameplay is effectively the same, keep one maintained VS hurdle page and archive or merge this variant.
+
+## Validation status
+
+Static page/link checks only. Before public promotion, confirm two-device connection, gameplay difference from `GAME-HURDLE-VS`, finish/retry flow, and disconnect/reconnect behavior on Chrome.
+
+## Related examples
+
+- [`examples/GAME-HURDLE-VS/`](../GAME-HURDLE-VS/) — baseline 110m hurdle VS variant
+- [`examples/GAME-HURDLE/`](../GAME-HURDLE/README.md) — current public flagship 110m hurdle game

--- a/examples/GAME-HURDLE-VS/README.md
+++ b/examples/GAME-HURDLE-VS/README.md
@@ -1,0 +1,39 @@
+# 110m Hurdle VS
+
+Two-player 110m hurdle race using ORPHE CORE motion input.
+
+## What this example shows
+
+- Use two ORPHE CORE modules as player inputs.
+- Compare left/right or player 1/player 2 gait-style movement in a race format.
+- Build a competitive game around running and jumping motions.
+
+## Required devices
+
+- 2 ORPHE CORE modules for sensor play
+- Keyboard fallback may be useful for screen/layout checks, but promotion needs a two-device check.
+
+## How to run
+
+Open the page from a local server or GitHub Pages:
+
+```text
+examples/GAME-HURDLE-VS/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome. Connect both ORPHE CORE modules from the CoreToolkit UI before starting a sensor-based play test.
+
+## Data
+
+- Expected notify type: `SENSOR_VALUES`
+- Main input: motion values converted into running / jumping controls
+
+## Validation status
+
+Static page/link checks only. Before public promotion, confirm two-device connection, start/restart flow, running, jumping, finish, and disconnect/reconnect behavior on Chrome.
+
+## Related examples
+
+- [`examples/GAME-HURDLE/`](../GAME-HURDLE/README.md) — current public flagship 110m hurdle game
+- [`examples/GAME-HURDLE-400M-VS/`](../GAME-HURDLE-400M-VS/) — 400m hurdle variant
+- [`examples/GAME-SPRINT-100M-VS/`](../GAME-SPRINT-100M-VS/) — sprint variant without hurdles

--- a/examples/GAME-SPRINT-100M-VS/README.md
+++ b/examples/GAME-SPRINT-100M-VS/README.md
@@ -1,0 +1,39 @@
+# 100m Sprint VS
+
+Two-player 100m sprint race using ORPHE CORE motion input.
+
+## What this example shows
+
+- Use two ORPHE CORE modules as player inputs for a sprint race.
+- Focus on running cadence and speed without hurdle timing.
+- Provide a simpler virtual track game than the hurdle variants.
+
+## Required devices
+
+- 2 ORPHE CORE modules for sensor play
+- Keyboard fallback may be useful for screen/layout checks, but promotion needs a two-device check.
+
+## How to run
+
+Open the page from a local server or GitHub Pages:
+
+```text
+examples/GAME-SPRINT-100M-VS/
+```
+
+Use a Web Bluetooth compatible browser such as Chrome. Connect both ORPHE CORE modules from the CoreToolkit UI before starting a sensor-based play test.
+
+## Data
+
+- Expected notify type: `SENSOR_VALUES`
+- Main input: motion values converted into running controls
+
+## Validation status
+
+Static page/link checks only. Before public promotion, confirm two-device connection, running speed response, finish/retry flow, and disconnect/reconnect behavior on Chrome.
+
+## Related examples
+
+- [`examples/GAME-HURDLE/`](../GAME-HURDLE/README.md) — current public flagship hurdle game
+- [`examples/GAME-HURDLE-VS/`](../GAME-HURDLE-VS/) — 110m hurdle VS variant
+- [`examples/GAME-HURDLE-400M-VS/`](../GAME-HURDLE-400M-VS/) — 400m hurdle VS variant


### PR DESCRIPTION
## Summary
- Add README files for five Virtual Track variants that are not yet listed in the main examples gallery.
- Document what each variant is for, required device count, launch path, expected data, and real-device validation checklist.
- Keep these pages unpromoted until two-device Chrome testing confirms the play flow.

## Validation
- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `node scripts/check-examples-static-quality.js`
- Confirmed all five README files exist.

## Needs real-device validation
- All five variants need two ORPHE CORE modules before public promotion:
  - `examples/GAME-HURDLE-VS/`
  - `examples/GAME-HURDLE-2D-VS/`
  - `examples/GAME-HURDLE-400M-VS/`
  - `examples/GAME-HURDLE-VS-advance/`
  - `examples/GAME-SPRINT-100M-VS/`

## Out of scope
- Changing gameplay or BLE logic.
- Adding these variants to `examples/catalog.json`.
- Public gallery promotion.
- Directory rename or cleanup.

## Questions for human
- Should `GAME-HURDLE-VS` or `GAME-HURDLE-VS-advance` become the maintained 110m VS variant?
- Should Virtual Track appear as a first-class gallery category or as a family page linked from playable apps?
