### PR TITLE
SEO向けメタ情報・sitemap・言語別入口を追加

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-preferred-language="en">
 
 <head>
   <meta charset="utf-8">
@@ -7,7 +7,7 @@
   <title>ORPHE-CORE.js | JavaScript SDK for Foot-Mounted IMU and Gait Analysis</title>
   <meta name="description"
     content="ORPHE-CORE.js is a JavaScript SDK for ORPHE CORE, a foot-mounted IMU sensor. Build Web Bluetooth apps for gait analysis, motion data, virtual sports, education, and research.">
-  <link rel="canonical" href="https://orphe-oss.github.io/ORPHE-CORE.js/">
+  <link rel="canonical" href="https://orphe-oss.github.io/ORPHE-CORE.js/en/">
   <link rel="alternate" hreflang="x-default" href="https://orphe-oss.github.io/ORPHE-CORE.js/">
   <link rel="alternate" hreflang="en" href="https://orphe-oss.github.io/ORPHE-CORE.js/en/">
   <link rel="alternate" hreflang="ja" href="https://orphe-oss.github.io/ORPHE-CORE.js/ja/">
@@ -16,7 +16,7 @@
   <meta property="og:title" content="ORPHE-CORE.js | Foot-Mounted IMU and Gait Analysis JavaScript SDK">
   <meta property="og:description"
     content="Build Web Bluetooth apps for ORPHE CORE: foot-mounted IMU data, gait analysis, virtual sports, education, and research tools.">
-  <meta property="og:url" content="https://orphe-oss.github.io/ORPHE-CORE.js/">
+  <meta property="og:url" content="https://orphe-oss.github.io/ORPHE-CORE.js/en/">
   <meta property="og:image" content="https://orphe-oss.github.io/ORPHE-CORE.js/images/ORPHE_TRACK_scene_03.jpg">
   <meta property="og:locale" content="en_US">
   <meta property="og:locale:alternate" content="ja_JP">
@@ -57,7 +57,7 @@
       "@type": "SoftwareSourceCode",
       "name": "ORPHE-CORE.js",
       "alternateName": "ORPHE CORE JavaScript SDK",
-      "url": "https://orphe-oss.github.io/ORPHE-CORE.js/",
+      "url": "https://orphe-oss.github.io/ORPHE-CORE.js/en/",
       "codeRepository": "https://github.com/Orphe-OSS/ORPHE-CORE.js",
       "programmingLanguage": "JavaScript",
       "runtimePlatform": "Web Bluetooth API",
@@ -72,13 +72,13 @@
     }
   </script>
 
-  <link href="./css/custom.css" rel="stylesheet">
+  <link href="../css/custom.css" rel="stylesheet">
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/vs2015.min.css">
   <link rel="stylesheet" href="https://unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.css" />
-  <link href="./css/orphe_custom.css" rel="stylesheet">
-  <script src="./js/site-analytics.js"></script>
+  <link href="../css/orphe_custom.css" rel="stylesheet">
+  <script src="../js/site-analytics.js"></script>
   <style>
     .lang {
       display: none;
@@ -115,7 +115,7 @@
       <div class="container-fluid">
         <span class="navbar-brand mb-0 h1">
           <a class="navbar-brand" href="https://orphe.io/">
-            <img src="./images/orphe.svg" alt="" height="24" class="d-inline-block align-text-top">
+            <img src="../images/orphe.svg" alt="" height="24" class="d-inline-block align-text-top">
           </a>
           <span id="last_modified" class="position-absolute top-25 end-0 badge bg-base border-light p-1"
             style="font-size:0.5em;">
@@ -172,7 +172,7 @@
       <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js" target="_blank" data-goatcounter-click="click-link-github" data-goatcounter-title="Top link: GitHub">
         <i class="bi bi-github"></i> GitHub
       </a>
-      <a href="./api_doc/" target="_blank" data-goatcounter-click="click-link-api-reference" data-goatcounter-title="Top link: API Reference">
+      <a href="../api_doc/" target="_blank" data-goatcounter-click="click-link-api-reference" data-goatcounter-title="Top link: API Reference">
         <i class="bi bi-book"></i> API Reference
       </a>
       <a href="https://shop.orphe.io/products/orphe-core-3-0" target="_blank" data-goatcounter-click="click-link-buy-core" data-goatcounter-title="Top link: Buy ORPHE CORE 3.0">
@@ -245,7 +245,7 @@
       </div>
       <div class="dx-spec-layout">
         <figure class="dx-product-visual">
-          <img src="./images/product/orphe-core-3-front.jpg" alt="ORPHE CORE 3.0 front view">
+          <img src="../images/product/orphe-core-3-front.jpg" alt="ORPHE CORE 3.0 front view">
           <div class="dx-measure-x">29mm</div>
           <div class="dx-measure-y">45mm</div>
         </figure>
@@ -410,50 +410,50 @@
         </h2>
       </div>
       <div class="dx-demo-game-grid">
-        <a class="dx-demo-game" href="./examples/GAME-HURDLE/" target="_blank" data-goatcounter-click="click-example-game-hurdle" data-goatcounter-title="Example: 110m Hurdles">
-          <img src="./examples/_thumbnails/hurdle-110m.png" alt="110m hurdle game">
+        <a class="dx-demo-game" href="../examples/GAME-HURDLE/" target="_blank" data-goatcounter-click="click-example-game-hurdle" data-goatcounter-title="Example: 110m Hurdles">
+          <img src="../examples/_thumbnails/hurdle-110m.png" alt="110m hurdle game">
           <span>
             <span class="lang en">110m Hurdles</span>
             <span class="lang ja active">110m ハードル走</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-UDON/" target="_blank" data-goatcounter-click="click-example-game-udon" data-goatcounter-title="Example: Udon kneading game">
-          <img src="./examples/_thumbnails/udon.png" alt="Udon kneading game">
+        <a class="dx-demo-game" href="../examples/GAME-UDON/" target="_blank" data-goatcounter-click="click-example-game-udon" data-goatcounter-title="Example: Udon kneading game">
+          <img src="../examples/_thumbnails/udon.png" alt="Udon kneading game">
           <span>
             <span class="lang en">Udon kneading game</span>
             <span class="lang ja active">うどんふみふみゲーム！</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/MOVEYOURFEET/" target="_blank" data-goatcounter-click="click-example-move-your-feet" data-goatcounter-title="Example: Move your feet">
-          <img src="./examples/_thumbnails/move-your-feet.png" alt="Move your feet game">
+        <a class="dx-demo-game" href="../examples/MOVEYOURFEET/" target="_blank" data-goatcounter-click="click-example-move-your-feet" data-goatcounter-title="Example: Move your feet">
+          <img src="../examples/_thumbnails/move-your-feet.png" alt="Move your feet game">
           <span>
             <span class="lang en">Move your feet</span>
             <span class="lang ja active">足パタパタゲーム☆</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-PINGPONG/" target="_blank" data-goatcounter-click="click-example-game-pingpong" data-goatcounter-title="Example: Ping pong game">
-          <img src="./examples/_thumbnails/pingpong.png" alt="Ping pong game">
+        <a class="dx-demo-game" href="../examples/GAME-PINGPONG/" target="_blank" data-goatcounter-click="click-example-game-pingpong" data-goatcounter-title="Example: Ping pong game">
+          <img src="../examples/_thumbnails/pingpong.png" alt="Ping pong game">
           <span>
             <span class="lang en">Ping pong game</span>
             <span class="lang ja active">ピンポンゲーム</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/drum_test/" target="_blank" data-goatcounter-click="click-example-drum-test" data-goatcounter-title="Example: Drum game">
-          <img src="./examples/_thumbnails/drum.png" alt="Drum game">
+        <a class="dx-demo-game" href="../examples/drum_test/" target="_blank" data-goatcounter-click="click-example-drum-test" data-goatcounter-title="Example: Drum game">
+          <img src="../examples/_thumbnails/drum.png" alt="Drum game">
           <span>
             <span class="lang en">Drum game</span>
             <span class="lang ja active">ドラムゲーム</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-BOXING/" target="_blank" data-goatcounter-click="click-example-game-boxing" data-goatcounter-title="Example: Boxing game">
-          <img src="./examples/_thumbnails/boxing.png" alt="Boxing game">
+        <a class="dx-demo-game" href="../examples/GAME-BOXING/" target="_blank" data-goatcounter-click="click-example-game-boxing" data-goatcounter-title="Example: Boxing game">
+          <img src="../examples/_thumbnails/boxing.png" alt="Boxing game">
           <span>
             <span class="lang en">Boxing game</span>
             <span class="lang ja active">ボクシングゲーム</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-DDR/" target="_blank" data-goatcounter-click="click-example-game-ddr" data-goatcounter-title="Example: DDR game">
-          <img src="./examples/_thumbnails/ddr.png" alt="DDR game">
+        <a class="dx-demo-game" href="../examples/GAME-DDR/" target="_blank" data-goatcounter-click="click-example-game-ddr" data-goatcounter-title="Example: DDR game">
+          <img src="../examples/_thumbnails/ddr.png" alt="DDR game">
           <span>
             <span class="lang en">DDR game</span>
             <span class="lang ja active">DDRゲーム</span>
@@ -461,7 +461,7 @@
         </a>
       </div>
       <div class="dx-demo-actions">
-        <a class="btn btn-outline-light" href="./examples/" data-goatcounter-click="click-examples-catalog" data-goatcounter-title="What you can build: Examples catalog">
+        <a class="btn btn-outline-light" href="../examples/" data-goatcounter-click="click-examples-catalog" data-goatcounter-title="What you can build: Examples catalog">
           <i class="bi bi-grid-3x3-gap"></i>
           <span class="lang en">Browse all examples by purpose</span>
           <span class="lang ja active">すべてのExampleを目的別に探す</span>
@@ -524,17 +524,17 @@
         </div>
       </div>
       <div class="dx-inline-actions">
-        <a class="btn btn-sm btn-primary" href="./docs/getting-started-p5.html" data-goatcounter-click="click-guide-p5" data-goatcounter-title="Guide: p5.js starter">
+        <a class="btn btn-sm btn-primary" href="../docs/getting-started-p5.html" data-goatcounter-click="click-guide-p5" data-goatcounter-title="Guide: p5.js starter">
           <i class="bi bi-brush"></i>
           <span class="lang en">Try p5.js starter</span>
           <span class="lang ja active">p5.jsですぐ試す</span>
         </a>
-        <a class="btn btn-sm btn-outline-light" href="./docs/getting-started-vscode.html" data-goatcounter-click="click-guide-vscode" data-goatcounter-title="Guide: VSCode">
+        <a class="btn btn-sm btn-outline-light" href="../docs/getting-started-vscode.html" data-goatcounter-click="click-guide-vscode" data-goatcounter-title="Guide: VSCode">
           <i class="bi bi-code-square"></i>
           <span class="lang en">Use VSCode</span>
           <span class="lang ja active">VSCodeで始める</span>
         </a>
-        <a class="btn btn-sm btn-outline-light" href="./docs/getting-started-led.html" data-goatcounter-click="click-guide-led" data-goatcounter-title="Guide: LED control">
+        <a class="btn btn-sm btn-outline-light" href="../docs/getting-started-led.html" data-goatcounter-click="click-guide-led" data-goatcounter-title="Guide: LED control">
           <i class="bi bi-lightbulb"></i>
           <span class="lang en">Control the LED</span>
           <span class="lang ja active">LED制御を試す</span>
@@ -551,7 +551,7 @@
             <span class="lang ja active">接続できたらフルカラーLEDを点滅させて、そのままセンサ値の取得へ進めます。</span>
           </p>
         </div>
-        <img src="./images/led_blinking.gif" alt="ORPHE CORE LED blinking">
+        <img src="../images/led_blinking.gif" alt="ORPHE CORE LED blinking">
       </div>
     </section>
 
@@ -567,7 +567,7 @@
         </h2>
       </div>
       <div class="dx-path-grid">
-        <a class="dx-path" href="./docs/getting-started-p5.html" data-goatcounter-click="click-path-p5" data-goatcounter-title="Start building: p5.js Web Editor">
+        <a class="dx-path" href="../docs/getting-started-p5.html" data-goatcounter-click="click-path-p5" data-goatcounter-title="Start building: p5.js Web Editor">
           <i class="bi bi-brush"></i>
           <strong>p5.js Web Editor</strong>
           <span>
@@ -575,7 +575,7 @@
             <span class="lang ja active">ローカル環境を作らず、ブラウザ上ですぐに試します。</span>
           </span>
         </a>
-        <a class="dx-path" href="./docs/getting-started-vscode.html" data-goatcounter-click="click-path-vscode" data-goatcounter-title="Start building: VSCode">
+        <a class="dx-path" href="../docs/getting-started-vscode.html" data-goatcounter-click="click-path-vscode" data-goatcounter-title="Start building: VSCode">
           <i class="bi bi-code-square"></i>
           <strong>VSCode</strong>
           <span>
@@ -583,7 +583,7 @@
             <span class="lang ja active">ローカルでHTMLを書き、Live Serverで動かします。</span>
           </span>
         </a>
-        <a class="dx-path" href="./docs/getting-started-coretoolkit.html" data-goatcounter-click="click-path-coretoolkit" data-goatcounter-title="Start building: CoreToolkit.js">
+        <a class="dx-path" href="../docs/getting-started-coretoolkit.html" data-goatcounter-click="click-path-coretoolkit" data-goatcounter-title="Start building: CoreToolkit.js">
           <i class="bi bi-window-sidebar"></i>
           <strong>CoreToolkit.js</strong>
           <span>
@@ -591,7 +591,7 @@
             <span class="lang ja active">接続UI、デバイス操作、設定まわりをすばやく追加します。</span>
           </span>
         </a>
-        <a class="dx-path" href="./examples/" data-goatcounter-click="click-path-examples-catalog" data-goatcounter-title="Start building: Examples catalog">
+        <a class="dx-path" href="../examples/" data-goatcounter-click="click-path-examples-catalog" data-goatcounter-title="Start building: Examples catalog">
           <i class="bi bi-grid-3x3-gap"></i>
           <strong>Examples</strong>
           <span>
@@ -615,7 +615,7 @@
             <span class="lang ja active">ジェスチャー認識、周波数解析、生データの記録。</span>
           </span>
         </a>
-        <a class="dx-path" href="./docs/getting-started-electron.html" data-goatcounter-click="click-path-electron" data-goatcounter-title="Start building: Desktop apps with Electron">
+        <a class="dx-path" href="../docs/getting-started-electron.html" data-goatcounter-click="click-path-electron" data-goatcounter-title="Start building: Desktop apps with Electron">
           <i class="bi bi-display"></i>
           <strong>Desktop apps with Electron</strong>
           <span>
@@ -655,27 +655,27 @@
       </p>
       <div class="dx-example-card-grid dx-workshop-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/workshop-07.png" alt="ORPHE CORE WS DFT and FFT material">
+          <img src="../examples/_thumbnails/workshop-07.png" alt="ORPHE CORE WS DFT and FFT material">
           <div class="dx-example-card-body">
             <h4>ORPHE CORE WS #7 / #8</h4>
             <p class="lang en">Workshop material for learning Fourier, DFT, and FFT with ORPHE CORE sensor data.</p>
             <p class="lang ja active">YouTubeのORPHE CORE WSで扱った、フーリエ解析・DFT/FFTの教材です。</p>
             <div class="dx-example-tags"><span>Workshop</span><span>DFT / FFT</span></div>
             <div class="dx-example-links">
-              <a href="./examples/WORKSHOP_07/" target="_blank">Material</a>
+              <a href="../examples/WORKSHOP_07/" target="_blank">Material</a>
               <a href="https://www.youtube.com/playlist?list=PLP_ql9XSx6s2Dex83_jkLLz28Mw2X9P_2" target="_blank">YouTube</a>
             </div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/ws-tmu2025.png" alt="Tokyo Metropolitan University 2025 workshop gallery">
+          <img src="../examples/_thumbnails/ws-tmu2025.png" alt="Tokyo Metropolitan University 2025 workshop gallery">
           <div class="dx-example-card-body">
             <h4>TMU 2025 Workshop Gallery</h4>
             <p class="lang en">Tokyo Metropolitan University class and workshop outcomes made with ORPHE CORE.</p>
             <p class="lang ja active">東京都立大学での授業・ワークショップ成果をまとめたギャラリーです。</p>
             <div class="dx-example-tags"><span>Education</span><span>Student Works</span></div>
             <div class="dx-example-links">
-              <a href="./ws/tmu2025/" target="_blank">Gallery</a>
+              <a href="../ws/tmu2025/" target="_blank">Gallery</a>
             </div>
           </div>
         </article>
@@ -710,128 +710,128 @@
       <p class="lang en">Use these examples to inspect the device, control LEDs, visualize sensor and gait data, and connect ORPHE CORE with other web APIs.</p>
       <p class="lang ja active">デバイス情報、LED制御、センサー値や歩容データの可視化、外部API連携など、アプリ開発の起点になるExampleです。</p>
       <div class="dx-mini-link-grid">
-        <a class="dx-mini-link lang en" href="./examples/" target="_blank">Browse all examples</a>
-        <a class="dx-mini-link lang ja active" href="./examples/" target="_blank">すべてのExampleを見る</a>
+        <a class="dx-mini-link lang en" href="../examples/" target="_blank">Browse all examples</a>
+        <a class="dx-mini-link lang ja active" href="../examples/" target="_blank">すべてのExampleを見る</a>
       </div>
       <div class="dx-example-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/INFORMATION/teaser.gif" alt="Device Information">
+          <img src="../examples/INFORMATION/teaser.gif" alt="Device Information">
           <div class="dx-example-card-body">
             <h4>INFORMATION</h4>
             <p class="lang en">Read ORPHE CORE device information before building an app.</p>
             <p class="lang ja active">アプリを作る前に、ORPHE COREのデバイス情報を確認します。</p>
             <div class="dx-example-tags"><span>Device</span><span>Setup</span></div>
-            <div class="dx-example-links"><a href="./examples/INFORMATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/INFORMATION" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/INFORMATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/INFORMATION" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/LIGHT/teaser.gif" alt="LED Control">
+          <img src="../examples/LIGHT/teaser.gif" alt="LED Control">
           <div class="dx-example-card-body">
             <h4>LIGHT</h4>
             <p class="lang en">Connect to ORPHE CORE and control the full-color LED.</p>
             <p class="lang ja active">ORPHE COREに接続して、フルカラーLEDを制御します。</p>
             <div class="dx-example-tags"><span>LED</span><span>Beginner</span></div>
-            <div class="dx-example-links"><a href="./examples/LIGHT/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/LIGHT" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/LIGHT/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/LIGHT" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/VIEW/data-viewer.gif" alt="Data Viewer">
+          <img src="../examples/VIEW/data-viewer.gif" alt="Data Viewer">
           <div class="dx-example-card-body">
             <h4>VIEW</h4>
             <p class="lang en">Inspect sensor and gait values in a browser UI.</p>
             <p class="lang ja active">センサー値と歩容解析の値をブラウザ上で確認します。</p>
             <div class="dx-example-tags"><span>Viewer</span><span>Gait</span></div>
-            <div class="dx-example-links"><a href="./examples/VIEW/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VIEW" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/VIEW/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VIEW" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/visualize.png" alt="Sensor Values Visualizer">
+          <img src="../examples/_thumbnails/visualize.png" alt="Sensor Values Visualizer">
           <div class="dx-example-card-body">
             <h4>VISUALIZE</h4>
             <p class="lang en">Visualize SENSOR_VALUES in a simple browser interface.</p>
             <p class="lang ja active">SENSOR_VALUESをシンプルな画面で可視化します。</p>
             <div class="dx-example-tags"><span>Sensor</span><span>Chart</span></div>
-            <div class="dx-example-links"><a href="./examples/VISUALIZE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VISUALIZE" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/VISUALIZE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VISUALIZE" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/foot-angle.png" alt="Foot Angle">
+          <img src="../examples/_thumbnails/foot-angle.png" alt="Foot Angle">
           <div class="dx-example-card-body">
             <h4>FOOT ANGLE</h4>
             <p class="lang en">Visualize landing and foot-angle data from ORPHE gait analysis.</p>
             <p class="lang ja active">歩容解析から得られる接地角や足角度を可視化します。</p>
             <div class="dx-example-tags"><span>Gait</span><span>Foot angle</span></div>
-            <div class="dx-example-links"><a href="./examples/FOOT%20ANGLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/FOOT%20ANGLE" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/ozss3px1G" target="_blank">p5.js</a></div>
+            <div class="dx-example-links"><a href="../examples/FOOT%20ANGLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/FOOT%20ANGLE" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/ozss3px1G" target="_blank">p5.js</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/pronation.png" alt="Pronation">
+          <img src="../examples/_thumbnails/pronation.png" alt="Pronation">
           <div class="dx-example-card-body">
             <h4>PRONATION</h4>
             <p class="lang en">Visualize pronation and landing-related gait data.</p>
             <p class="lang ja active">プロネーションや着地に関わる歩容データを可視化します。</p>
             <div class="dx-example-tags"><span>Gait</span><span>Pronation</span></div>
-            <div class="dx-example-links"><a href="./examples/PRONATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/PRONATION" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/PRONATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/PRONATION" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/airwalker.png" alt="Air Walker">
+          <img src="../examples/_thumbnails/airwalker.png" alt="Air Walker">
           <div class="dx-example-card-body">
             <h4>AIR WALKER</h4>
             <p class="lang en">Show steps, motion, and activity in a workout dashboard.</p>
             <p class="lang ja active">歩数、動き、アクティビティをダッシュボードで表示します。</p>
             <div class="dx-example-tags"><span>Dashboard</span><span>Activity</span></div>
-            <div class="dx-example-links"><a href="./examples/AIRWALKER/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/AIRWALKER" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/AIRWALKER/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/AIRWALKER" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/pose.png" alt="Pose with ORPHE CORE">
+          <img src="../examples/_thumbnails/pose.png" alt="Pose with ORPHE CORE">
           <div class="dx-example-card-body">
             <h4>POSE</h4>
             <p class="lang en">Combine MediaPipe Pose with ORPHE CORE sensor data.</p>
             <p class="lang ja active">MediaPipe PoseとORPHE COREのセンサーデータを組み合わせます。</p>
             <div class="dx-example-tags"><span>Pose</span><span>Creative</span></div>
-            <div class="dx-example-links"><a href="./examples/POSE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/POSE" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/POSE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/POSE" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/oh1.png" alt="OH1 Heart Rate">
+          <img src="../examples/_thumbnails/oh1.png" alt="OH1 Heart Rate">
           <div class="dx-example-card-body">
             <h4>OH1</h4>
             <p class="lang en">Connect OH1 heart rate data with ORPHE CORE motion data.</p>
             <p class="lang ja active">OH1の心拍データとORPHE COREのモーションデータを連携します。</p>
             <div class="dx-example-tags"><span>BLE</span><span>Heart rate</span></div>
-            <div class="dx-example-links"><a href="./examples/OH1/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/OH1" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/OH1/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/OH1" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/coretoolkit-starter.png" alt="CoreToolkit Starter">
+          <img src="../examples/_thumbnails/coretoolkit-starter.png" alt="CoreToolkit Starter">
           <div class="dx-example-card-body">
             <h4>CORETOOLKIT STARTER</h4>
             <p class="lang en">Start faster with CoreToolkit.js connection UI and sensor monitor.</p>
             <p class="lang ja active">CoreToolkit.jsの接続UIとセンサーモニターからすばやく始めます。</p>
             <div class="dx-example-tags"><span>CoreToolkit</span><span>UI</span></div>
-            <div class="dx-example-links"><a href="./examples/CORETOOLKIT-STARTER/" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/5nV83PG1A" target="_blank">p5.js</a></div>
+            <div class="dx-example-links"><a href="../examples/CORETOOLKIT-STARTER/" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/5nV83PG1A" target="_blank">p5.js</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/sensor-calibration.png" alt="Sensor Calibration">
+          <img src="../examples/_thumbnails/sensor-calibration.png" alt="Sensor Calibration">
           <div class="dx-example-card-body">
             <h4>SENSOR CALIBRATION</h4>
             <p class="lang en">Record sensor data for gesture recognition and AI training.</p>
             <p class="lang ja active">ジェスチャー認識やAI学習用にセンサーデータを記録します。</p>
             <div class="dx-example-tags"><span>Recording</span><span>AI</span></div>
-            <div class="dx-example-links"><a href="./examples/SENSOR-CALIBRATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/SENSOR-CALIBRATION" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/SENSOR-CALIBRATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/SENSOR-CALIBRATION" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/gesture-demo.png" alt="Gesture Demo">
+          <img src="../examples/_thumbnails/gesture-demo.png" alt="Gesture Demo">
           <div class="dx-example-card-body">
             <h4>GESTURE DEMO</h4>
             <p class="lang en">Detect toe tap, heel tap, and stomp gestures in real time.</p>
             <p class="lang ja active">つま先タップ、かかとタップ、踏み込みをリアルタイムに検出します。</p>
             <div class="dx-example-tags"><span>Gesture</span><span>Sound</span></div>
-            <div class="dx-example-links"><a href="./examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
           </div>
         </article>
       </div>
@@ -843,40 +843,40 @@
       <p class="lang ja active">Starter Templatesは、1つのデータ型や通知モードを小さく試すための最小サンプルです。</p>
       <div class="dx-example-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-light.png" alt="LED Starter">
-          <div class="dx-example-card-body"><h4>LIGHT</h4><p>LED control.</p><div class="dx-example-tags"><span>LED</span></div><div class="dx-example-links"><a href="./starter-templates/LIGHT.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/LIGHT.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/X7O5PU87S" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-light.png" alt="LED Starter">
+          <div class="dx-example-card-body"><h4>LIGHT</h4><p>LED control.</p><div class="dx-example-tags"><span>LED</span></div><div class="dx-example-links"><a href="../starter-templates/LIGHT.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/LIGHT.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/X7O5PU87S" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-accelerometer.png" alt="Accelerometer Starter">
-          <div class="dx-example-card-body"><h4>ACCELEROMETER</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Acc</span></div><div class="dx-example-links"><a href="./starter-templates/ACCELEROMETER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/ACCELEROMETER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WqUWEul5N" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-accelerometer.png" alt="Accelerometer Starter">
+          <div class="dx-example-card-body"><h4>ACCELEROMETER</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Acc</span></div><div class="dx-example-links"><a href="../starter-templates/ACCELEROMETER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/ACCELEROMETER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WqUWEul5N" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-gyro.png" alt="Gyro Starter">
-          <div class="dx-example-card-body"><h4>GYRO</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Gyro</span></div><div class="dx-example-links"><a href="./starter-templates/GYRO.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/GYRO.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/LvUXsj0WT" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-gyro.png" alt="Gyro Starter">
+          <div class="dx-example-card-body"><h4>GYRO</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Gyro</span></div><div class="dx-example-links"><a href="../starter-templates/GYRO.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/GYRO.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/LvUXsj0WT" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-quaternion.png" alt="Quaternion Starter">
-          <div class="dx-example-card-body"><h4>QUATERNION</h4><p>{w, x, y, z}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="./starter-templates/QUATERNION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/QUATERNION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/4modSEX2J" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-quaternion.png" alt="Quaternion Starter">
+          <div class="dx-example-card-body"><h4>QUATERNION</h4><p>{w, x, y, z}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="../starter-templates/QUATERNION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/QUATERNION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/4modSEX2J" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-euler.png" alt="Euler Starter">
-          <div class="dx-example-card-body"><h4>EULER</h4><p>{pitch, roll, yaw}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="./starter-templates/EULER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/EULER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WiTZ23rw2" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-euler.png" alt="Euler Starter">
+          <div class="dx-example-card-body"><h4>EULER</h4><p>{pitch, roll, yaw}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="../starter-templates/EULER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/EULER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WiTZ23rw2" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-steps.png" alt="Steps Starter">
-          <div class="dx-example-card-body"><h4>STEPS</h4><p>Number of steps.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/STEPS.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STEPS.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/fTR9Jj0kC" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-steps.png" alt="Steps Starter">
+          <div class="dx-example-card-body"><h4>STEPS</h4><p>Number of steps.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="../starter-templates/STEPS.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STEPS.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/fTR9Jj0kC" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-stride.png" alt="Stride Starter">
-          <div class="dx-example-card-body"><h4>STRIDE</h4><p>Stride data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/STRIDE.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STRIDE.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/PbW-apAGP" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-stride.png" alt="Stride Starter">
+          <div class="dx-example-card-body"><h4>STRIDE</h4><p>Stride data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="../starter-templates/STRIDE.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STRIDE.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/PbW-apAGP" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-pronation.png" alt="Pronation Starter">
-          <div class="dx-example-card-body"><h4>PRONATION</h4><p>Pronation data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/PRONATION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/PRONATION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/FAw49ZU7g" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-pronation.png" alt="Pronation Starter">
+          <div class="dx-example-card-body"><h4>PRONATION</h4><p>Pronation data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="../starter-templates/PRONATION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/PRONATION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/FAw49ZU7g" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-analysis-and-sensor-values.png" alt="Step Analysis and Sensor Values">
-          <div class="dx-example-card-body"><h4>STEP_ANALYSIS + SENSOR_VALUES</h4><p class="lang en">Start STEP_ANALYSIS_AND_SENSOR_VALUES notify.</p><p class="lang ja active">解析値と生センサー値を同時に受け取ります。</p><div class="dx-example-tags"><span>Gait</span><span>Sensor</span></div><div class="dx-example-links"><a href="./starter-templates/ANALYSIS_AND_RAW.html" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/1mNA7vd1g" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-analysis-and-sensor-values.png" alt="Step Analysis and Sensor Values">
+          <div class="dx-example-card-body"><h4>STEP_ANALYSIS + SENSOR_VALUES</h4><p class="lang en">Start STEP_ANALYSIS_AND_SENSOR_VALUES notify.</p><p class="lang ja active">解析値と生センサー値を同時に受け取ります。</p><div class="dx-example-tags"><span>Gait</span><span>Sensor</span></div><div class="dx-example-links"><a href="../starter-templates/ANALYSIS_AND_RAW.html" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/1mNA7vd1g" target="_blank">p5.js</a></div></div>
         </article>
       </div>
       <h4 class="dx-example-subhead">p5.js Recipes</h4>
@@ -895,10 +895,10 @@
       <p class="lang en">Sports examples that turn gait and foot motion into track, sprint, hurdle, and competition-style experiences.</p>
       <p class="lang ja active">歩行・走行・足の動きを使って、陸上競技や対戦型スポーツ体験を作るExampleです。</p>
       <div class="dx-example-card-grid">
-        <article class="dx-example-card"><img src="./examples/_thumbnails/hurdle-110m.png" alt="110m Hurdles"><div class="dx-example-card-body"><h4 class="lang en">110m Hurdles</h4><h4 class="lang ja active">110m ハードル走</h4><p class="lang en">A flagship Virtual Sports example powered by Gait Analysis and foot motion.</p><p class="lang ja active">Gait Analysisと足の動きで走る、Virtual Sportsの代表Exampleです。</p><div class="dx-example-tags"><span>Virtual Sports</span><span>2 COREs</span></div><div class="dx-example-links"><a href="./examples/GAME-HURDLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-HURDLE" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/hurdle-110m.png" alt="110m Hurdles"><div class="dx-example-card-body"><h4 class="lang en">110m Hurdles</h4><h4 class="lang ja active">110m ハードル走</h4><p class="lang en">A flagship Virtual Sports example powered by Gait Analysis and foot motion.</p><p class="lang ja active">Gait Analysisと足の動きで走る、Virtual Sportsの代表Exampleです。</p><div class="dx-example-tags"><span>Virtual Sports</span><span>2 COREs</span></div><div class="dx-example-links"><a href="../examples/GAME-HURDLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-HURDLE" target="_blank">Source</a></div></div></article>
       </div>
       <div class="dx-mini-link-grid">
-        <a class="dx-mini-link" href="./examples/?category=virtual-sports" target="_blank">Virtual Sports category</a>
+        <a class="dx-mini-link" href="../examples/?category=virtual-sports" target="_blank">Virtual Sports category</a>
       </div>
     </section>
 
@@ -907,12 +907,12 @@
       <p class="lang en">Play with graphics, sounds, and physical game mechanics using ORPHE CORE as an input device.</p>
       <p class="lang ja active">ORPHE COREを入力デバイスとして使い、グラフィック、サウンド、身体動作のゲームを作るExampleです。</p>
       <div class="dx-example-card-grid">
-        <article class="dx-example-card"><img src="./examples/_thumbnails/udon.png" alt="Udon game"><div class="dx-example-card-body"><h4>UDON</h4><p>足踏みでうどんをこねるゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-UDON/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-UDON" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/move-your-feet.png" alt="Move your feet"><div class="dx-example-card-body"><h4>MOVEYOURFEET</h4><p>足を動かして遊ぶエクササイズ系ゲーム。</p><div class="dx-example-links"><a href="./examples/MOVEYOURFEET/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/MOVEYOURFEET" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/pingpong.png" alt="Ping pong game"><div class="dx-example-card-body"><h4>PINGPONG GAME</h4><p>2人で遊べるシンプルな対戦ゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-PINGPONG/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-PINGPONG" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/drum.png" alt="Drum game"><div class="dx-example-card-body"><h4>ORPHE CORE Gesture Drum</h4><p>ジェスチャーで音を鳴らすドラムサンプラー。</p><div class="dx-example-links"><a href="./examples/drum_test/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/drum_test" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/boxing.png" alt="Boxing game"><div class="dx-example-card-body"><h4>BOXING GAME</h4><p>パンチ動作を使ったアクションゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-BOXING/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-BOXING" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/ddr.png" alt="DDR game"><div class="dx-example-card-body"><h4>DDR GAME</h4><p>音楽と足の動きを組み合わせたリズムゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-DDR/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-DDR" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/udon.png" alt="Udon game"><div class="dx-example-card-body"><h4>UDON</h4><p>足踏みでうどんをこねるゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-UDON/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-UDON" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/move-your-feet.png" alt="Move your feet"><div class="dx-example-card-body"><h4>MOVEYOURFEET</h4><p>足を動かして遊ぶエクササイズ系ゲーム。</p><div class="dx-example-links"><a href="../examples/MOVEYOURFEET/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/MOVEYOURFEET" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/pingpong.png" alt="Ping pong game"><div class="dx-example-card-body"><h4>PINGPONG GAME</h4><p>2人で遊べるシンプルな対戦ゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-PINGPONG/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-PINGPONG" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/drum.png" alt="Drum game"><div class="dx-example-card-body"><h4>ORPHE CORE Gesture Drum</h4><p>ジェスチャーで音を鳴らすドラムサンプラー。</p><div class="dx-example-links"><a href="../examples/drum_test/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/drum_test" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/boxing.png" alt="Boxing game"><div class="dx-example-card-body"><h4>BOXING GAME</h4><p>パンチ動作を使ったアクションゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-BOXING/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-BOXING" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/ddr.png" alt="DDR game"><div class="dx-example-card-body"><h4>DDR GAME</h4><p>音楽と足の動きを組み合わせたリズムゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-DDR/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-DDR" target="_blank">Source</a></div></div></article>
       </div>
       <h4 class="dx-example-subhead">p5.js Sketches</h4>
       <div class="dx-mini-link-grid">
@@ -929,13 +929,13 @@
       <p class="lang ja active">ジェスチャー認識、時系列マッチング、周波数解析、データ可視化を試すためのExampleです。</p>
       <div class="dx-example-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/gesture-demo.png" alt="Gesture recognition">
+          <img src="../examples/_thumbnails/gesture-demo.png" alt="Gesture recognition">
           <div class="dx-example-card-body">
             <h4>GESTURE DEMO</h4>
             <p class="lang en">A practical starting point for real-time gesture detection.</p>
             <p class="lang ja active">リアルタイムのジェスチャー検出を試す実用的な起点です。</p>
             <div class="dx-example-tags"><span>Gesture</span><span>Detection</span></div>
-            <div class="dx-example-links"><a href="./examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
           </div>
         </article>
       </div>
@@ -956,7 +956,7 @@
       <p class="lang ja active">
         以下はjsdocによって生成されたORPHEクラスのAPIリファレンスです。
       </p>
-      <li><a href="./api_doc/" target="_blank">API Reference for ORPHE-CORE.js</a></li>
+      <li><a href="../api_doc/" target="_blank">API Reference for ORPHE-CORE.js</a></li>
     </section>
 
 
@@ -970,10 +970,10 @@
   </div>
 
 
-  <script src="./js/bootstrap.bundle.min.js"
+  <script src="../js/bootstrap.bundle.min.js"
     integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2"
     crossorigin="anonymous"></script>
-  <script src="./js/run_prettify.js?skin=sunburst"></script>
+  <script src="../js/run_prettify.js?skin=sunburst"></script>
 
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>

--- a/examples/gallery.js
+++ b/examples/gallery.js
@@ -3,7 +3,7 @@
 
   const uiText = {
     ja: {
-      documentTitle: 'Examples一覧 - ORPHE-CORE.js',
+      documentTitle: 'ORPHE-CORE.js Examples | IMUセンサー・歩容解析・Virtual Sports',
       toggle: 'English',
       title: 'ORPHE COREで作れるものを探す。',
       lead: '接続やLED制御から、センサー値の取得、Gait Analysis、記録・解析、ゲーム、クリエイティブ表現まで、目的に合わせてExampleを選べます。',
@@ -20,7 +20,7 @@
       deviceUnit: (count) => `${count}台`
     },
     en: {
-      documentTitle: 'Examples - ORPHE-CORE.js',
+      documentTitle: 'ORPHE-CORE.js Examples | IMU Sensor, Gait Analysis, Virtual Sports',
       toggle: '日本語',
       title: 'Find examples by what you want to build.',
       lead: 'Choose an example for your goal, from connection and LED control to sensor values, Gait Analysis, recording, games, and creative coding.',

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,22 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Examples一覧 - ORPHE-CORE.js</title>
+  <title>ORPHE-CORE.js Examples | IMU Sensor, Gait Analysis, Virtual Sports</title>
+  <meta name="description"
+    content="Browse ORPHE-CORE.js examples for Web Bluetooth, foot-mounted IMU sensor data, gait analysis, recording tools, virtual sports, creative coding, and education.">
+  <link rel="canonical" href="https://orphe-oss.github.io/ORPHE-CORE.js/examples/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="ORPHE-CORE.js">
+  <meta property="og:title" content="ORPHE-CORE.js Examples">
+  <meta property="og:description"
+    content="Find examples for ORPHE CORE: IMU sensor values, gait analysis, recording, virtual sports, games, and creative coding.">
+  <meta property="og:url" content="https://orphe-oss.github.io/ORPHE-CORE.js/examples/">
+  <meta property="og:image" content="https://orphe-oss.github.io/ORPHE-CORE.js/examples/_thumbnails/hurdle-110m.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ORPHE-CORE.js Examples">
+  <meta name="twitter:description"
+    content="Examples for ORPHE CORE: Web Bluetooth, foot-mounted IMU data, gait analysis, recording, and virtual sports.">
+  <meta name="twitter:image" content="https://orphe-oss.github.io/ORPHE-CORE.js/examples/_thumbnails/hurdle-110m.png">
   <script>
     (function () {
       const storageKey = 'orphe-core-js-language';

--- a/ja/index.html
+++ b/ja/index.html
@@ -1,29 +1,29 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja" data-preferred-language="ja">
 
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>ORPHE-CORE.js | JavaScript SDK for Foot-Mounted IMU and Gait Analysis</title>
+  <title>ORPHE-CORE.js | 足部IMUセンサー・歩容解析のためのJavaScript SDK</title>
   <meta name="description"
-    content="ORPHE-CORE.js is a JavaScript SDK for ORPHE CORE, a foot-mounted IMU sensor. Build Web Bluetooth apps for gait analysis, motion data, virtual sports, education, and research.">
-  <link rel="canonical" href="https://orphe-oss.github.io/ORPHE-CORE.js/">
+    content="ORPHE-CORE.jsは、足部装着型IMUセンサーORPHE COREをWeb Bluetooth経由で扱うJavaScript SDKです。歩容解析、モーションデータ、Virtual Sports、教育、研究用Webアプリを作れます。">
+  <link rel="canonical" href="https://orphe-oss.github.io/ORPHE-CORE.js/ja/">
   <link rel="alternate" hreflang="x-default" href="https://orphe-oss.github.io/ORPHE-CORE.js/">
   <link rel="alternate" hreflang="en" href="https://orphe-oss.github.io/ORPHE-CORE.js/en/">
   <link rel="alternate" hreflang="ja" href="https://orphe-oss.github.io/ORPHE-CORE.js/ja/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="ORPHE-CORE.js">
-  <meta property="og:title" content="ORPHE-CORE.js | Foot-Mounted IMU and Gait Analysis JavaScript SDK">
+  <meta property="og:title" content="ORPHE-CORE.js | 足部IMUセンサー・歩容解析のためのJavaScript SDK">
   <meta property="og:description"
-    content="Build Web Bluetooth apps for ORPHE CORE: foot-mounted IMU data, gait analysis, virtual sports, education, and research tools.">
-  <meta property="og:url" content="https://orphe-oss.github.io/ORPHE-CORE.js/">
+    content="ORPHE COREの足部IMUデータ、歩容解析、Virtual Sports、教育、研究用WebアプリをJavaScriptで作れます。">
+  <meta property="og:url" content="https://orphe-oss.github.io/ORPHE-CORE.js/ja/">
   <meta property="og:image" content="https://orphe-oss.github.io/ORPHE-CORE.js/images/ORPHE_TRACK_scene_03.jpg">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:locale:alternate" content="ja_JP">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:locale:alternate" content="en_US">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="ORPHE-CORE.js | Foot-Mounted IMU and Gait Analysis JavaScript SDK">
+  <meta name="twitter:title" content="ORPHE-CORE.js | 足部IMUセンサー・歩容解析のためのJavaScript SDK">
   <meta name="twitter:description"
-    content="JavaScript SDK for ORPHE CORE, Web Bluetooth, foot-mounted IMU data, gait analysis, and motion-based web apps.">
+    content="ORPHE CORE、Web Bluetooth、足部IMUデータ、歩容解析、身体動作WebアプリのためのJavaScript SDK。">
   <meta name="twitter:image" content="https://orphe-oss.github.io/ORPHE-CORE.js/images/ORPHE_TRACK_scene_03.jpg">
   <script>
     var last_modified = `
@@ -57,13 +57,13 @@
       "@type": "SoftwareSourceCode",
       "name": "ORPHE-CORE.js",
       "alternateName": "ORPHE CORE JavaScript SDK",
-      "url": "https://orphe-oss.github.io/ORPHE-CORE.js/",
+      "url": "https://orphe-oss.github.io/ORPHE-CORE.js/ja/",
       "codeRepository": "https://github.com/Orphe-OSS/ORPHE-CORE.js",
       "programmingLanguage": "JavaScript",
       "runtimePlatform": "Web Bluetooth API",
       "applicationCategory": "DeveloperApplication",
       "keywords": "ORPHE CORE, foot-mounted IMU, gait analysis, Web Bluetooth, JavaScript SDK, wearable sensor, smart footwear, motion sensor",
-      "description": "ORPHE-CORE.js is a JavaScript SDK for ORPHE CORE, a foot-mounted IMU sensor for gait analysis, motion data, virtual sports, education, and research.",
+      "description": "ORPHE-CORE.jsは、歩容解析、モーションデータ、Virtual Sports、教育、研究に使える足部装着型IMUセンサーORPHE COREのJavaScript SDKです。",
       "publisher": {
         "@type": "Organization",
         "name": "ORPHE Inc.",
@@ -72,13 +72,13 @@
     }
   </script>
 
-  <link href="./css/custom.css" rel="stylesheet">
+  <link href="../css/custom.css" rel="stylesheet">
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/vs2015.min.css">
   <link rel="stylesheet" href="https://unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.css" />
-  <link href="./css/orphe_custom.css" rel="stylesheet">
-  <script src="./js/site-analytics.js"></script>
+  <link href="../css/orphe_custom.css" rel="stylesheet">
+  <script src="../js/site-analytics.js"></script>
   <style>
     .lang {
       display: none;
@@ -115,7 +115,7 @@
       <div class="container-fluid">
         <span class="navbar-brand mb-0 h1">
           <a class="navbar-brand" href="https://orphe.io/">
-            <img src="./images/orphe.svg" alt="" height="24" class="d-inline-block align-text-top">
+            <img src="../images/orphe.svg" alt="" height="24" class="d-inline-block align-text-top">
           </a>
           <span id="last_modified" class="position-absolute top-25 end-0 badge bg-base border-light p-1"
             style="font-size:0.5em;">
@@ -172,7 +172,7 @@
       <a href="https://github.com/Orphe-OSS/ORPHE-CORE.js" target="_blank" data-goatcounter-click="click-link-github" data-goatcounter-title="Top link: GitHub">
         <i class="bi bi-github"></i> GitHub
       </a>
-      <a href="./api_doc/" target="_blank" data-goatcounter-click="click-link-api-reference" data-goatcounter-title="Top link: API Reference">
+      <a href="../api_doc/" target="_blank" data-goatcounter-click="click-link-api-reference" data-goatcounter-title="Top link: API Reference">
         <i class="bi bi-book"></i> API Reference
       </a>
       <a href="https://shop.orphe.io/products/orphe-core-3-0" target="_blank" data-goatcounter-click="click-link-buy-core" data-goatcounter-title="Top link: Buy ORPHE CORE 3.0">
@@ -245,7 +245,7 @@
       </div>
       <div class="dx-spec-layout">
         <figure class="dx-product-visual">
-          <img src="./images/product/orphe-core-3-front.jpg" alt="ORPHE CORE 3.0 front view">
+          <img src="../images/product/orphe-core-3-front.jpg" alt="ORPHE CORE 3.0 front view">
           <div class="dx-measure-x">29mm</div>
           <div class="dx-measure-y">45mm</div>
         </figure>
@@ -410,50 +410,50 @@
         </h2>
       </div>
       <div class="dx-demo-game-grid">
-        <a class="dx-demo-game" href="./examples/GAME-HURDLE/" target="_blank" data-goatcounter-click="click-example-game-hurdle" data-goatcounter-title="Example: 110m Hurdles">
-          <img src="./examples/_thumbnails/hurdle-110m.png" alt="110m hurdle game">
+        <a class="dx-demo-game" href="../examples/GAME-HURDLE/" target="_blank" data-goatcounter-click="click-example-game-hurdle" data-goatcounter-title="Example: 110m Hurdles">
+          <img src="../examples/_thumbnails/hurdle-110m.png" alt="110m hurdle game">
           <span>
             <span class="lang en">110m Hurdles</span>
             <span class="lang ja active">110m ハードル走</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-UDON/" target="_blank" data-goatcounter-click="click-example-game-udon" data-goatcounter-title="Example: Udon kneading game">
-          <img src="./examples/_thumbnails/udon.png" alt="Udon kneading game">
+        <a class="dx-demo-game" href="../examples/GAME-UDON/" target="_blank" data-goatcounter-click="click-example-game-udon" data-goatcounter-title="Example: Udon kneading game">
+          <img src="../examples/_thumbnails/udon.png" alt="Udon kneading game">
           <span>
             <span class="lang en">Udon kneading game</span>
             <span class="lang ja active">うどんふみふみゲーム！</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/MOVEYOURFEET/" target="_blank" data-goatcounter-click="click-example-move-your-feet" data-goatcounter-title="Example: Move your feet">
-          <img src="./examples/_thumbnails/move-your-feet.png" alt="Move your feet game">
+        <a class="dx-demo-game" href="../examples/MOVEYOURFEET/" target="_blank" data-goatcounter-click="click-example-move-your-feet" data-goatcounter-title="Example: Move your feet">
+          <img src="../examples/_thumbnails/move-your-feet.png" alt="Move your feet game">
           <span>
             <span class="lang en">Move your feet</span>
             <span class="lang ja active">足パタパタゲーム☆</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-PINGPONG/" target="_blank" data-goatcounter-click="click-example-game-pingpong" data-goatcounter-title="Example: Ping pong game">
-          <img src="./examples/_thumbnails/pingpong.png" alt="Ping pong game">
+        <a class="dx-demo-game" href="../examples/GAME-PINGPONG/" target="_blank" data-goatcounter-click="click-example-game-pingpong" data-goatcounter-title="Example: Ping pong game">
+          <img src="../examples/_thumbnails/pingpong.png" alt="Ping pong game">
           <span>
             <span class="lang en">Ping pong game</span>
             <span class="lang ja active">ピンポンゲーム</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/drum_test/" target="_blank" data-goatcounter-click="click-example-drum-test" data-goatcounter-title="Example: Drum game">
-          <img src="./examples/_thumbnails/drum.png" alt="Drum game">
+        <a class="dx-demo-game" href="../examples/drum_test/" target="_blank" data-goatcounter-click="click-example-drum-test" data-goatcounter-title="Example: Drum game">
+          <img src="../examples/_thumbnails/drum.png" alt="Drum game">
           <span>
             <span class="lang en">Drum game</span>
             <span class="lang ja active">ドラムゲーム</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-BOXING/" target="_blank" data-goatcounter-click="click-example-game-boxing" data-goatcounter-title="Example: Boxing game">
-          <img src="./examples/_thumbnails/boxing.png" alt="Boxing game">
+        <a class="dx-demo-game" href="../examples/GAME-BOXING/" target="_blank" data-goatcounter-click="click-example-game-boxing" data-goatcounter-title="Example: Boxing game">
+          <img src="../examples/_thumbnails/boxing.png" alt="Boxing game">
           <span>
             <span class="lang en">Boxing game</span>
             <span class="lang ja active">ボクシングゲーム</span>
           </span>
         </a>
-        <a class="dx-demo-game" href="./examples/GAME-DDR/" target="_blank" data-goatcounter-click="click-example-game-ddr" data-goatcounter-title="Example: DDR game">
-          <img src="./examples/_thumbnails/ddr.png" alt="DDR game">
+        <a class="dx-demo-game" href="../examples/GAME-DDR/" target="_blank" data-goatcounter-click="click-example-game-ddr" data-goatcounter-title="Example: DDR game">
+          <img src="../examples/_thumbnails/ddr.png" alt="DDR game">
           <span>
             <span class="lang en">DDR game</span>
             <span class="lang ja active">DDRゲーム</span>
@@ -461,7 +461,7 @@
         </a>
       </div>
       <div class="dx-demo-actions">
-        <a class="btn btn-outline-light" href="./examples/" data-goatcounter-click="click-examples-catalog" data-goatcounter-title="What you can build: Examples catalog">
+        <a class="btn btn-outline-light" href="../examples/" data-goatcounter-click="click-examples-catalog" data-goatcounter-title="What you can build: Examples catalog">
           <i class="bi bi-grid-3x3-gap"></i>
           <span class="lang en">Browse all examples by purpose</span>
           <span class="lang ja active">すべてのExampleを目的別に探す</span>
@@ -524,17 +524,17 @@
         </div>
       </div>
       <div class="dx-inline-actions">
-        <a class="btn btn-sm btn-primary" href="./docs/getting-started-p5.html" data-goatcounter-click="click-guide-p5" data-goatcounter-title="Guide: p5.js starter">
+        <a class="btn btn-sm btn-primary" href="../docs/getting-started-p5.html" data-goatcounter-click="click-guide-p5" data-goatcounter-title="Guide: p5.js starter">
           <i class="bi bi-brush"></i>
           <span class="lang en">Try p5.js starter</span>
           <span class="lang ja active">p5.jsですぐ試す</span>
         </a>
-        <a class="btn btn-sm btn-outline-light" href="./docs/getting-started-vscode.html" data-goatcounter-click="click-guide-vscode" data-goatcounter-title="Guide: VSCode">
+        <a class="btn btn-sm btn-outline-light" href="../docs/getting-started-vscode.html" data-goatcounter-click="click-guide-vscode" data-goatcounter-title="Guide: VSCode">
           <i class="bi bi-code-square"></i>
           <span class="lang en">Use VSCode</span>
           <span class="lang ja active">VSCodeで始める</span>
         </a>
-        <a class="btn btn-sm btn-outline-light" href="./docs/getting-started-led.html" data-goatcounter-click="click-guide-led" data-goatcounter-title="Guide: LED control">
+        <a class="btn btn-sm btn-outline-light" href="../docs/getting-started-led.html" data-goatcounter-click="click-guide-led" data-goatcounter-title="Guide: LED control">
           <i class="bi bi-lightbulb"></i>
           <span class="lang en">Control the LED</span>
           <span class="lang ja active">LED制御を試す</span>
@@ -551,7 +551,7 @@
             <span class="lang ja active">接続できたらフルカラーLEDを点滅させて、そのままセンサ値の取得へ進めます。</span>
           </p>
         </div>
-        <img src="./images/led_blinking.gif" alt="ORPHE CORE LED blinking">
+        <img src="../images/led_blinking.gif" alt="ORPHE CORE LED blinking">
       </div>
     </section>
 
@@ -567,7 +567,7 @@
         </h2>
       </div>
       <div class="dx-path-grid">
-        <a class="dx-path" href="./docs/getting-started-p5.html" data-goatcounter-click="click-path-p5" data-goatcounter-title="Start building: p5.js Web Editor">
+        <a class="dx-path" href="../docs/getting-started-p5.html" data-goatcounter-click="click-path-p5" data-goatcounter-title="Start building: p5.js Web Editor">
           <i class="bi bi-brush"></i>
           <strong>p5.js Web Editor</strong>
           <span>
@@ -575,7 +575,7 @@
             <span class="lang ja active">ローカル環境を作らず、ブラウザ上ですぐに試します。</span>
           </span>
         </a>
-        <a class="dx-path" href="./docs/getting-started-vscode.html" data-goatcounter-click="click-path-vscode" data-goatcounter-title="Start building: VSCode">
+        <a class="dx-path" href="../docs/getting-started-vscode.html" data-goatcounter-click="click-path-vscode" data-goatcounter-title="Start building: VSCode">
           <i class="bi bi-code-square"></i>
           <strong>VSCode</strong>
           <span>
@@ -583,7 +583,7 @@
             <span class="lang ja active">ローカルでHTMLを書き、Live Serverで動かします。</span>
           </span>
         </a>
-        <a class="dx-path" href="./docs/getting-started-coretoolkit.html" data-goatcounter-click="click-path-coretoolkit" data-goatcounter-title="Start building: CoreToolkit.js">
+        <a class="dx-path" href="../docs/getting-started-coretoolkit.html" data-goatcounter-click="click-path-coretoolkit" data-goatcounter-title="Start building: CoreToolkit.js">
           <i class="bi bi-window-sidebar"></i>
           <strong>CoreToolkit.js</strong>
           <span>
@@ -591,7 +591,7 @@
             <span class="lang ja active">接続UI、デバイス操作、設定まわりをすばやく追加します。</span>
           </span>
         </a>
-        <a class="dx-path" href="./examples/" data-goatcounter-click="click-path-examples-catalog" data-goatcounter-title="Start building: Examples catalog">
+        <a class="dx-path" href="../examples/" data-goatcounter-click="click-path-examples-catalog" data-goatcounter-title="Start building: Examples catalog">
           <i class="bi bi-grid-3x3-gap"></i>
           <strong>Examples</strong>
           <span>
@@ -615,7 +615,7 @@
             <span class="lang ja active">ジェスチャー認識、周波数解析、生データの記録。</span>
           </span>
         </a>
-        <a class="dx-path" href="./docs/getting-started-electron.html" data-goatcounter-click="click-path-electron" data-goatcounter-title="Start building: Desktop apps with Electron">
+        <a class="dx-path" href="../docs/getting-started-electron.html" data-goatcounter-click="click-path-electron" data-goatcounter-title="Start building: Desktop apps with Electron">
           <i class="bi bi-display"></i>
           <strong>Desktop apps with Electron</strong>
           <span>
@@ -655,27 +655,27 @@
       </p>
       <div class="dx-example-card-grid dx-workshop-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/workshop-07.png" alt="ORPHE CORE WS DFT and FFT material">
+          <img src="../examples/_thumbnails/workshop-07.png" alt="ORPHE CORE WS DFT and FFT material">
           <div class="dx-example-card-body">
             <h4>ORPHE CORE WS #7 / #8</h4>
             <p class="lang en">Workshop material for learning Fourier, DFT, and FFT with ORPHE CORE sensor data.</p>
             <p class="lang ja active">YouTubeのORPHE CORE WSで扱った、フーリエ解析・DFT/FFTの教材です。</p>
             <div class="dx-example-tags"><span>Workshop</span><span>DFT / FFT</span></div>
             <div class="dx-example-links">
-              <a href="./examples/WORKSHOP_07/" target="_blank">Material</a>
+              <a href="../examples/WORKSHOP_07/" target="_blank">Material</a>
               <a href="https://www.youtube.com/playlist?list=PLP_ql9XSx6s2Dex83_jkLLz28Mw2X9P_2" target="_blank">YouTube</a>
             </div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/ws-tmu2025.png" alt="Tokyo Metropolitan University 2025 workshop gallery">
+          <img src="../examples/_thumbnails/ws-tmu2025.png" alt="Tokyo Metropolitan University 2025 workshop gallery">
           <div class="dx-example-card-body">
             <h4>TMU 2025 Workshop Gallery</h4>
             <p class="lang en">Tokyo Metropolitan University class and workshop outcomes made with ORPHE CORE.</p>
             <p class="lang ja active">東京都立大学での授業・ワークショップ成果をまとめたギャラリーです。</p>
             <div class="dx-example-tags"><span>Education</span><span>Student Works</span></div>
             <div class="dx-example-links">
-              <a href="./ws/tmu2025/" target="_blank">Gallery</a>
+              <a href="../ws/tmu2025/" target="_blank">Gallery</a>
             </div>
           </div>
         </article>
@@ -710,128 +710,128 @@
       <p class="lang en">Use these examples to inspect the device, control LEDs, visualize sensor and gait data, and connect ORPHE CORE with other web APIs.</p>
       <p class="lang ja active">デバイス情報、LED制御、センサー値や歩容データの可視化、外部API連携など、アプリ開発の起点になるExampleです。</p>
       <div class="dx-mini-link-grid">
-        <a class="dx-mini-link lang en" href="./examples/" target="_blank">Browse all examples</a>
-        <a class="dx-mini-link lang ja active" href="./examples/" target="_blank">すべてのExampleを見る</a>
+        <a class="dx-mini-link lang en" href="../examples/" target="_blank">Browse all examples</a>
+        <a class="dx-mini-link lang ja active" href="../examples/" target="_blank">すべてのExampleを見る</a>
       </div>
       <div class="dx-example-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/INFORMATION/teaser.gif" alt="Device Information">
+          <img src="../examples/INFORMATION/teaser.gif" alt="Device Information">
           <div class="dx-example-card-body">
             <h4>INFORMATION</h4>
             <p class="lang en">Read ORPHE CORE device information before building an app.</p>
             <p class="lang ja active">アプリを作る前に、ORPHE COREのデバイス情報を確認します。</p>
             <div class="dx-example-tags"><span>Device</span><span>Setup</span></div>
-            <div class="dx-example-links"><a href="./examples/INFORMATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/INFORMATION" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/INFORMATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/INFORMATION" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/LIGHT/teaser.gif" alt="LED Control">
+          <img src="../examples/LIGHT/teaser.gif" alt="LED Control">
           <div class="dx-example-card-body">
             <h4>LIGHT</h4>
             <p class="lang en">Connect to ORPHE CORE and control the full-color LED.</p>
             <p class="lang ja active">ORPHE COREに接続して、フルカラーLEDを制御します。</p>
             <div class="dx-example-tags"><span>LED</span><span>Beginner</span></div>
-            <div class="dx-example-links"><a href="./examples/LIGHT/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/LIGHT" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/LIGHT/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/LIGHT" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/VIEW/data-viewer.gif" alt="Data Viewer">
+          <img src="../examples/VIEW/data-viewer.gif" alt="Data Viewer">
           <div class="dx-example-card-body">
             <h4>VIEW</h4>
             <p class="lang en">Inspect sensor and gait values in a browser UI.</p>
             <p class="lang ja active">センサー値と歩容解析の値をブラウザ上で確認します。</p>
             <div class="dx-example-tags"><span>Viewer</span><span>Gait</span></div>
-            <div class="dx-example-links"><a href="./examples/VIEW/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VIEW" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/VIEW/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VIEW" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/visualize.png" alt="Sensor Values Visualizer">
+          <img src="../examples/_thumbnails/visualize.png" alt="Sensor Values Visualizer">
           <div class="dx-example-card-body">
             <h4>VISUALIZE</h4>
             <p class="lang en">Visualize SENSOR_VALUES in a simple browser interface.</p>
             <p class="lang ja active">SENSOR_VALUESをシンプルな画面で可視化します。</p>
             <div class="dx-example-tags"><span>Sensor</span><span>Chart</span></div>
-            <div class="dx-example-links"><a href="./examples/VISUALIZE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VISUALIZE" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/VISUALIZE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/VISUALIZE" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/foot-angle.png" alt="Foot Angle">
+          <img src="../examples/_thumbnails/foot-angle.png" alt="Foot Angle">
           <div class="dx-example-card-body">
             <h4>FOOT ANGLE</h4>
             <p class="lang en">Visualize landing and foot-angle data from ORPHE gait analysis.</p>
             <p class="lang ja active">歩容解析から得られる接地角や足角度を可視化します。</p>
             <div class="dx-example-tags"><span>Gait</span><span>Foot angle</span></div>
-            <div class="dx-example-links"><a href="./examples/FOOT%20ANGLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/FOOT%20ANGLE" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/ozss3px1G" target="_blank">p5.js</a></div>
+            <div class="dx-example-links"><a href="../examples/FOOT%20ANGLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/FOOT%20ANGLE" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/ozss3px1G" target="_blank">p5.js</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/pronation.png" alt="Pronation">
+          <img src="../examples/_thumbnails/pronation.png" alt="Pronation">
           <div class="dx-example-card-body">
             <h4>PRONATION</h4>
             <p class="lang en">Visualize pronation and landing-related gait data.</p>
             <p class="lang ja active">プロネーションや着地に関わる歩容データを可視化します。</p>
             <div class="dx-example-tags"><span>Gait</span><span>Pronation</span></div>
-            <div class="dx-example-links"><a href="./examples/PRONATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/PRONATION" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/PRONATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/PRONATION" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/airwalker.png" alt="Air Walker">
+          <img src="../examples/_thumbnails/airwalker.png" alt="Air Walker">
           <div class="dx-example-card-body">
             <h4>AIR WALKER</h4>
             <p class="lang en">Show steps, motion, and activity in a workout dashboard.</p>
             <p class="lang ja active">歩数、動き、アクティビティをダッシュボードで表示します。</p>
             <div class="dx-example-tags"><span>Dashboard</span><span>Activity</span></div>
-            <div class="dx-example-links"><a href="./examples/AIRWALKER/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/AIRWALKER" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/AIRWALKER/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/AIRWALKER" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/pose.png" alt="Pose with ORPHE CORE">
+          <img src="../examples/_thumbnails/pose.png" alt="Pose with ORPHE CORE">
           <div class="dx-example-card-body">
             <h4>POSE</h4>
             <p class="lang en">Combine MediaPipe Pose with ORPHE CORE sensor data.</p>
             <p class="lang ja active">MediaPipe PoseとORPHE COREのセンサーデータを組み合わせます。</p>
             <div class="dx-example-tags"><span>Pose</span><span>Creative</span></div>
-            <div class="dx-example-links"><a href="./examples/POSE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/POSE" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/POSE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/POSE" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/oh1.png" alt="OH1 Heart Rate">
+          <img src="../examples/_thumbnails/oh1.png" alt="OH1 Heart Rate">
           <div class="dx-example-card-body">
             <h4>OH1</h4>
             <p class="lang en">Connect OH1 heart rate data with ORPHE CORE motion data.</p>
             <p class="lang ja active">OH1の心拍データとORPHE COREのモーションデータを連携します。</p>
             <div class="dx-example-tags"><span>BLE</span><span>Heart rate</span></div>
-            <div class="dx-example-links"><a href="./examples/OH1/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/OH1" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/OH1/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/OH1" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/coretoolkit-starter.png" alt="CoreToolkit Starter">
+          <img src="../examples/_thumbnails/coretoolkit-starter.png" alt="CoreToolkit Starter">
           <div class="dx-example-card-body">
             <h4>CORETOOLKIT STARTER</h4>
             <p class="lang en">Start faster with CoreToolkit.js connection UI and sensor monitor.</p>
             <p class="lang ja active">CoreToolkit.jsの接続UIとセンサーモニターからすばやく始めます。</p>
             <div class="dx-example-tags"><span>CoreToolkit</span><span>UI</span></div>
-            <div class="dx-example-links"><a href="./examples/CORETOOLKIT-STARTER/" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/5nV83PG1A" target="_blank">p5.js</a></div>
+            <div class="dx-example-links"><a href="../examples/CORETOOLKIT-STARTER/" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/5nV83PG1A" target="_blank">p5.js</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/sensor-calibration.png" alt="Sensor Calibration">
+          <img src="../examples/_thumbnails/sensor-calibration.png" alt="Sensor Calibration">
           <div class="dx-example-card-body">
             <h4>SENSOR CALIBRATION</h4>
             <p class="lang en">Record sensor data for gesture recognition and AI training.</p>
             <p class="lang ja active">ジェスチャー認識やAI学習用にセンサーデータを記録します。</p>
             <div class="dx-example-tags"><span>Recording</span><span>AI</span></div>
-            <div class="dx-example-links"><a href="./examples/SENSOR-CALIBRATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/SENSOR-CALIBRATION" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/SENSOR-CALIBRATION/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/SENSOR-CALIBRATION" target="_blank">Source</a></div>
           </div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/gesture-demo.png" alt="Gesture Demo">
+          <img src="../examples/_thumbnails/gesture-demo.png" alt="Gesture Demo">
           <div class="dx-example-card-body">
             <h4>GESTURE DEMO</h4>
             <p class="lang en">Detect toe tap, heel tap, and stomp gestures in real time.</p>
             <p class="lang ja active">つま先タップ、かかとタップ、踏み込みをリアルタイムに検出します。</p>
             <div class="dx-example-tags"><span>Gesture</span><span>Sound</span></div>
-            <div class="dx-example-links"><a href="./examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
           </div>
         </article>
       </div>
@@ -843,40 +843,40 @@
       <p class="lang ja active">Starter Templatesは、1つのデータ型や通知モードを小さく試すための最小サンプルです。</p>
       <div class="dx-example-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-light.png" alt="LED Starter">
-          <div class="dx-example-card-body"><h4>LIGHT</h4><p>LED control.</p><div class="dx-example-tags"><span>LED</span></div><div class="dx-example-links"><a href="./starter-templates/LIGHT.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/LIGHT.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/X7O5PU87S" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-light.png" alt="LED Starter">
+          <div class="dx-example-card-body"><h4>LIGHT</h4><p>LED control.</p><div class="dx-example-tags"><span>LED</span></div><div class="dx-example-links"><a href="../starter-templates/LIGHT.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/LIGHT.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/X7O5PU87S" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-accelerometer.png" alt="Accelerometer Starter">
-          <div class="dx-example-card-body"><h4>ACCELEROMETER</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Acc</span></div><div class="dx-example-links"><a href="./starter-templates/ACCELEROMETER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/ACCELEROMETER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WqUWEul5N" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-accelerometer.png" alt="Accelerometer Starter">
+          <div class="dx-example-card-body"><h4>ACCELEROMETER</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Acc</span></div><div class="dx-example-links"><a href="../starter-templates/ACCELEROMETER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/ACCELEROMETER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WqUWEul5N" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-gyro.png" alt="Gyro Starter">
-          <div class="dx-example-card-body"><h4>GYRO</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Gyro</span></div><div class="dx-example-links"><a href="./starter-templates/GYRO.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/GYRO.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/LvUXsj0WT" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-gyro.png" alt="Gyro Starter">
+          <div class="dx-example-card-body"><h4>GYRO</h4><p>{x, y, z}</p><div class="dx-example-tags"><span>Gyro</span></div><div class="dx-example-links"><a href="../starter-templates/GYRO.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/GYRO.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/LvUXsj0WT" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-quaternion.png" alt="Quaternion Starter">
-          <div class="dx-example-card-body"><h4>QUATERNION</h4><p>{w, x, y, z}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="./starter-templates/QUATERNION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/QUATERNION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/4modSEX2J" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-quaternion.png" alt="Quaternion Starter">
+          <div class="dx-example-card-body"><h4>QUATERNION</h4><p>{w, x, y, z}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="../starter-templates/QUATERNION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/QUATERNION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/4modSEX2J" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-euler.png" alt="Euler Starter">
-          <div class="dx-example-card-body"><h4>EULER</h4><p>{pitch, roll, yaw}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="./starter-templates/EULER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/EULER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WiTZ23rw2" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-euler.png" alt="Euler Starter">
+          <div class="dx-example-card-body"><h4>EULER</h4><p>{pitch, roll, yaw}</p><div class="dx-example-tags"><span>Orientation</span></div><div class="dx-example-links"><a href="../starter-templates/EULER.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/EULER.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/WiTZ23rw2" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-steps.png" alt="Steps Starter">
-          <div class="dx-example-card-body"><h4>STEPS</h4><p>Number of steps.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/STEPS.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STEPS.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/fTR9Jj0kC" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-steps.png" alt="Steps Starter">
+          <div class="dx-example-card-body"><h4>STEPS</h4><p>Number of steps.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="../starter-templates/STEPS.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STEPS.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/fTR9Jj0kC" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-stride.png" alt="Stride Starter">
-          <div class="dx-example-card-body"><h4>STRIDE</h4><p>Stride data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/STRIDE.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STRIDE.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/PbW-apAGP" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-stride.png" alt="Stride Starter">
+          <div class="dx-example-card-body"><h4>STRIDE</h4><p>Stride data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="../starter-templates/STRIDE.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/STRIDE.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/PbW-apAGP" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-pronation.png" alt="Pronation Starter">
-          <div class="dx-example-card-body"><h4>PRONATION</h4><p>Pronation data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="./starter-templates/PRONATION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/PRONATION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/FAw49ZU7g" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-pronation.png" alt="Pronation Starter">
+          <div class="dx-example-card-body"><h4>PRONATION</h4><p>Pronation data.</p><div class="dx-example-tags"><span>Gait</span></div><div class="dx-example-links"><a href="../starter-templates/PRONATION.html" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/blob/main/starter-templates/PRONATION.html" target="_blank">Source</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/FAw49ZU7g" target="_blank">p5.js</a></div></div>
         </article>
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/starter-analysis-and-sensor-values.png" alt="Step Analysis and Sensor Values">
-          <div class="dx-example-card-body"><h4>STEP_ANALYSIS + SENSOR_VALUES</h4><p class="lang en">Start STEP_ANALYSIS_AND_SENSOR_VALUES notify.</p><p class="lang ja active">解析値と生センサー値を同時に受け取ります。</p><div class="dx-example-tags"><span>Gait</span><span>Sensor</span></div><div class="dx-example-links"><a href="./starter-templates/ANALYSIS_AND_RAW.html" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/1mNA7vd1g" target="_blank">p5.js</a></div></div>
+          <img src="../examples/_thumbnails/starter-analysis-and-sensor-values.png" alt="Step Analysis and Sensor Values">
+          <div class="dx-example-card-body"><h4>STEP_ANALYSIS + SENSOR_VALUES</h4><p class="lang en">Start STEP_ANALYSIS_AND_SENSOR_VALUES notify.</p><p class="lang ja active">解析値と生センサー値を同時に受け取ります。</p><div class="dx-example-tags"><span>Gait</span><span>Sensor</span></div><div class="dx-example-links"><a href="../starter-templates/ANALYSIS_AND_RAW.html" target="_blank">DEMO</a><a href="https://editor.p5js.org/tetsuakibaba/sketches/1mNA7vd1g" target="_blank">p5.js</a></div></div>
         </article>
       </div>
       <h4 class="dx-example-subhead">p5.js Recipes</h4>
@@ -895,10 +895,10 @@
       <p class="lang en">Sports examples that turn gait and foot motion into track, sprint, hurdle, and competition-style experiences.</p>
       <p class="lang ja active">歩行・走行・足の動きを使って、陸上競技や対戦型スポーツ体験を作るExampleです。</p>
       <div class="dx-example-card-grid">
-        <article class="dx-example-card"><img src="./examples/_thumbnails/hurdle-110m.png" alt="110m Hurdles"><div class="dx-example-card-body"><h4 class="lang en">110m Hurdles</h4><h4 class="lang ja active">110m ハードル走</h4><p class="lang en">A flagship Virtual Sports example powered by Gait Analysis and foot motion.</p><p class="lang ja active">Gait Analysisと足の動きで走る、Virtual Sportsの代表Exampleです。</p><div class="dx-example-tags"><span>Virtual Sports</span><span>2 COREs</span></div><div class="dx-example-links"><a href="./examples/GAME-HURDLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-HURDLE" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/hurdle-110m.png" alt="110m Hurdles"><div class="dx-example-card-body"><h4 class="lang en">110m Hurdles</h4><h4 class="lang ja active">110m ハードル走</h4><p class="lang en">A flagship Virtual Sports example powered by Gait Analysis and foot motion.</p><p class="lang ja active">Gait Analysisと足の動きで走る、Virtual Sportsの代表Exampleです。</p><div class="dx-example-tags"><span>Virtual Sports</span><span>2 COREs</span></div><div class="dx-example-links"><a href="../examples/GAME-HURDLE/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-HURDLE" target="_blank">Source</a></div></div></article>
       </div>
       <div class="dx-mini-link-grid">
-        <a class="dx-mini-link" href="./examples/?category=virtual-sports" target="_blank">Virtual Sports category</a>
+        <a class="dx-mini-link" href="../examples/?category=virtual-sports" target="_blank">Virtual Sports category</a>
       </div>
     </section>
 
@@ -907,12 +907,12 @@
       <p class="lang en">Play with graphics, sounds, and physical game mechanics using ORPHE CORE as an input device.</p>
       <p class="lang ja active">ORPHE COREを入力デバイスとして使い、グラフィック、サウンド、身体動作のゲームを作るExampleです。</p>
       <div class="dx-example-card-grid">
-        <article class="dx-example-card"><img src="./examples/_thumbnails/udon.png" alt="Udon game"><div class="dx-example-card-body"><h4>UDON</h4><p>足踏みでうどんをこねるゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-UDON/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-UDON" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/move-your-feet.png" alt="Move your feet"><div class="dx-example-card-body"><h4>MOVEYOURFEET</h4><p>足を動かして遊ぶエクササイズ系ゲーム。</p><div class="dx-example-links"><a href="./examples/MOVEYOURFEET/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/MOVEYOURFEET" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/pingpong.png" alt="Ping pong game"><div class="dx-example-card-body"><h4>PINGPONG GAME</h4><p>2人で遊べるシンプルな対戦ゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-PINGPONG/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-PINGPONG" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/drum.png" alt="Drum game"><div class="dx-example-card-body"><h4>ORPHE CORE Gesture Drum</h4><p>ジェスチャーで音を鳴らすドラムサンプラー。</p><div class="dx-example-links"><a href="./examples/drum_test/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/drum_test" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/boxing.png" alt="Boxing game"><div class="dx-example-card-body"><h4>BOXING GAME</h4><p>パンチ動作を使ったアクションゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-BOXING/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-BOXING" target="_blank">Source</a></div></div></article>
-        <article class="dx-example-card"><img src="./examples/_thumbnails/ddr.png" alt="DDR game"><div class="dx-example-card-body"><h4>DDR GAME</h4><p>音楽と足の動きを組み合わせたリズムゲーム。</p><div class="dx-example-links"><a href="./examples/GAME-DDR/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-DDR" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/udon.png" alt="Udon game"><div class="dx-example-card-body"><h4>UDON</h4><p>足踏みでうどんをこねるゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-UDON/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-UDON" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/move-your-feet.png" alt="Move your feet"><div class="dx-example-card-body"><h4>MOVEYOURFEET</h4><p>足を動かして遊ぶエクササイズ系ゲーム。</p><div class="dx-example-links"><a href="../examples/MOVEYOURFEET/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/MOVEYOURFEET" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/pingpong.png" alt="Ping pong game"><div class="dx-example-card-body"><h4>PINGPONG GAME</h4><p>2人で遊べるシンプルな対戦ゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-PINGPONG/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-PINGPONG" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/drum.png" alt="Drum game"><div class="dx-example-card-body"><h4>ORPHE CORE Gesture Drum</h4><p>ジェスチャーで音を鳴らすドラムサンプラー。</p><div class="dx-example-links"><a href="../examples/drum_test/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/drum_test" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/boxing.png" alt="Boxing game"><div class="dx-example-card-body"><h4>BOXING GAME</h4><p>パンチ動作を使ったアクションゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-BOXING/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-BOXING" target="_blank">Source</a></div></div></article>
+        <article class="dx-example-card"><img src="../examples/_thumbnails/ddr.png" alt="DDR game"><div class="dx-example-card-body"><h4>DDR GAME</h4><p>音楽と足の動きを組み合わせたリズムゲーム。</p><div class="dx-example-links"><a href="../examples/GAME-DDR/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GAME-DDR" target="_blank">Source</a></div></div></article>
       </div>
       <h4 class="dx-example-subhead">p5.js Sketches</h4>
       <div class="dx-mini-link-grid">
@@ -929,13 +929,13 @@
       <p class="lang ja active">ジェスチャー認識、時系列マッチング、周波数解析、データ可視化を試すためのExampleです。</p>
       <div class="dx-example-card-grid">
         <article class="dx-example-card">
-          <img src="./examples/_thumbnails/gesture-demo.png" alt="Gesture recognition">
+          <img src="../examples/_thumbnails/gesture-demo.png" alt="Gesture recognition">
           <div class="dx-example-card-body">
             <h4>GESTURE DEMO</h4>
             <p class="lang en">A practical starting point for real-time gesture detection.</p>
             <p class="lang ja active">リアルタイムのジェスチャー検出を試す実用的な起点です。</p>
             <div class="dx-example-tags"><span>Gesture</span><span>Detection</span></div>
-            <div class="dx-example-links"><a href="./examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
+            <div class="dx-example-links"><a href="../examples/GESTURE-DEMO/" target="_blank">DEMO</a><a href="https://github.com/Orphe-OSS/ORPHE-CORE.js/tree/main/examples/GESTURE-DEMO" target="_blank">Source</a></div>
           </div>
         </article>
       </div>
@@ -956,7 +956,7 @@
       <p class="lang ja active">
         以下はjsdocによって生成されたORPHEクラスのAPIリファレンスです。
       </p>
-      <li><a href="./api_doc/" target="_blank">API Reference for ORPHE-CORE.js</a></li>
+      <li><a href="../api_doc/" target="_blank">API Reference for ORPHE-CORE.js</a></li>
     </section>
 
 
@@ -970,10 +970,10 @@
   </div>
 
 
-  <script src="./js/bootstrap.bundle.min.js"
+  <script src="../js/bootstrap.bundle.min.js"
     integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2"
     crossorigin="anonymous"></script>
-  <script src="./js/run_prettify.js?skin=sunburst"></script>
+  <script src="../js/run_prettify.js?skin=sunburst"></script>
 
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://orphe-oss.github.io/ORPHE-CORE.js/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://orphe-oss.github.io/ORPHE-CORE.js/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://orphe-oss.github.io/ORPHE-CORE.js/en/" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://orphe-oss.github.io/ORPHE-CORE.js/ja/" />
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/en/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://orphe-oss.github.io/ORPHE-CORE.js/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://orphe-oss.github.io/ORPHE-CORE.js/en/" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://orphe-oss.github.io/ORPHE-CORE.js/ja/" />
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/ja/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://orphe-oss.github.io/ORPHE-CORE.js/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://orphe-oss.github.io/ORPHE-CORE.js/en/" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://orphe-oss.github.io/ORPHE-CORE.js/ja/" />
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/examples/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/docs/getting-started-p5.html</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/docs/getting-started-vscode.html</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/docs/getting-started-coretoolkit.html</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/api_doc/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/examples/GAME-HURDLE/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/examples/GAME-SPRINT-100M-VS/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://orphe-oss.github.io/ORPHE-CORE.js/examples/GAME-HURDLE-400M-VS/</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- トップページにSEO向けのtitle / meta description / canonical / hreflang / OGP / Twitter cardを追加
- トップページにSoftwareSourceCodeのJSON-LDを追加
- 既存URL `/ORPHE-CORE.js/` はx-defaultとして維持しつつ、SEO用に `/en/` と `/ja/` の言語別入口を追加
- `sitemap.xml` と `robots.txt` を追加
- Examplesページにtitle / description / canonical / OGP / Twitter cardを追加
- Examplesページの実行時titleもSEO向けに更新

## Compatibility
- 既存のトップURLはそのまま残し、ブラウザ言語 / localStorage による初期表示も維持しています。
- `/en/` と `/ja/` は同じLP内容を言語固定で開く入口です。

## Validation
- `git diff --check`
- `node scripts/check-examples-catalog.js`
- `node scripts/check-examples-static-quality.js`
- JSON-LD parse check for `/`, `/en/`, `/ja/`
- `sitemap.xml` XML parse check
- local href/src existence check for `index.html`, `en/index.html`, `ja/index.html`, `examples/index.html`
- local server 200 OK: `/`, `/en/`, `/ja/`, `/examples/`, `/sitemap.xml`, `/robots.txt`
- in-app browser smoke check: `/`, `/en/`, `/ja/`, `/examples/` loaded without page errors
