### PR TITLE
docs(ai): ORPHE-INSOLE.js 移植・改修プランと適用可能なステージング一式

### DIFF
--- a/docs/ai/insole-migration-plan.md
+++ b/docs/ai/insole-migration-plan.md
@@ -1,0 +1,132 @@
+# ORPHE-INSOLE.js 移植・改修プラン（確定版）
+
+- 作成日: 2026-06-10
+- 対象: [ORPHE-INSOLE.js](https://github.com/Orphe-OSS/ORPHE-INSOLE.js)（v1.0.0 beta, src 1455行）
+- 参照: [ORPHE-CORE.js](https://github.com/Orphe-OSS/ORPHE-CORE.js)（v1.3.4 stable, 1924行）
+- ステージング実装: `docs/ai/insole-migration/staging/`（INSOLE リポジトリへコピー可能な状態）
+
+## ゴール
+
+**ORPHE INSOLE.js のページで安定してインソールを接続し、いろいろな計測・可視化・可聴化ができる状態にする。**
+
+## 確定した意思決定
+
+| # | 論点 | 決定 |
+|---|---|---|
+| 1 | STEP_ANALYSIS | **FW対応を待つ。** まずは生データ（SENSOR_VALUES）ストリーミングでできることに集中。SDKのgait系コールバックは「FW対応待ち」と明記して温存 |
+| 2 | クラス名 | **`OrpheInsole` を正式名、`Orphe` は後方互換エイリアス**（詳細は下記） |
+| 3 | CoreToolkit | **INSOLE 専用 slim 版 `InsoleToolkit.js` を新規作成**（Phase 2 案A）。`buildCoreToolkit` 互換ラッパーを残す |
+| 4 | Examples | **まず VISUALIZE のみ移植。** 他はあとで増やす |
+| 5 | プラン保管場所 | **本リポジトリ `docs/ai/insole-migration-plan.md`**（INSOLE 側にPRを切る際に staging ごと持っていく） |
+
+### 決定2の根拠（クラス名）
+
+CORE と INSOLE を今後もずっと並走させる前提では、**同名クラス `Orphe` の二重定義は致命的**:
+
+- 両SDKとも classic script のトップレベルで `class Orphe` に加え `class FixedSizeArray`・`class OrpheTimestamp` を宣言しており、同一ページに両方読み込むと `SyntaxError: Identifier ... has already been declared` で**後から読み込んだ側のスクリプト全体が死ぬ**（vm 検証で確認済み）。CORE+INSOLE 併用アプリ（例: 足背CORE＋インソールのハイブリッド計測）が原理的に作れない。
+- INSOLE は beta でユーザが少ない今が rename の最後のチャンス。
+
+採用した設計（staging 実装済み）:
+
+```javascript
+(function (global) {            // ライブラリ本体をIIFEで包み、レキシカル束縛の衝突自体を排除
+  class FixedSizeArray { ... }
+  class OrpheTimestamp { ... }
+  class OrpheInsole { ... }     // 正式クラス名
+  global.OrpheInsole = global.OrpheInsole || OrpheInsole;
+  // CORE が同一ページに居ない場合のみ Orphe エイリアスを公開
+  if (typeof Orphe === 'undefined' && typeof global.Orphe === 'undefined') {
+    global.Orphe = OrpheInsole;
+  }
+})(globalThis);
+```
+
+- INSOLE 単独ページ: 既存コード `new Orphe(0)` はそのまま動く（後方互換）
+- CORE 併用ページ: 読み込み順に関わらず `Orphe`=CORE、`OrpheInsole`=INSOLE と決定的に解決（CORE のレキシカル束縛がグローバルプロパティを常にシャドウするため）
+- 上記3パターンすべて `tests/insole-coexistence.test.js` で回帰テスト化済み
+- 将来 CORE 側にも `OrpheCore` エイリアスを追加し、ドキュメントは段階的に `OrpheInsole`/`OrpheCore` 表記へ移行することを推奨
+
+## 両SDKの差分サマリ（調査結果）
+
+| 観点 | ORPHE-CORE.js v1.3.4 | ORPHE-INSOLE.js v1.0.0 beta |
+|---|---|---|
+| 圧力(FSR) | なし | **6ch `gotPress`**（mode 3=200Hz / mode 4=100Hz） |
+| STEP_ANALYSIS | 完全実装 | コールバック宣言のみ・未配線（FW未対応） |
+| LED / Mount書込 | あり | なし（ハードに存在しない） |
+| データ設定 | `begin(type,{range})` | `setDataStreamingMode(1/3/4)`（0x0D write） |
+| パケット | header 50 (92byte) | header 50/55/56 (104byte)、パーサは関数分離済みでテスト可能 |
+| 接続安定化 | デバイス記憶・自動再接続・BleSharedBridge | **なし** ← 今回の移植対象 |
+| Toolkit | CoreToolkit 512行 | CORE版の流用388行（LED等の無効UIが残存） |
+| Examples | 30+ | 3（dashboard / terminal / hula-motion-sonifier） |
+| 配布 | js/ 直読み | src/ + dist/（terser, jsDelivr） |
+| テスト | なし | node 単体テストあり（`npm test`） |
+| 隠れ依存 | — | float16/quaternion を **CORE リポの CDN から実行時ロード** |
+
+## フェーズ計画と進捗
+
+### Phase 1: SDK 安定化 — ✅ staging 実装済み
+
+`staging/src/ORPHE-INSOLE.js`（v1.1.0 相当）。CORE.js から以下を移植:
+
+1. **デバイス記憶 + ダイアログレス再接続**: 接続成功時に localStorage へデバイス情報を記憶（キーは `orphe_insole_last_bluetooth_device_{id}` で CORE と非衝突）。次回 `begin()` 時に `navigator.bluetooth.getDevices()` で選択ダイアログなしの再接続。デバイス喪失時は自動でダイアログにフォールバック。`selectBluetoothDevice()` / `forgetLastBluetoothDevice()` も移植。
+2. **自動再接続**: `begin('SENSOR_VALUES', {autoReconnect: true})`。切断検知→最大120回・3秒間隔（設定可）で再接続。`onReconnectAttempt/Success/Failed` コールバック。再接続中の `onError` 連発は `_reportError` で抑制。
+3. **品質改善**: `gattserverdisconnected` リスナーを遅延バインド化（リスナー登録後の `onDisconnect` 上書きが効かないバグの修正）、`setDeviceInformation` の `alert()` を `console.warn`+`onError` に変更、`console.info` ノイズを `insole.debug` フラグでゲート、`reset()` 時に autoReconnect も解除。
+4. **クラス名整理**: 上記の決定2。Node エクスポート（`module.exports`）は従来どおり `Orphe`/`OrpheInsole` 両方を維持し**既存テストはそのままパス**。
+
+検証済み（INSOLE リポジトリの実テスト一式を staged ソースで実行）:
+- `node --check`: src 2本 + 既存 examples（terminal / hula-motion-sonifier）すべてパス
+- 既存テスト: `insole-parser.test.js` / `hula-detector.test.js` パス
+- 新規テスト: `insole-stability.test.js`（エイリアス・デバイスマッチング・再接続設定・streaming mode バリデーション）、`insole-coexistence.test.js`（CORE↔INSOLE 両順序の共存 + 単独後方互換）パス
+
+**やらなかったこと（意図的）**: BleSharedBridge（複数タブ共有）は CORE 固有の運用要件が強く、INSOLE では必要になってから移植する。interpolation の実装は CORE 側も未実装のため見送り。`gotConvertedPress` は kgf 換算式が未確定のため API を作らない（キャリブレーションパターンを PRESSURE_RECIPES.md で提供）。
+
+### Phase 2: InsoleToolkit（slim版） — ✅ staging 実装済み
+
+`staging/src/InsoleToolkit.js`（CORE 版から新規書き起こし）:
+
+- 削除: LEDトグル、LED輝度、L/R書込、notification選択（STEP_ANALYSIS系）、acc/gyroレンジ書込（INSOLE は setDeviceInformation 未対応のため読み取り専用表示に変更）
+- 追加: **データストリーミングモード選択（1/3/4）**、**L/Rバッジ**（mount_position bit0 から自動判定・色分け）、**自動再接続ステータス表示**（試行回数）、mount_position 詳細表示
+- グローバルは `insoles[]` を正とし、`bles`/`cores` エイリアスで CORE 系コードの移植を容易化
+- `buildCoreToolkit()` 互換ラッパーを残置（notification 引数は警告つきで無視）
+- toolkit が上書きする `gotBLEFrequency` 等はユーザコールバックとチェーン実行（CORE 版は上書きで衝突していた）
+
+### Phase 3: Examples — ✅ VISUALIZE 移植済み（決定4によりまずこれのみ）
+
+`staging/examples/VISUALIZE/`:
+
+- CORE 版 VISUALIZE をベースに、圧力6chチャートを追加（計5チャート×2台）
+- 接続UIを InsoleToolkit に置換（自動再接続つき）
+- **rAF スロットリング**を導入: 100Hz×複数チャートの `chart.update()` 連打はタブを固まらせるため、受信はバッファ、描画は約30fps。今後のINSOLE向けサンプルの標準パターンとする
+- `lostData` でパケット欠損を console 警告
+
+### Phase 4: ドキュメント — ✅ staging 実装済み
+
+- `staging/CLAUDE.md`: INSOLE リポジトリ用 AI 開発ガイド（CORE の CLAUDE.md と同形式）。ストリーミングモード選択ガイド、全コールバックリファレンス、接地検出/バランス/CoP/可聴化/描画スロットリングの5パターン、アンチパターン集
+- `staging/docs-ai/PRESSURE_RECIPES.md`: 圧力6chの処理レシピ集（キャリブレーション、ヒステリシス接地検出、ケイデンス/エアタイム、前後内外バランス、CoP、ピーク/インパルス、可聴化3種、データ記録）
+
+### Phase 5: INSOLE リポジトリへの適用（次のアクション・未実施）
+
+このリポジトリの GitHub 連携は orphe-core.js に限定されているため、INSOLE 側への反映は手動またはローカルで行う:
+
+1. `docs/ai/insole-migration/staging/` の内容を ORPHE-INSOLE.js リポジトリへコピー（手順は `docs/ai/insole-migration/README.md`）
+2. `npm test` → `npm run build` → `npm run generate-docs`
+3. 既存 examples（sensor-dashboard / terminal / hula-motion-sonifier）の動作確認（`Orphe` エイリアスで動くはず。順次 `OrpheInsole` 表記へ）
+4. README に InsoleToolkit / autoReconnect / VISUALIZE を追記
+5. v1.1.0 としてリリース（jsDelivr の参照は `@latest` でなく `@1` 系タグ推奨）
+
+### Phase 6: 中期ロードマップ（未実施・優先順）
+
+1. **float16/quaternion の同梱**: 現状 CORE リポの CDN から実行時ロードしており、CORE 側の変更で INSOLE が壊れる。`src/vendor/` に同梱して切る
+2. **実機での安定性検証**: autoReconnect の実機テスト（電源断・距離・スリープ復帰の3シナリオ）
+3. **examples 増設**（PRESSURE_RECIPES.md のレシピをそのまま製品化）: PRESS-HEATMAP（足型ヒートマップ）→ BALANCE(2台) → SONIFY-PRESSURE → JUMP-AIR-TIME
+4. **starter-templates**: PRESS / ACCELEROMETER / QUATERNION / STREAMING_MODE の4本から
+5. **STEP_ANALYSIS**: FW対応がリリースされたら CORE のパーサ（`ORPHE-CORE.js` l.1330-1495 相当）を移植。それまでに圧力ベースの接地検出（レシピ2）で代替できるよう examples を整備
+6. **CORE 側に `OrpheCore` エイリアス追加**: 命名の対称性を完成させる（CORE リポ側の小PR）
+7. **共通コア抽出（モノレポ化）の検討**: BLE接続・デバイス記憶・自動再接続・時刻同期は今回の移植で両SDKがほぼ同型になったので、抽出コストが下がっている
+
+## リスク・未確定事項
+
+1. **DEVICE_INFORMATION のバイトレイアウト**: INSOLE の `getDeviceInformation` は offset 8,9 を range として読むが、ハード仕様書との照合が未実施。実機確認推奨
+2. **圧力の物理量換算**: ADC生値→kgf の変換式が未公開。`gotConvertedPress` API はそれまで作らない
+3. **`navigator.bluetooth.getDevices()` の可用性**: 環境によっては無効。無効時は従来どおり選択ダイアログにフォールバックする実装にしてある
+4. **mode 3（200Hz）の実効スループット**: BLE接続パラメータ次第で欠損が増える可能性。`lostData` の発生率を VISUALIZE で観察できる

--- a/docs/ai/insole-migration/README.md
+++ b/docs/ai/insole-migration/README.md
@@ -1,0 +1,54 @@
+# INSOLE Migration Staging
+
+`staging/` 配下は [ORPHE-INSOLE.js](https://github.com/Orphe-OSS/ORPHE-INSOLE.js) リポジトリへ
+そのままコピーできる形で作成した移植・改修ファイル一式です。
+背景と設計判断は [`../insole-migration-plan.md`](../insole-migration-plan.md) を参照してください。
+
+## staging の内容
+
+| staging 内パス | INSOLE リポジトリでの配置先 | 内容 |
+|---|---|---|
+| `src/ORPHE-INSOLE.js` | `src/ORPHE-INSOLE.js`（置換） | SDK v1.1.0: デバイス記憶・自動再接続・クラス名 `OrpheInsole` 化（`Orphe` エイリアス維持） |
+| `src/InsoleToolkit.js` | `src/InsoleToolkit.js`（新規） | slim 接続UIツールキット。`src/CoreToolkit.js` は削除候補（互換ラッパー内蔵のため） |
+| `examples/VISUALIZE/` | `examples/VISUALIZE/`（新規） | 圧力6ch+IMU可視化（CORE 版 VISUALIZE の移植） |
+| `tests/insole-stability.test.js` | `tests/`（新規） | 安定化機能の単体テスト |
+| `tests/insole-coexistence.test.js` | `tests/`（新規） | CORE.js 併用時の識別子衝突の回帰テスト |
+| `CLAUDE.md` | リポジトリ直下（新規） | AI 開発ガイド |
+| `docs-ai/PRESSURE_RECIPES.md` | `docs/ai/PRESSURE_RECIPES.md`（新規） | 圧力データ処理レシピ集 |
+
+## 適用手順
+
+```bash
+git clone https://github.com/Orphe-OSS/ORPHE-INSOLE.js
+cd ORPHE-INSOLE.js
+git checkout -b feature/stability-and-toolkit
+
+# 本リポジトリの staging からコピー
+STAGING=/path/to/ORPHE-CORE.js/docs/ai/insole-migration/staging
+cp  $STAGING/src/ORPHE-INSOLE.js        src/
+cp  $STAGING/src/InsoleToolkit.js       src/
+cp -r $STAGING/examples/VISUALIZE       examples/
+cp  $STAGING/tests/insole-stability.test.js tests/
+cp  $STAGING/CLAUDE.md                  ./
+mkdir -p docs/ai && cp $STAGING/docs-ai/PRESSURE_RECIPES.md docs/ai/
+
+# package.json の test スクリプトに追記:
+#   && node --check src/InsoleToolkit.js
+#   && node tests/insole-stability.test.js
+#   && node tests/insole-coexistence.test.js
+# 検証とビルド
+npm install
+npm test
+npm run build
+npm run generate-docs
+```
+
+## 適用後の確認チェックリスト
+
+- [ ] `npm test` 全パス（既存の insole-parser / hula-detector を含む）
+- [ ] `examples/terminal` が従来どおり動作（`Orphe` エイリアス経由）
+- [ ] `examples/sensor-dashboard` が従来どおり動作
+- [ ] `examples/VISUALIZE` で 2台接続・5チャート描画・モード切替
+- [ ] 電源OFF→ONで autoReconnect が復帰する（実機）
+- [ ] ページ再読み込み時に選択ダイアログなしで再接続（chrome://flags 依存環境ではフォールバック動作）
+- [ ] CORE.js と同一ページで読み込んでも SyntaxError にならず、`OrpheInsole` で利用できる

--- a/docs/ai/insole-migration/staging/CLAUDE.md
+++ b/docs/ai/insole-migration/staging/CLAUDE.md
@@ -1,0 +1,407 @@
+# ORPHE-INSOLE.js - AI Development Guide
+
+ORPHE INSOLEは6チャネル圧力センサ＋IMU（加速度・ジャイロ・クォータニオン）を内蔵したインソール型IoTセンサーです。このガイドは生成AIがORPHE INSOLEを使ったアプリケーションを正確に生成するための包括的なリファレンスです。
+
+## ORPHE CORE との関係
+
+ORPHE-INSOLE.js は [ORPHE-CORE.js](https://github.com/Orphe-OSS/ORPHE-CORE.js) と互換性のあるAPI設計（`got*` コールバック、id 0/1 の2デバイスモデル、同一BLE UUID）を持ちますが、別ハードウェア・別SDKです。
+
+| 観点 | ORPHE CORE | ORPHE INSOLE |
+|---|---|---|
+| クラス名 | `Orphe` | `OrpheInsole`（`Orphe` エイリアスあり※） |
+| 圧力センサ | なし | **6ch (`gotPress`)** |
+| STEP_ANALYSIS (gait/stride/pronation) | あり | **なし（FW対応待ち）** |
+| LED制御 | `setLED()` | なし |
+| データ設定 | `begin(type, {range})` | `setDataStreamingMode(1/3/4)` |
+| Notification | STEP_ANALYSIS / SENSOR_VALUES / 両方 | SENSOR_VALUES のみ |
+
+※ 同一ページに ORPHE-CORE.js が読み込まれていない場合のみ `Orphe` が INSOLE を指します。CORE と併用するページでは必ず `OrpheInsole` を使ってください。
+
+**重要: `gait.direction` や `gotStride` 等を使うコードはINSOLEでは動きません。** 歩行イベントが必要な場合は圧力センサから自前で導出します（後述のパターン参照）。
+
+## Project Overview
+
+```
+ORPHE-INSOLE.js/
+├── src/
+│   ├── ORPHE-INSOLE.js        # Main SDK
+│   └── InsoleToolkit.js       # Connection UI toolkit
+├── dist/
+│   ├── orphe-insole.js        # ビルド済み（未圧縮）
+│   └── orphe-insole.min.js    # ビルド済み（CDN配信対象）
+├── examples/
+│   ├── VISUALIZE/             # センサ可視化（推奨スターター）
+│   ├── sensor-dashboard/      # 2台同時ダッシュボード
+│   ├── hula-motion-sonifier/  # 動作の可聴化（Web Audio）
+│   └── terminal/              # 生データデバッグ
+├── tests/                     # node 単体テスト（npm test）
+└── docs/                      # JSDoc
+```
+
+## Quick Start
+
+### Pattern A: 最小構成（テスト用）
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="src/ORPHE-INSOLE.js"></script>
+</head>
+<body>
+  <button onclick="insole.begin('SENSOR_VALUES')">Connect</button>
+  <div id="output"></div>
+
+  <script>
+    var insole = new OrpheInsole(0);
+    insole.setup();
+
+    insole.gotPress = function(press) {
+      // press.values は 6ch の ADC 生値
+      document.getElementById('output').textContent = press.values.join(', ');
+    };
+  </script>
+</body>
+</html>
+```
+
+### Pattern B: InsoleToolkit使用（推奨）
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <script src="../../src/ORPHE-INSOLE.js"></script>
+  <script src="../../src/InsoleToolkit.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+  <div id="toolkit_placeholder"></div>
+
+  <script>
+    // InsoleToolkit generates insoles[0] and insoles[1] globally
+    buildInsoleToolkit(
+      document.getElementById('toolkit_placeholder'),
+      'ORPHE INSOLE',
+      0,                                        // device ID (0 or 1)
+      { streamingMode: 4, autoReconnect: true } // options
+    );
+
+    window.onload = function() {
+      insoles[0].setup();
+
+      insoles[0].gotPress = function(press) {
+        console.log('Pressure:', press.values);
+      };
+      insoles[0].gotConvertedAcc = function(acc) {
+        console.log('Acceleration [G]:', acc);
+      };
+    };
+  </script>
+</body>
+</html>
+```
+
+## Data Streaming Modes - 最も重要な設計判断
+
+`begin()` のオプション、または `setDataStreamingMode(mode)` で選択します。
+
+| Mode | Data | Frequency | Use Case |
+|---|---|---|---|
+| `1` | quat + gyro + acc | 200Hz | 姿勢のみ高速取得（CORE互換） |
+| `3` | gyro + acc + **press** | 200Hz | 圧力＋IMUの高速取得（クォータニオン不要時） |
+| `4` | gyro + acc + **press** + quat | 100Hz | **全データ。デフォルト。迷ったらこれ** |
+
+```
+What does your app need?
+
+├── 圧力 + 姿勢（quat/euler）も使う
+│   └── Mode 4 (default)
+├── 圧力のイベント検出を最高レートで（着地検出・リズム系）
+│   └── Mode 3 (200Hz, quatなし → gotEulerも来ない)
+└── 姿勢のみ・圧力不要
+    └── Mode 1 (200Hz)
+```
+
+## API Reference
+
+### OrpheInsole Class
+
+```javascript
+// Constructor
+var insole = new OrpheInsole(id);  // id: 0 or 1 (supports 2 devices max)
+
+// Initialization (MUST call before begin)
+insole.setup();
+
+// Start connection and data streaming
+await insole.begin('SENSOR_VALUES', {
+  streamingMode: 4,        // 1 | 3 | 4
+  autoReconnect: true,     // 切断時に自動再接続
+  reconnectIntervalMs: 3000,
+  reconnectMaxAttempts: 120
+});
+
+// Stop / reset（マニュアル切断。autoReconnectも解除される）
+insole.stop();
+insole.reset();
+
+// Streaming mode change while connected
+await insole.setDataStreamingMode(3);
+
+// Device info
+await insole.getDeviceInformation();
+// Returns: { battery: 0-2, mount_position, range: { acc, gyro } }
+// mount_position bit0: 0=LEFT, 1=RIGHT / bit1: 0=足底, 1=足背
+
+// デバイス選択ダイアログを強制表示（別のINSOLEに切り替えたいとき）
+insole.selectBluetoothDevice();
+insole.forgetLastBluetoothDevice();
+
+// Analysis log reset
+insole.resetAnalysisLogs();
+
+// デバッグログ（接続トラブル調査時）
+insole.debug = true;
+```
+
+### Data Callbacks - Override these to receive data
+
+```javascript
+// === 圧力（INSOLE固有・最重要） ===
+insole.gotPress = function(press) {
+  // press: {
+  //   values: [p0, p1, p2, p3, p4, p5],  // 6ch ADC生値 (uint16)
+  //   timestamp, serial_number, packet_number
+  // }
+  // 注意: チャネルの物理配置はモデルによって異なる場合があるため、
+  // 配置依存のロジックにはチャネルリマップ層を挟むこと
+};
+
+// === IMU（CORE互換） ===
+insole.gotAcc = function(acc) { };           // {x,y,z} normalized -1..1
+insole.gotConvertedAcc = function(acc) { };  // {x,y,z} 実値[G]
+insole.gotGyro = function(gyro) { };         // {x,y,z} normalized -1..1
+insole.gotConvertedGyro = function(gyro) { };// {x,y,z} 実値[deg/s]
+insole.gotQuat = function(quat) { };         // {w,x,y,z} (mode 1, 4のみ)
+insole.gotEuler = function(euler) { };       // {pitch,roll,yaw} [rad] (mode 1, 4のみ)
+
+// === Advertisement（接続前のステータス監視） ===
+insole.gotStatus = function(status) {
+  // { name, rssi, txPower, id, battery, model_type,
+  //   mounting_position, human_activity_recognition, version }
+};
+
+// === Connection / quality events ===
+insole.onConnect = function(uuid) { };
+insole.onDisconnect = function() { };
+insole.onError = function(error) { };
+insole.gotBLEFrequency = function(frequency) { }; // 実測Hz
+insole.lostData = function(serial, prevSerial) { }; // パケット欠損
+
+// === Auto reconnect events ===
+insole.onReconnectAttempt = function(info) { }; // {attempt, maxAttempts, intervalMs}
+insole.onReconnectSuccess = function(info) { }; // {attempt, elapsedMs}
+insole.onReconnectFailed  = function(info) { }; // {maxAttempts, error}
+```
+
+### InsoleToolkit.js
+
+```javascript
+buildInsoleToolkit(
+  parent_element,   // DOM element to append UI
+  title,            // 表示タイトル (e.g., 'Left Foot')
+  insole_id,        // 0 or 1
+  options           // { streamingMode: 4, autoReconnect: true }
+);
+
+// Global variables created by InsoleToolkit:
+// var insoles = [new OrpheInsole(0), new OrpheInsole(1)];
+// var bles = insoles;   // CORE互換エイリアス
+// var cores = insoles;  // CORE互換エイリアス
+```
+
+接続後、ツールキットのヘッダには 実測周波数 / L・Rバッジ（mount_position から自動判定）/ バッテリー / 再接続ステータス / 設定（ストリーミングモード変更）が表示されます。
+
+## Common Patterns
+
+### Pattern 1: 接地検出（圧力合計＋ヒステリシス）
+
+```javascript
+const CONTACT_ON = 800;   // 接地判定しきい値（要キャリブレーション）
+const CONTACT_OFF = 400;  // 離地判定しきい値（ヒステリシス）
+let isContact = false;
+
+insole.gotPress = function(press) {
+  const total = press.values.reduce((a, b) => a + b, 0);
+
+  if (!isContact && total > CONTACT_ON) {
+    isContact = true;
+    onFootDown(press.timestamp);   // 着地イベント
+  } else if (isContact && total < CONTACT_OFF) {
+    isContact = false;
+    onFootUp(press.timestamp);     // 離地イベント
+  }
+};
+```
+
+### Pattern 2: 左右荷重バランス（2台接続）
+
+```javascript
+const totals = [0, 0];
+for (let i = 0; i < 2; i++) {
+  buildInsoleToolkit(document.getElementById(`toolkit${i}`), `INSOLE ${i}`, i);
+}
+window.onload = function() {
+  for (let i = 0; i < 2; i++) {
+    insoles[i].setup();
+    insoles[i].gotPress = function(press) {
+      totals[this.id] = press.values.reduce((a, b) => a + b, 0);
+      const balance = totals[0] / (totals[0] + totals[1] + 1e-6); // 0..1
+      updateBalanceUI(balance);
+    };
+  }
+};
+// 注意: insoles[0]が左足とは限らない。device_information.mount_position の
+// bit0 (0=LEFT, 1=RIGHT) で実際の左右を判定して表示にマップすること。
+```
+
+### Pattern 3: 圧力中心（CoP）の推定
+
+```javascript
+// SENSOR_POSITIONS はモデルの物理配置に合わせて調整（単位は任意の足座標系）
+const SENSOR_POSITIONS = [
+  { x: -1, y:  2 }, { x: 1, y:  2 },   // 前足部
+  { x: -1, y:  0 }, { x: 1, y:  0 },   // 中足部
+  { x: -1, y: -2 }, { x: 1, y: -2 },   // 踵部
+];
+
+insole.gotPress = function(press) {
+  const total = press.values.reduce((a, b) => a + b, 0);
+  if (total < 100) return; // 接地していない
+  let cx = 0, cy = 0;
+  press.values.forEach((v, i) => {
+    cx += SENSOR_POSITIONS[i].x * v;
+    cy += SENSOR_POSITIONS[i].y * v;
+  });
+  drawCoP(cx / total, cy / total);
+};
+```
+
+### Pattern 4: 可聴化（Web Audio）
+
+```javascript
+const ctx = new AudioContext();
+const osc = ctx.createOscillator();
+const gain = ctx.createGain();
+gain.gain.value = 0;
+osc.connect(gain).connect(ctx.destination);
+osc.start();
+// ユーザー操作（クリック等）の中で ctx.resume() を呼ぶこと
+
+insole.gotPress = function(press) {
+  const total = press.values.reduce((a, b) => a + b, 0);
+  const norm = Math.min(1, total / 6000);  // 要キャリブレーション
+  // 荷重→音量、前後バランス→ピッチ
+  const front = press.values[0] + press.values[1];
+  const heel = press.values[4] + press.values[5];
+  const fb = front / (front + heel + 1e-6);
+  gain.gain.setTargetAtTime(norm * 0.4, ctx.currentTime, 0.02);
+  osc.frequency.setTargetAtTime(220 + fb * 440, ctx.currentTime, 0.02);
+};
+```
+
+イベント駆動の可聴化（着地で音を鳴らす等）は Pattern 1 の接地イベントと組み合わせます。連続値の垂れ流しより、状態遷移時のみ発音する方が聴き取りやすくなります（examples/hula-motion-sonifier 参照）。
+
+### Pattern 5: 高頻度データの描画スロットリング（CRITICAL）
+
+```javascript
+// WRONG - 100Hz で chart.update() するとタブが固まる
+insole.gotPress = function(press) {
+  chart.data.datasets[0].data.push(press.values[0]);
+  chart.update();  // 重い！
+};
+
+// CORRECT - データはバッファに溜め、描画は rAF で 30fps に間引く
+const buffer = [];
+insole.gotPress = function(press) { buffer.push(press.values); };
+(function render() {
+  if (buffer.length) {
+    for (const v of buffer.splice(0)) pushToChart(v);
+    chart.update();
+  }
+  requestAnimationFrame(render);
+})();
+```
+
+## Common Mistakes to Avoid
+
+### 1. setup()を忘れる
+
+```javascript
+// WRONG
+var insole = new OrpheInsole(0);
+insole.begin('SENSOR_VALUES');  // Will fail!
+
+// CORRECT
+var insole = new OrpheInsole(0);
+insole.setup();
+insole.begin('SENSOR_VALUES');
+```
+
+### 2. アロー関数でコールバックを書く
+
+```javascript
+// WRONG - 'this' will be undefined
+insole.gotPress = (press) => { console.log(this.id); };
+
+// CORRECT
+insole.gotPress = function(press) { console.log(this.id); };  // 0 or 1
+```
+
+### 3. CORE専用APIを呼ぶ
+
+```javascript
+// WRONG - INSOLEに存在しない
+insole.setLED(1, 0);
+insole.begin('STEP_ANALYSIS');         // SENSOR_VALUESに強制される
+insole.gotGait = function(gait) {};    // 呼び出されない（FW対応待ち）
+
+// CORRECT - 歩行イベントは圧力から導出する（Pattern 1）
+```
+
+### 4. 圧力生値を体重等の物理量として扱う
+
+`press.values` は ADC 生値です。個体差・装着差があるため、物理量が必要な場合はアプリ起動時にキャリブレーション（無負荷時・全体重時のサンプリング）を行ってください。
+
+### 5. gotData をデバッグ目的でオーバーライドしたまま放置
+
+`gotData` をオーバーライドすると **他のすべての got* コールバックが停止**します（TERMINALモード）。
+
+## Browser Compatibility
+
+- **Required**: Web Bluetooth API
+- **Supported**: Chrome (desktop/Android), Edge, Opera
+- **NOT Supported**: Firefox, Safari (iOS/macOS)
+- デバイス記憶による自動再接続には `navigator.bluetooth.getDevices()` が必要（Chrome では既定で有効。無効環境では選択ダイアログにフォールバック）
+
+## Development
+
+```bash
+npm test            # 構文チェック + 単体テスト
+npm run build       # dist/ を生成（terser）
+npm run generate-docs  # JSDoc
+```
+
+ソースを編集したら必ず `npm test` と `npm run build` を実行してください。CDN利用者は `dist/orphe-insole.min.js` を読み込んでいます。
+
+## Reference Examples
+
+| App Type | Reference | Key Patterns |
+|---|---|---|
+| 可視化 | examples/VISUALIZE | 6chチャート、描画スロットリング |
+| ダッシュボード | examples/sensor-dashboard | 2台接続、L/R自動マッピング |
+| 可聴化 | examples/hula-motion-sonifier | Web Audio、状態遷移発音 |
+| プロトコルデバッグ | examples/terminal | gotData生データ |

--- a/docs/ai/insole-migration/staging/docs-ai/PRESSURE_RECIPES.md
+++ b/docs/ai/insole-migration/staging/docs-ai/PRESSURE_RECIPES.md
@@ -1,0 +1,251 @@
+# ORPHE INSOLE — Pressure Sensor Recipes
+
+6チャネル圧力センサ（FSR）データの典型的な処理パターン集です。
+すべて `insole.gotPress = function(press) {...}` で受け取る `press.values`（ADC生値の6要素配列）を入力とします。
+
+対象レート: mode 4 = 100Hz / mode 3 = 200Hz
+
+---
+
+## 0. 前提: キャリブレーション
+
+ADC生値は個体・装着状態で大きく変わります。アプリ起動時に2点サンプリングを推奨します。
+
+```javascript
+class PressCalibration {
+  constructor() {
+    this.zero = new Array(6).fill(0);     // 無負荷時
+    this.full = new Array(6).fill(4095);  // 全体重時
+  }
+  // それぞれ1〜2秒分のサンプル平均を取って設定する
+  setZero(samples) { this.zero = averageChannels(samples); }
+  setFull(samples) { this.full = averageChannels(samples); }
+  normalize(values) {
+    return values.map((v, i) =>
+      Math.max(0, Math.min(1, (v - this.zero[i]) / (this.full[i] - this.zero[i] + 1e-6))));
+  }
+}
+
+function averageChannels(samples) {
+  const sum = new Array(6).fill(0);
+  for (const s of samples) s.forEach((v, i) => sum[i] += v);
+  return sum.map(v => v / samples.length);
+}
+```
+
+## 1. 合計荷重・移動平均
+
+```javascript
+const window = [];
+const WINDOW_SIZE = 10; // 100Hzなら100ms
+
+insole.gotPress = function(press) {
+  const total = press.values.reduce((a, b) => a + b, 0);
+  window.push(total);
+  if (window.length > WINDOW_SIZE) window.shift();
+  const smoothed = window.reduce((a, b) => a + b, 0) / window.length;
+  // smoothed を荷重インジケータに使用
+};
+```
+
+## 2. 接地/離地イベント（ヒステリシス付き）
+
+しきい値1本では接地境界でチャタリングします。必ずON/OFF 2しきい値にします。
+
+```javascript
+class ContactDetector {
+  constructor(onThreshold, offThreshold) {
+    this.on = onThreshold;   // 例: 校正済み合計の 0.15
+    this.off = offThreshold; // 例: 0.08
+    this.isContact = false;
+    this.lastChange = 0;
+  }
+  update(total, timestamp) {
+    if (!this.isContact && total > this.on) {
+      this.isContact = true;
+      const flight = timestamp - this.lastChange; // 遊脚時間
+      this.lastChange = timestamp;
+      return { event: 'down', flight };
+    }
+    if (this.isContact && total < this.off) {
+      this.isContact = false;
+      const stance = timestamp - this.lastChange; // 立脚時間
+      this.lastChange = timestamp;
+      return { event: 'up', stance };
+    }
+    return null;
+  }
+}
+```
+
+## 3. ケイデンス（歩調）とエアタイム
+
+```javascript
+const detector = new ContactDetector(0.15, 0.08);
+const downTimes = [];
+
+insole.gotPress = function(press) {
+  const total = calib.normalize(press.values).reduce((a, b) => a + b, 0);
+  const ev = detector.update(total, press.timestamp);
+  if (ev?.event === 'down') {
+    downTimes.push(press.timestamp);
+    if (downTimes.length > 5) downTimes.shift();
+    if (downTimes.length >= 2) {
+      const periodMs = (downTimes.at(-1) - downTimes[0]) / (downTimes.length - 1);
+      const cadenceSpm = 60000 / periodMs;  // この足のみ。両足ケイデンスは×2
+    }
+  }
+  if (ev?.event === 'down' && ev.flight > 80) {
+    // 遊脚時間が長い → ジャンプの可能性。両足同時離地ならジャンプ確定
+    onAirTime(ev.flight);
+  }
+};
+```
+
+## 4. 前後・内外バランス
+
+チャネルの物理配置はモデルに依存するため、必ずリマップ層を挟みます。
+
+```javascript
+// 物理配置に合わせて編集（例: 0,1=前足部 2,3=中足部 4,5=踵部）
+const REGION = {
+  front: [0, 1],
+  mid: [2, 3],
+  heel: [4, 5],
+  inner: [0, 2, 4],
+  outer: [1, 3, 5],
+};
+const sumOf = (values, idxs) => idxs.reduce((a, i) => a + values[i], 0);
+
+insole.gotPress = function(press) {
+  const v = press.values;
+  const frontBack = sumOf(v, REGION.front) / (sumOf(v, REGION.front) + sumOf(v, REGION.heel) + 1e-6);
+  const innerOuter = sumOf(v, REGION.inner) / (sumOf(v, REGION.inner) + sumOf(v, REGION.outer) + 1e-6);
+  // frontBack: 1=つま先荷重, 0=踵荷重 / innerOuter: 1=内側, 0=外側
+};
+```
+
+## 5. 圧力中心（CoP）軌跡
+
+```javascript
+const SENSOR_POSITIONS = [          // 足座標系での各chの位置（要モデル調整）
+  { x: -1, y: 2 }, { x: 1, y: 2 },
+  { x: -1, y: 0 }, { x: 1, y: 0 },
+  { x: -1, y: -2 }, { x: 1, y: -2 },
+];
+
+function centerOfPressure(values) {
+  const total = values.reduce((a, b) => a + b, 0);
+  if (total < 1e-6) return null;
+  let cx = 0, cy = 0;
+  values.forEach((v, i) => { cx += SENSOR_POSITIONS[i].x * v; cy += SENSOR_POSITIONS[i].y * v; });
+  return { x: cx / total, y: cy / total };
+}
+```
+
+CoP軌跡を `<canvas>` に残像つきで描くと歩行の質が一目でわかります（蹴り出しの直線性、回内傾向など）。
+
+## 6. ピーク検出と荷重インパルス
+
+```javascript
+let prev = 0, rising = false;
+
+insole.gotPress = function(press) {
+  const total = press.values.reduce((a, b) => a + b, 0);
+  if (total > prev) rising = true;
+  else if (rising && total < prev * 0.95) {
+    rising = false;
+    onPeak(prev, press.timestamp);  // 着地衝撃ピーク
+  }
+  prev = total;
+};
+
+// インパルス（荷重×時間の積分）: リハビリ・トレーニング量の指標
+let impulse = 0;
+insole.gotPress = function(press) {
+  const total = calib.normalize(press.values).reduce((a, b) => a + b, 0);
+  impulse += total * (1 / 100); // mode 4 = 100Hz → dt = 10ms
+};
+```
+
+## 7. 可聴化（Sonification）レシピ
+
+### 7a. 連続マッピング（荷重→音量、バランス→ピッチ）
+
+```javascript
+const ctx = new AudioContext();
+const osc = ctx.createOscillator();
+const gain = ctx.createGain();
+gain.gain.value = 0;
+osc.connect(gain).connect(ctx.destination);
+osc.start();
+// AudioContextはユーザー操作内で ctx.resume() しないと鳴らない
+
+insole.gotPress = function(press) {
+  const v = calib.normalize(press.values);
+  const total = v.reduce((a, b) => a + b, 0) / 6;
+  const fb = sumOf(v, REGION.front) / (sumOf(v, REGION.front) + sumOf(v, REGION.heel) + 1e-6);
+  gain.gain.setTargetAtTime(total * 0.4, ctx.currentTime, 0.02);
+  osc.frequency.setTargetAtTime(220 + fb * 440, ctx.currentTime, 0.02);
+};
+```
+
+### 7b. イベント発音（着地→打楽器、離地→消音）
+
+連続音は疲れるので、フィードバック用途では状態遷移時のみ発音する方が有効です。
+
+```javascript
+function playClick(velocity = 1) {
+  const o = ctx.createOscillator();
+  const g = ctx.createGain();
+  o.frequency.value = 180;
+  g.gain.setValueAtTime(velocity * 0.5, ctx.currentTime);
+  g.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.15);
+  o.connect(g).connect(ctx.destination);
+  o.start(); o.stop(ctx.currentTime + 0.16);
+}
+
+insole.gotPress = function(press) {
+  const total = calib.normalize(press.values).reduce((a, b) => a + b, 0);
+  const ev = detector.update(total, press.timestamp);
+  if (ev?.event === 'down') playClick(Math.min(1, total));
+};
+```
+
+### 7c. 左右2台でステレオパン
+
+```javascript
+// insoles[i].device_information.mount_position の bit0 で左右を判定し、
+// PannerNode/StereoPannerNode の pan=-1（左足）/+1（右足）に割り当てる
+const panner = ctx.createStereoPanner();
+panner.pan.value = isRight ? 1 : -1;
+```
+
+## 8. データ記録（後解析用）
+
+```javascript
+const log = [];
+insole.gotPress = function(press) {
+  log.push({ t: press.timestamp, sn: press.serial_number, v: [...press.values] });
+};
+
+function exportJSON() {
+  const blob = new Blob([JSON.stringify(log)], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `insole_press_${Date.now()}.json`;
+  a.click();
+}
+```
+
+`lostData` コールバックで欠損も記録しておくと、後解析時に信頼区間が判断できます。
+
+---
+
+## アンチパターン
+
+1. **しきい値1本での接地判定** → 必ずヒステリシス（レシピ2）
+2. **100Hzコールバック内でのDOM更新/chart.update()** → rAFスロットリング（VISUALIZE参照）
+3. **ADC生値の機種間比較・体重換算** → キャリブレーション必須（レシピ0）
+4. **チャネル番号の物理位置ハードコード** → REGION リマップ層を挟む（レシピ4）
+5. **insoles[0]=左足の決め打ち** → mount_position bit0 で判定

--- a/docs/ai/insole-migration/staging/examples/VISUALIZE/README.md
+++ b/docs/ai/insole-migration/staging/examples/VISUALIZE/README.md
@@ -1,0 +1,23 @@
+# VISUALIZE — ORPHE INSOLE
+
+ORPHE CORE.js の `examples/VISUALIZE` を INSOLE 向けに移植したサンプルです。
+2台までのインソールの圧力(6ch)・加速度・ジャイロ・クォータニオン・オイラー角を
+Chart.js でリアルタイム表示します。
+
+## 使い方
+
+1. Chrome / Edge でこのディレクトリの `index.html` を開く（要 HTTPS または localhost）
+2. トグルスイッチを ON にして INSOLE デバイス（INS で始まる名前）を選択
+3. ストリーミングモードは歯車アイコンから変更可能（デフォルト: mode 4 = 100Hz 全データ）
+
+## CORE 版との違い
+
+| 項目 | CORE 版 | INSOLE 版 |
+|---|---|---|
+| 接続UI | 独自トグル | InsoleToolkit（自動再接続つき） |
+| チャート | acc/gyro/quat/euler | **press(6ch)** + acc/gyro/quat/euler |
+| 描画更新 | コールバック毎に update() | requestAnimationFrame で約30fpsにスロットリング |
+
+100Hz×複数チャートの `chart.update()` 連打はタブ全体を固まらせるため、
+受信データはバッファに溜めて描画ループでまとめて反映しています。
+INSOLE 向けサンプルを新規に書く場合も同じパターンを推奨します。

--- a/docs/ai/insole-migration/staging/examples/VISUALIZE/index.html
+++ b/docs/ai/insole-migration/staging/examples/VISUALIZE/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sensor Visualize — ORPHE INSOLE</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.3/font/bootstrap-icons.css">
+  <link href="../assets/css/orphe_insole.css" rel="stylesheet">
+</head>
+
+<body class="bg-dark text-light">
+
+  <div class="container mt-3">
+    <nav class="navbar navbar-dark position-relative">
+      <span class="navbar-brand mb-0 h1">ORPHE INSOLE — VISUALIZE</span>
+      <span class="position-absolute top-25 end-0 badge bg-secondary p-1" style="font-size:0.7em;">Version 1.0</span>
+    </nav>
+
+    <div class="row">
+      <div class="col-md-6">
+        <div id="toolkit0" class="mb-2"></div>
+        <canvas id="chart0_press"></canvas>
+        <canvas id="chart0_acc"></canvas>
+        <canvas id="chart0_gyro"></canvas>
+        <canvas id="chart0_quat"></canvas>
+        <canvas id="chart0_euler"></canvas>
+      </div>
+
+      <div class="col-md-6">
+        <div id="toolkit1" class="mb-2"></div>
+        <canvas id="chart1_press"></canvas>
+        <canvas id="chart1_acc"></canvas>
+        <canvas id="chart1_gyro"></canvas>
+        <canvas id="chart1_quat"></canvas>
+        <canvas id="chart1_euler"></canvas>
+      </div>
+    </div>
+
+    <hr>
+    <footer class="text-center small">
+      &copy; 2026 ORPHE Inc.
+    </footer>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.0/chart.min.js"
+    integrity="sha512-R60W3LgKdvvfwbGbqKusRu/434Snuvr9/Flhtoq9cj1LQ9P4HFKParULqOCAisHk/J4zyaEWWjiWIMuP13vXEg=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
+
+  <!-- ORPHE Libraries (REQUIRED ORDER) -->
+  <script src="../../src/ORPHE-INSOLE.js"></script>
+  <script src="../../src/InsoleToolkit.js"></script>
+
+  <script src="./sketch.js"></script>
+
+</body>
+
+</html>

--- a/docs/ai/insole-migration/staging/examples/VISUALIZE/sketch.js
+++ b/docs/ai/insole-migration/staging/examples/VISUALIZE/sketch.js
@@ -1,0 +1,146 @@
+/**
+ * ORPHE INSOLE — VISUALIZE
+ *
+ * 2台までのインソールの 圧力(6ch)・加速度・ジャイロ・クォータニオン・オイラー角を
+ * Chart.js でリアルタイム表示するサンプル。
+ *
+ * CORE 版 examples/VISUALIZE からの主な変更点:
+ *  - 接続UIを InsoleToolkit に変更（自動再接続つき）
+ *  - 圧力6chチャートを追加
+ *  - 100Hz/200Hz のデータレートに耐えるよう、チャート更新を
+ *    requestAnimationFrame でスロットリング（描画は最大30fps、データは全サンプル保持）
+ */
+
+const HISTORY = 100;          // チャートに表示するサンプル数
+const RENDER_INTERVAL_MS = 33; // 描画間隔（約30fps）
+
+const SERIES_COLORS = [
+    'rgb(69, 230, 230)',
+    'rgb(255, 96, 64)',
+    'rgb(255, 255, 255)',
+    'rgb(127, 127, 127)',
+    'rgb(255, 205, 86)',
+    'rgb(153, 102, 255)',
+];
+
+/**
+ * 折れ線チャートを生成するファクトリ
+ */
+function makeLineChart(canvasId, title, seriesLabels, yMin, yMax) {
+    const datasets = seriesLabels.map((label, i) => ({
+        label,
+        backgroundColor: SERIES_COLORS[i % SERIES_COLORS.length],
+        borderColor: SERIES_COLORS[i % SERIES_COLORS.length],
+        pointRadius: 0,
+        borderWidth: 1.5,
+        data: [],
+    }));
+    const scales = {};
+    if (typeof yMin === 'number' && typeof yMax === 'number') {
+        scales.y = { min: yMin, max: yMax };
+    }
+    return new Chart(document.getElementById(canvasId), {
+        type: 'line',
+        data: { labels: [], datasets },
+        options: {
+            animation: false,
+            plugins: {
+                legend: { position: 'top', labels: { boxWidth: 12 } },
+                title: { display: true, text: title },
+            },
+            scales,
+        },
+    });
+}
+
+/**
+ * 1チャート分の受信バッファ。コールバック（100Hz〜）で push し、
+ * 描画ループ（30fps）でまとめて Chart.js に流し込む。
+ */
+class ChartFeed {
+    constructor(chart) {
+        this.chart = chart;
+        this.pending = [];
+        this.count = 0;
+    }
+    push(values) {
+        this.pending.push(values);
+    }
+    flush() {
+        if (this.pending.length === 0) return false;
+        const data = this.chart.data;
+        for (const values of this.pending) {
+            data.labels.push(this.count++);
+            values.forEach((v, i) => data.datasets[i].data.push(v));
+        }
+        this.pending.length = 0;
+        while (data.labels.length > HISTORY) {
+            data.labels.shift();
+            data.datasets.forEach(ds => ds.data.shift());
+        }
+        return true;
+    }
+}
+
+const feeds = []; // feeds[id] = {press, acc, gyro, quat, euler}
+
+window.onload = function () {
+    for (let id = 0; id < 2; id++) {
+        buildInsoleToolkit(
+            document.getElementById(`toolkit${id}`),
+            `INSOLE ${id === 0 ? '01' : '02'}`,
+            id,
+            { streamingMode: 4, autoReconnect: true }
+        );
+
+        feeds[id] = {
+            press: new ChartFeed(makeLineChart(`chart${id}_press`, 'Pressure (6ch raw)',
+                ['p0', 'p1', 'p2', 'p3', 'p4', 'p5'])),
+            acc: new ChartFeed(makeLineChart(`chart${id}_acc`, 'Accelerometer (normalized)',
+                ['x', 'y', 'z'], -1, 1)),
+            gyro: new ChartFeed(makeLineChart(`chart${id}_gyro`, 'Gyro (normalized)',
+                ['x', 'y', 'z'], -1, 1)),
+            quat: new ChartFeed(makeLineChart(`chart${id}_quat`, 'Quaternion',
+                ['w', 'x', 'y', 'z'], -1.2, 1.2)),
+            euler: new ChartFeed(makeLineChart(`chart${id}_euler`, 'Euler [rad]',
+                ['pitch', 'roll', 'yaw'], -3.2, 3.2)),
+        };
+
+        const insole = insoles[id];
+        insole.setup();
+
+        insole.gotPress = function (press) {
+            feeds[this.id].press.push(press.values);
+        };
+        insole.gotAcc = function (acc) {
+            feeds[this.id].acc.push([acc.x, acc.y, acc.z]);
+        };
+        insole.gotGyro = function (gyro) {
+            feeds[this.id].gyro.push([gyro.x, gyro.y, gyro.z]);
+        };
+        insole.gotQuat = function (quat) {
+            feeds[this.id].quat.push([quat.w, quat.x, quat.y, quat.z]);
+        };
+        insole.gotEuler = function (euler) {
+            feeds[this.id].euler.push([euler.pitch, euler.roll, euler.yaw]);
+        };
+        insole.lostData = function (serial_number, serial_number_prev) {
+            console.warn(`INSOLE${this.id}: lost packets ${serial_number_prev} -> ${serial_number}`);
+        };
+    }
+
+    // 描画ループ: pending データがあるチャートだけ update する
+    let lastRender = 0;
+    function renderLoop(now) {
+        if (now - lastRender >= RENDER_INTERVAL_MS) {
+            lastRender = now;
+            for (const feed of feeds) {
+                for (const key of Object.keys(feed)) {
+                    if (feed[key].flush()) feed[key].chart.update();
+                }
+            }
+        }
+        requestAnimationFrame(renderLoop);
+    }
+    requestAnimationFrame(renderLoop);
+};

--- a/docs/ai/insole-migration/staging/src/InsoleToolkit.js
+++ b/docs/ai/insole-migration/staging/src/InsoleToolkit.js
@@ -1,0 +1,346 @@
+var insoleToolkit_version_date = `
+Last modified: 2026/06/10 00:00:00
+`;
+// insoleToolkit_version_dateから改行を削除
+insoleToolkit_version_date = insoleToolkit_version_date.replace(/\n/g, '');
+
+/**
+ * InsoleToolkit.js
+ *
+ * ORPHE INSOLE 用の接続GUIツールキット。CORE 用 CoreToolkit.js の slim 版で、
+ * INSOLE に存在しない機能（LED、左右書き込み、STEP_ANALYSIS通知選択）を削除し、
+ * 代わりに INSOLE 固有のデータストリーミングモード選択と
+ * 取り付け位置（左右）バッジ、自動再接続ステータス表示を追加しています。
+ *
+ * 依存: Bootstrap 5 (CSS/JS) + bootstrap-icons + ORPHE-INSOLE.js
+ */
+
+/**
+ * insoles = [new OrpheInsole(0), new OrpheInsole(1)];
+ * INSOLE は最大2足（左右）まで同時接続できます。
+ */
+var insoles = [new OrpheInsole(0), new OrpheInsole(1)];
+
+/**
+ * CORE 系コードからの移植を容易にするためのエイリアス。参照先は insoles と同じ。
+ */
+var bles = insoles;
+var cores = insoles;
+
+/**
+ * インソール操作GUIを生成する。ユーザはこれを呼び出すだけでよい。
+ * @param {Element} parent_element - InsoleToolkitを追加する親要素
+ * @param {string} title - タイトル。トグルボタンの横に表示される
+ * @param {number} [insole_id=0]  - 0,1のどちらかを指定する。インソールは最大2つまで
+ * @param {object} [options] - {streamingMode: 1|3|4, autoReconnect: boolean}
+ */
+function buildInsoleToolkit(parent_element, title, insole_id = 0, options = {}) {
+    if (typeof options.streamingMode === 'undefined') options.streamingMode = 4;
+    if (typeof options.autoReconnect === 'undefined') options.autoReconnect = true;
+    insoles[insole_id]._insoleToolkitOptions = options;
+
+    let div_form_check = ITbuildElement('div', '', 'form-check form-switch d-flex', '', parent_element);
+    div_form_check.id = `insole_toolkit${insole_id}`;
+
+    // toggle and title
+    let input = ITbuildElement('input', '', 'form-check-input position-relative', '', div_form_check);
+    input.setAttribute('type', 'checkbox');
+    input.setAttribute('role', 'switch');
+    input.setAttribute('id', `switch_ble${insole_id}`);
+    input.setAttribute('value', `${insole_id}`);
+    input.setAttribute('title', `insoleToolkit_version_date: ${insoleToolkit_version_date}\norphe_js_version_date: ${orphe_js_version_date}`);
+    input.addEventListener('change', function () {
+        toggleInsoleModule(this, options);
+    })
+    ITbuildElement('label', title, 'form-check-label ms-1', '', div_form_check);
+
+    let span_group = ITbuildElement('span', '', '', '', div_form_check);
+    span_group.id = `ui${insole_id}`;
+    span_group.style.visibility = 'hidden';
+
+    // 実測周波数
+    let span_activity = ITbuildElement('span',
+        `<i class="bi bi-activity position-relative">
+        <span class="position-absolute top-0 start-50 translate-middle badge text-muted" style="font-size:0.2em;"
+          id="freq${insole_id}">
+        </span>
+      </i>`,
+        'text-muted ms-1', '', span_group);
+    span_activity.id = `icon_bluetooth${insole_id}`;
+
+    // 左右バッジ（device_information.mount_position bit0 から自動表示）
+    let span_lr = ITbuildElement('span', `<span class="badge bg-secondary" id="lr_badge${insole_id}">-</span>`, 'ms-1', '', span_group);
+    span_lr.id = `icon_lr${insole_id}`;
+    span_lr.setAttribute('title', 'mount position (L/R)');
+
+    // バッテリー
+    let span_battery = ITbuildElement('span', `<i class="bi bi-battery"></i>`, 'text-muted ms-1', '', span_group);
+    span_battery.id = `icon_battery${insole_id}`;
+    span_battery.setAttribute('insole_id', `${insole_id}`);
+    span_battery.addEventListener('click', function () {
+        updateInsoleBatteryInfo(span_battery);
+    })
+
+    // 自動再接続ステータス（再接続試行中のみ表示）
+    let span_reconnect = ITbuildElement('span',
+        `<i class="bi bi-arrow-repeat"></i><span class="small" id="reconnect_text${insole_id}"></span>`,
+        'text-warning ms-1', '', span_group);
+    span_reconnect.id = `icon_reconnect${insole_id}`;
+    span_reconnect.style.display = 'none';
+    span_reconnect.setAttribute('title', 'auto reconnecting...');
+
+    // 設定モーダル
+    let span_settings = ITbuildElement('span', `<i class="bi bi-gear"></i>`, 'text-muted ms-1', '', span_group);
+    span_settings.id = `icon_settings${insole_id}`;
+    span_settings.setAttribute('value', `${insole_id}`);
+    span_settings.setAttribute('title', `settings for streaming mode.`);
+    span_settings.setAttribute('data-bs-toggle', 'modal');
+    span_settings.setAttribute('data-bs-target', `#settings_modal${insole_id}`);
+    span_settings.addEventListener('click', function () {
+        updateInsoleModalParameters(parseInt(insole_id));
+    })
+
+    let div_modal = ITbuildElement('div', '', 'modal fade', '', span_group);
+    div_modal.id = `settings_modal${insole_id}`;
+    div_modal.setAttribute('tabindex', '-1');
+    div_modal.setAttribute('aria-hidden', 'true');
+    let div_modal_dialog = ITbuildElement('div', '', 'modal-dialog text-dark', '', div_modal);
+    let div_modal_content = ITbuildElement('div', '', 'modal-content', '', div_modal_dialog);
+    ITbuildElement('div', `<h5 class="modal-title"><i class="bi bi-gear"></i> INSOLE0${insole_id} Settings</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>`, 'modal-header', '', div_modal_content);
+
+    ITbuildElement('div', `<div class="form-floating mt-2">
+    <select class="form-select text-black" id="select_streaming_mode${insole_id}"
+      onchange="changeInsoleStreamingMode(${insole_id}, this);">
+      <option value="1">1: quat + gyro + acc (200Hz)</option>
+      <option value="3">3: gyro + acc + press (200Hz)</option>
+      <option value="4" selected>4: gyro + acc + press + quat (100Hz)</option>
+    </select>
+    <label for="select_streaming_mode${insole_id}" class="small">Data Streaming Mode</label>
+  </div>
+  <div class="row mt-3 small text-muted">
+    <div class="col-6">Accelerometer Range: <span id="info_acc_range${insole_id}">-</span> g</div>
+    <div class="col-6">Gyroscope Range: <span id="info_gyro_range${insole_id}">-</span> °/s</div>
+  </div>
+  <div class="row mt-1 small text-muted">
+    <div class="col-12">Mount Position: <span id="info_mount_position${insole_id}">-</span></div>
+  </div>
+  <div class="d-grid gap-2 col-10 mx-auto mt-4">
+    <button class="btn btn-warning text-white" type="button" onclick="resetInsoleModule(${insole_id});">Reset
+      Analysis Logs</button>
+  </div>`, 'modal-body', '', div_modal_content);
+
+    // 設定モーダルのストリーミングモード初期値を options に合わせる
+    let select_mode = div_modal_content.querySelector(`#select_streaming_mode${insole_id}`);
+    for (const opt of select_mode.options) {
+        opt.selected = (parseInt(opt.value) === options.streamingMode);
+    }
+}
+
+/**
+ * CoreToolkit 互換ラッパー。
+ * CORE 用コードからの移植を容易にするために残してあります。
+ * notification 引数は INSOLE では SENSOR_VALUES 固定のため無視されます。
+ * @deprecated buildInsoleToolkit を利用してください
+ */
+function buildCoreToolkit(parent_element, title, core_id = 0, notification = 'SENSOR_VALUES', options = {}) {
+    if (notification && notification !== 'SENSOR_VALUES') {
+        console.warn(`InsoleToolkit: notification '${notification}' is ignored. ORPHE INSOLE only supports SENSOR_VALUES.`);
+    }
+    return buildInsoleToolkit(parent_element, title, core_id, options);
+}
+
+/**
+ * BLE接続のトグルボタンが切り替わったときに呼び出される関数
+ * @param {Element} dom
+ * @param {object} options
+ *
+ */
+async function toggleInsoleModule(dom, options = {}) {
+    let checked = dom.checked;
+    let number = parseInt(dom.value);
+    let insole = insoles[number];
+    if (checked == true) {
+        let ret;
+        try {
+            ret = await insole.begin('SENSOR_VALUES', options);
+        } catch (error) {
+            ret = null;
+        }
+        if (!ret) {
+            document.querySelector(`#switch_ble${number}`).checked = false;
+            return;
+        }
+
+        document.querySelector(`#ui${number}`).style.visibility = 'visible';
+        updateInsoleLRBadge(number);
+
+        // ツールキットUI用コールバック。ユーザ側の上書きと共存できるよう、
+        // 既存のユーザコールバックがあれば チェーンして呼び出す。
+        const userGotBLEFrequency = insole.gotBLEFrequency;
+        insole.gotBLEFrequency = function (freq) {
+            const el = document.querySelector(`#freq${this.id}`);
+            if (el) el.innerHTML = `${Math.floor(freq)} Hz`;
+            if (typeof userGotBLEFrequency === 'function') userGotBLEFrequency.call(this, freq);
+        };
+
+        const userOnReconnectAttempt = insole.onReconnectAttempt;
+        insole.onReconnectAttempt = function (info) {
+            const icon = document.querySelector(`#icon_reconnect${this.id}`);
+            const text = document.querySelector(`#reconnect_text${this.id}`);
+            if (icon) icon.style.display = '';
+            if (text) text.innerText = `${info.attempt}/${info.maxAttempts}`;
+            if (typeof userOnReconnectAttempt === 'function') userOnReconnectAttempt.call(this, info);
+        };
+        const userOnReconnectSuccess = insole.onReconnectSuccess;
+        insole.onReconnectSuccess = function (info) {
+            const icon = document.querySelector(`#icon_reconnect${this.id}`);
+            if (icon) icon.style.display = 'none';
+            updateInsoleLRBadge(this.id);
+            if (typeof userOnReconnectSuccess === 'function') userOnReconnectSuccess.call(this, info);
+        };
+        const userOnReconnectFailed = insole.onReconnectFailed;
+        insole.onReconnectFailed = function (info) {
+            const icon = document.querySelector(`#icon_reconnect${this.id}`);
+            if (icon) icon.style.display = 'none';
+            setInsoleHeaderStatusOffline(this.id);
+            document.querySelector(`#ui${this.id}`).style.visibility = 'hidden';
+            if (typeof userOnReconnectFailed === 'function') userOnReconnectFailed.call(this, info);
+        };
+    }
+    else {
+        insole.reset();
+        document.querySelector(`#ui${number}`).style.visibility = 'hidden';
+    }
+}
+
+/**
+ * device_information.mount_position から左右バッジを更新する
+ * bit0: 0=LEFT, 1=RIGHT
+ * @param {number} no - insole_id(0,1)
+ */
+function updateInsoleLRBadge(no) {
+    const badge = document.querySelector(`#lr_badge${no}`);
+    if (!badge) return;
+    const info = insoles[no].device_information;
+    if (!info || typeof info.mount_position === 'undefined') {
+        badge.innerText = '-';
+        return;
+    }
+    const isRight = (info.mount_position & 0b1) === 1;
+    badge.innerText = isRight ? 'R' : 'L';
+    badge.classList.remove('bg-secondary');
+    badge.classList.add(isRight ? 'bg-primary' : 'bg-success');
+}
+
+/**
+ * InsoleToolkitからデータストリーミングモードが変更された場合に呼び出される関数
+ * @param {number} no (0,1)
+ * @param {Element} dom セレクタ
+ */
+async function changeInsoleStreamingMode(no, dom) {
+    const mode = parseInt(dom.value);
+    try {
+        await insoles[no].setDataStreamingMode(mode);
+        if (insoles[no]._insoleToolkitOptions) {
+            insoles[no]._insoleToolkitOptions.streamingMode = mode;
+        }
+    } catch (error) {
+        console.error('changeInsoleStreamingMode failed:', error);
+    }
+}
+
+/**
+ * 設定モーダルのパラメータを更新する関数
+ * @param {number} no (0,1)
+ */
+async function updateInsoleModalParameters(no) {
+    var obj = await insoles[no].getDeviceInformation();
+
+    // ACC/GYRO Range（読み取り専用表示。INSOLE は setDeviceInformation 未対応）
+    const ACC_RANGE = { 0: 2, 1: 4, 2: 8, 3: 16 };
+    const GYRO_RANGE = { 0: 250, 1: 500, 2: 1000, 3: 2000 };
+    const acc_el = document.querySelector(`#info_acc_range${no}`);
+    const gyro_el = document.querySelector(`#info_gyro_range${no}`);
+    const mount_el = document.querySelector(`#info_mount_position${no}`);
+    if (acc_el) acc_el.innerText = ACC_RANGE[obj.range.acc] ?? obj.range.acc;
+    if (gyro_el) gyro_el.innerText = GYRO_RANGE[obj.range.gyro] ?? obj.range.gyro;
+    if (mount_el) {
+        const isRight = (obj.mount_position & 0b1) === 1;
+        const isInstep = (obj.mount_position & 0b10) === 0b10;
+        mount_el.innerText = `${isRight ? 'RIGHT' : 'LEFT'} / ${isInstep ? 'instep(足背)' : 'plantar(足底)'}`;
+    }
+
+    // Streaming mode セレクタ
+    const select = document.querySelector(`#select_streaming_mode${no}`);
+    if (select && insoles[no].streaming_mode) {
+        for (const opt of select.options) {
+            opt.selected = (parseInt(opt.value) === insoles[no].streaming_mode);
+        }
+    }
+
+    updateInsoleLRBadge(no);
+}
+
+/**
+ * インソールの解析ログをリセットする関数
+ * @param {number} id - インソールのID(0,1)
+ */
+function resetInsoleModule(id) {
+    insoles[id].resetAnalysisLogs();
+}
+
+/**
+ * バッテリー情報を更新する関数。device_informationの3段階に応じてアイコンを変更する
+ * @param {Element} dom セレクタ
+ */
+async function updateInsoleBatteryInfo(dom) {
+    let number = parseInt(dom.getAttribute('insole_id'));
+    var obj = await insoles[number].getDeviceInformation();
+    let str_battery_status;
+    if (obj.battery == 0) str_battery_status = 'empty';
+    else if (obj.battery == 1) str_battery_status = 'normal';
+    else if (obj.battery == 2) str_battery_status = 'full';
+    const el = document.querySelector(`#icon_battery${number}`);
+    el.setAttribute('title', `${str_battery_status}`);
+
+    if (obj.battery == 0) {
+        el.innerHTML = '<i class="bi bi-battery"></i>';
+        el.classList.add('text-warning');
+    }
+    else if (obj.battery == 1) {
+        el.innerHTML = '<i class="bi bi-battery-half"></i>';
+    }
+    else if (obj.battery == 2) {
+        el.innerHTML = '<i class="bi bi-battery-full"></i>';
+    }
+}
+
+/**
+ * InsoleToolkitのトグルボタンをオフに変更する
+ * @param {number} id - (0,1)
+ */
+function setInsoleHeaderStatusOffline(id) {
+    const el = document.querySelector(`#switch_ble${id}`);
+    if (el) el.checked = false;
+}
+
+/**
+ * InsoleToolkit.js内でUIを生成するのに利用するbuildElementのラッパー関数
+ * @param {string} name_tag - タグ名
+ * @param {string} innerHTML - タグ内のテキスト
+ * @param {string} str_class - タグ内に適応するクラス
+ * @param {string} str_style - タグ内に適応するスタイル
+ * @param {Element} element_appended - 親要素
+ *
+ */
+function ITbuildElement(name_tag, innerHTML, str_class, str_style, element_appended) {
+    let element = document.createElement(name_tag);
+    element.innerHTML = innerHTML;
+    element.classList = str_class;
+    if (str_style != '') {
+        element.setAttribute('style', str_style);
+    }
+    element_appended.appendChild(element);
+    return element;
+}

--- a/docs/ai/insole-migration/staging/src/ORPHE-INSOLE.js
+++ b/docs/ai/insole-migration/staging/src/ORPHE-INSOLE.js
@@ -1,0 +1,1708 @@
+var orphe_js_version_date = `
+Last modified: 2026/06/10 00:00:00
+`;
+/**
+ORPHE-INSOLE.js is javascript library for ORPHE INSOLE Module, inspired by BlueJelly.js
+Class形式で記述を変更したバージョン
+v1.1.0 接続安定化（デバイス記憶・高速再接続・自動再接続）、クラス名を OrpheInsole に変更（Orphe はエイリアスとして維持）
+v0.9.0 ベータ版
+@module OrpheInsole
+@author Tetsuaki BABA
+@version 1.1.0
+
+@see https://github.com/Orphe-OSS/ORPHE-INSOLE.js
+*/
+
+// 外部スクリプトを読み込む関数
+function loadScript(src) {
+  if (typeof document === 'undefined') return;
+  const fileName = src.split('/').pop();
+  if (fileName) {
+    const already = Array.from(document.scripts).some(s => {
+      if (!s.src) return false;
+      return s.src === src || s.src.endsWith('/' + fileName);
+    });
+    if (already) return;
+  }
+  const script = document.createElement('script');
+  script.src = src;
+  script.type = 'text/javascript';
+  script.crossOrigin = 'anonymous';
+  document.head.appendChild(script);
+}
+
+// 外部スクリプトの読み込み
+function _orpheInsoleAutoLoadOptionalLibs() {
+  loadScript('https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/float16.min.js');
+  loadScript('https://cdn.jsdelivr.net/gh/Orphe-OSS/ORPHE-CORE.js@main/js/quaternion.js');
+}
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _orpheInsoleAutoLoadOptionalLibs, { once: true });
+  } else {
+    _orpheInsoleAutoLoadOptionalLibs();
+  }
+}
+
+// ── ライブラリ本体 ────────────────────────────────────────────────
+// ORPHE-CORE.js と同一ページで共存できるよう、クラス宣言
+// (FixedSizeArray, OrpheTimestamp など) をトップレベルに置かず IIFE で包む。
+// トップレベルの class 宣言はグローバルなレキシカル束縛を作るため、
+// CORE と INSOLE の両方を読み込むと SyntaxError で後勝ちスクリプト全体が死ぬ。
+(function (global) {
+
+/**
+ * 自動的に決められた配列サイズでunshiftしてくれるクラス
+ * sensor valuesのデータを保持するクラスです。sensor valuesのデータは、加速度、ジャイロ、クォータニオンの3つのデータを保持します。interpotion処理を行うために、過去のデータを保持する用途に使用します。
+ */
+class FixedSizeArray {
+  constructor(size) {
+    this.size = size;
+    this.array = [];
+  }
+  setSize(size) {
+    this.size = size;
+  }
+  push(element) {
+    if (this.array.length >= this.size) {
+      this.array.shift(); // 先頭の要素を削除
+    }
+    this.array.push(element); // 新しい要素を追加
+  }
+
+  getArray() {
+    return this.array;
+  }
+}
+
+
+
+
+/**
+ * Orpheクラス内部で利用されるタイムスタンプクラスです。BLE通信のデータ取得タイミングにおける実測周波数を取得するために利用されます。Orpheクラス内部で本当は宣言したかったのですが、jsdoc がクラス内部クラス定義に対応していないため、外部に出しています。無念。
+ * @class
+ */
+class OrpheTimestamp {
+  /**
+   * タイムスタンプクラスのコンストラクタです。
+   */
+  constructor() {
+    this.start = 0;
+  }
+
+  /**
+   * 前回呼び出した時刻からの経過時間をミリ秒で返します。
+   * @returns {number} 前回呼び出した時刻からの経過時間をミリ秒で返します。
+   */
+  millis() {
+    const blenow = performance.now();
+    let diff = (blenow - this.start);
+    this.start = blenow;
+    return diff;
+  }
+  /**
+   * 前回呼び出した時刻からの経過時間を周波数として返します。
+   * @returns {float} 周波数[Hz]
+   */
+  getHz() {
+    let t = this.millis();
+    if (t <= 15) return -1;
+    else return 1000 / t;
+  }
+}
+
+function _orpheInsoleTimestampToday(hours, minutes, seconds, milliseconds) {
+  const now = new Date();
+  now.setHours(hours);
+  now.setMinutes(minutes);
+  now.setSeconds(seconds);
+  now.setMilliseconds(milliseconds);
+  return now.getTime();
+}
+
+/**
+ * ORPHE INSOLE SENSOR_VALUES packet parser.
+ * @param {DataView} data
+ * @param {object} options
+ * @param {number} [options.gyroRange=2000]
+ * @param {number} [options.accRange=16]
+ * @returns {object|null}
+ */
+function parseInsoleSensorValues(data, options = {}) {
+  if (!data || typeof data.getUint8 !== 'function') {
+    throw new TypeError('parseInsoleSensorValues expects a DataView');
+  }
+  if (data.byteLength !== 104) return null;
+
+  const header = data.getUint8(0);
+  const serial_number = data.getUint16(1);
+  const gyroRange = Number.isFinite(Number(options.gyroRange)) ? Number(options.gyroRange) : 2000;
+  const accRange = Number.isFinite(Number(options.accRange)) ? Number(options.accRange) : 16;
+  const t_start = _orpheInsoleTimestampToday(
+    data.getUint8(3),
+    data.getUint8(4),
+    data.getUint8(5),
+    data.getUint16(6)
+  );
+  const samples = [];
+
+  function vector3(x, y, z, timestamp, packet_number) {
+    return {
+      x: data.getInt16(x) / 32768,
+      y: data.getInt16(y) / 32768,
+      z: data.getInt16(z) / 32768,
+      timestamp,
+      serial_number,
+      packet_number
+    };
+  }
+
+  function quat(w, x, y, z, timestamp, packet_number) {
+    return {
+      w: data.getInt16(w) / 32768,
+      x: data.getInt16(x) / 32768,
+      y: data.getInt16(y) / 32768,
+      z: data.getInt16(z) / 32768,
+      timestamp,
+      serial_number,
+      packet_number
+    };
+  }
+
+  function withConverted(sample) {
+    if (sample.gyro) {
+      sample.converted_gyro = {
+        x: sample.gyro.x * gyroRange,
+        y: sample.gyro.y * gyroRange,
+        z: sample.gyro.z * gyroRange,
+        timestamp: sample.timestamp,
+        serial_number,
+        packet_number: sample.packet_number
+      };
+    }
+    if (sample.acc) {
+      sample.converted_acc = {
+        x: sample.acc.x * accRange,
+        y: sample.acc.y * accRange,
+        z: sample.acc.z * accRange,
+        timestamp: sample.timestamp,
+        serial_number,
+        packet_number: sample.packet_number
+      };
+    }
+    return sample;
+  }
+
+  if (header === 50) {
+    let timestamp = t_start;
+    for (let i = 3; i >= 0; i--) {
+      if (i !== 3) timestamp += data.getUint8(28 + 21 * i);
+      samples.push(withConverted({
+        timestamp,
+        serial_number,
+        packet_number: 3 - i,
+        quat: quat(8 + 21 * i, 10 + 21 * i, 12 + 21 * i, 14 + 21 * i, timestamp, 3 - i),
+        gyro: vector3(16 + 21 * i, 18 + 21 * i, 20 + 21 * i, timestamp, 3 - i),
+        acc: vector3(22 + 21 * i, 24 + 21 * i, 26 + 21 * i, timestamp, 3 - i)
+      }));
+    }
+  } else if (header === 55) {
+    const offset = 24;
+    for (let i = 3; i >= 0; i--) {
+      const timestamp = t_start;
+      const packet_number = 3 - i;
+      samples.push(withConverted({
+        timestamp,
+        serial_number,
+        packet_number,
+        gyro: vector3(8 + offset * i, 10 + offset * i, 12 + offset * i, timestamp, packet_number),
+        acc: vector3(14 + offset * i, 16 + offset * i, 18 + offset * i, timestamp, packet_number),
+        press: {
+          values: [
+            data.getUint16(20 + offset * i),
+            data.getUint16(22 + offset * i),
+            data.getUint16(24 + offset * i),
+            data.getUint16(26 + offset * i),
+            data.getUint16(28 + offset * i),
+            data.getUint16(30 + offset * i)
+          ],
+          timestamp,
+          serial_number,
+          packet_number
+        }
+      }));
+    }
+  } else if (header === 56) {
+    const offset = 32;
+    for (let i = 1; i >= 0; i--) {
+      const timestamp = t_start;
+      const packet_number = 1 - i;
+      samples.push(withConverted({
+        timestamp,
+        serial_number,
+        packet_number,
+        quat: quat(8 + offset * i, 10 + offset * i, 12 + offset * i, 14 + offset * i, timestamp, packet_number),
+        gyro: vector3(16 + offset * i, 18 + offset * i, 20 + offset * i, timestamp, packet_number),
+        acc: vector3(22 + offset * i, 24 + offset * i, 26 + offset * i, timestamp, packet_number),
+        press: {
+          values: [
+            data.getUint16(28 + offset * i),
+            data.getUint16(30 + offset * i),
+            data.getUint16(32 + offset * i),
+            data.getUint16(34 + offset * i),
+            data.getUint16(36 + offset * i),
+            data.getUint16(38 + offset * i)
+          ],
+          timestamp,
+          serial_number,
+          packet_number
+        }
+      }));
+    }
+  } else {
+    return { header, serial_number, timestamp: t_start, samples: [] };
+  }
+
+  return { header, serial_number, timestamp: t_start, samples };
+}
+
+/**
+ * ORPHE INSOLE Module Javascript class
+* @class
+* @type {Object}
+* @property {string} ORPHE_INFORMATION "01a9d6b5-ff6e-444a-b266-0be75e85c064" SERVICE_UUID
+* @property {string} ORPHE_DEVICE_INFORMATION "24354f22-1c46-430e-a4ab-a1eeabbcdfc0" CHARACTERISTIC_UUID
+*
+* @property {string} ORPHE_OTHER_SERVICE "db1b7aca-cda5-4453-a49b-33a53d3f0833" SERVICE_UUID
+* @property {string} ORPHE_SENSOR_VALUES "f3f9c7ce-46ee-4205-89ac-abe64e626c0f" CHARACTERISTIC_UUID
+* @property {string} ORPHE_STEP_ANALYSIS "4eb776dc-cf99-4af7-b2d3-ad0f791a79dd" CHARACTERISTIC_UUID
+*/
+class OrpheInsole {
+  /**
+   * SENSOR_VALUES の DataView を ORPHE INSOLE のサンプル列に変換する。
+   * @param {DataView} data
+   * @param {object} options
+   * @returns {object|null}
+   */
+  static parseSensorValues(data, options = {}) {
+    return parseInsoleSensorValues(data, options);
+  }
+
+  /**
+   * 初期化関数
+   * @param {number}[id=0] id コアの番号（0 or 1）を指定します。
+   */
+  constructor(id = 0) {
+
+    this.defaultGotData = this.gotData;
+    this.timestamp = new OrpheTimestamp();
+
+    Object.defineProperty(this, 'ORPHE_INFORMATION', { value: "01a9d6b5-ff6e-444a-b266-0be75e85c064", writable: true });
+    Object.defineProperty(this, 'ORPHE_DEVICE_INFORMATION', { value: "24354f22-1c46-430e-a4ab-a1eeabbcdfc0", writable: true });
+    Object.defineProperty(this, 'ORPHE_DATE_TIME', { value: "f53eeeb1-b2e8-492a-9673-10e0f1c29026", writable: true });
+    Object.defineProperty(this, 'ORPHE_OTHER_SERVICE', { value: "db1b7aca-cda5-4453-a49b-33a53d3f0833", writable: false });
+    Object.defineProperty(this, 'ORPHE_SENSOR_VALUES', { value: "f3f9c7ce-46ee-4205-89ac-abe64e626c0f", writable: false });
+    Object.defineProperty(this, 'ORPHE_STEP_ANALYSIS', { value: "4eb776dc-cf99-4af7-b2d3-ad0f791a79dd", writable: false });
+
+
+    // Initialize member variables
+    this.bluetoothDevice = null;
+    this.dataCharacteristic = null;// 通知を行うcharacteristicを保持する
+    this.dataChangedEventHandlerMap = {}; // イベントハンドラを保持するマップ
+    this.hashUUID = {}; // UUIDを保持するハッシュ
+    this.hashUUID_lastConnected; // 最後に接続したUUIDを保持する
+    this.id = id;
+    this.array_device_information = new DataView(new ArrayBuffer(20));// device information用の配列
+
+    /**
+     * デバッグログ（console.info）の出力を有効にするフラグです。
+     * 接続トラブル調査時に true にしてください。
+     */
+    this.debug = false;
+
+    // ── 接続安定化まわりの内部状態 ───────────────────────────────
+    // デバイス記憶: 一度接続したデバイスを localStorage に記憶し、
+    // navigator.bluetooth.getDevices() (Chrome flag: Web Bluetooth New Permissions Backend)
+    // が使える環境では選択ダイアログなしで再接続できる。
+    this._lastBluetoothDeviceStorageKey = `orphe_insole_last_bluetooth_device_${id}`;
+    this._usingRememberedBluetoothDevice = false;
+    this._rememberedBluetoothDeviceUnavailable = false;
+    // 自動再接続
+    this._autoReconnectEnabled = false;
+    this._autoReconnectInProgress = false;
+    this._autoReconnectOptions = {};
+    this._autoReconnectDevice = null;
+    this._autoReconnectDisconnectHandler = (event) => this._handleAutoReconnectDisconnect(event);
+    this._suppressAutoReconnectErrors = false;
+    this._lastAutoReconnectError = null;
+    // gattserverdisconnected 用 遅延バインドハンドラ。
+    // this.onDisconnect を直接 addEventListener すると、リスナー登録後に
+    // ユーザが onDisconnect を上書きしても古い関数が呼ばれ続けるため、
+    // 必ずこのラッパーを登録する。
+    this._onDisconnectHandler = (event) => this.onDisconnect(event);
+
+    /**
+   * デバイスインフォメーションを取得して保存しておく連想配列です。begin()を呼び出すとデバイスから値を取得して初期化されます。
+   * @property {Object} device_information - デバイス情報
+   * @property {number} device_information.battery - バッテリー残量（少ない:0、普通:1、多い:2）
+   * @property {number} device_information.mount_position - コアモジュール取り付け位置（左右情報）
+  bit0 : 左右
+  bit1 : 0(足底) / 1(足背)
+  足底 : 左、右：0=(0000 0000b), 1=(0000 0001b)、
+  足背 : 左、右：2(=0000 0010b), 3(=0000 0011b)
+   * @property {Object} device_information.range - 加速度とジャイロセンサの感度設定
+   * @property {number} device_information.range.acc - 加速度レンジ（ 2, 4, 8, 16(g)：0, 1, 2, 3）
+   * @property {number} device_information.range.gyro - ジャイロレンジ（250, 500, 1000, 2000(°/s)：0, 1, 2, 3）
+  */
+    this.device_information = '';
+
+    /**
+     * 歩容解析のデータを保存しておく連想配列です。
+     * 注意: ORPHE INSOLE のファームウェアは現状 STEP_ANALYSIS 通知に未対応のため、
+     * この値が更新されることはありません（FW対応待ち）。
+     * @property {Object} gait - 歩容解析のデータ
+     */
+    this.gait = {
+      type: 0,
+      direction: 0,
+      calorie: 0,
+      distance: 0,
+      steps: 0,
+      standing_phase_duration: 0,
+      swing_phase_duration: 0
+    }
+    /**
+     * ストライドのデータを保存しておく連想配列です。（STEP_ANALYSIS FW対応待ち）
+     */
+    this.stride = {
+      foot_angle: 0,
+      x: 0,
+      y: 0,
+      z: 0,
+      steps: 0,
+    }
+    /**
+   * プロネーションのデータを保存しておく連想配列です。（STEP_ANALYSIS FW対応待ち）
+   */
+    this.pronation = {
+      landing_impact: 0,
+      x: 0,
+      y: 0,
+      z: 0,
+      steps: 0,
+    }
+    /**
+     * 歩数カウントを保存する変数
+     */
+    this.steps_number = 0;
+
+    /**
+     * クォータニオンを保存する連想配列です。
+     * @property {Object} quat - クォータニオン
+     * @property {number} quat.w - w
+     * @property {number} quat.x - x
+     * @property {number} quat.y - y
+     * @property {number} quat.z - z
+     *
+     */
+    this.quat = {
+      w: 0.0, x: 0.0, y: 0.0, z: 0.0
+    }
+
+    /**
+     * 加速度値から2回積分で基準フレーム間の移動距離を求めた変数です
+     * @property {Object} delta - 距離
+     */
+    this.delta = {
+      x: 0.0, y: 0.0, z: 0.0
+    }
+
+    /**
+     * オイラー角を保存する連想配列です。this.quatから計算されています。
+     * @property {Object} euler - オイラー角
+     * @property {number} euler.pitch - ピッチ
+     * @property {number} euler.roll - ロール
+     * @property {number} euler.yaw - ヨー
+     */
+    this.euler = {
+      pitch: 0.0,
+      roll: 0.0,
+      yaw: 0.0
+    }
+
+    /**
+     * ジャイロセンサの値を保存する連想配列です。
+     * @property {Object} gyro - ジャイロセンサの値
+     */
+    this.gyro = {
+      x: 0.0, y: 0.0, z: 0.0
+    }
+
+    /**
+     * 加速度センサの値を保存する連想配列です。
+     * @property {Object} acc - 加速度センサの値
+     */
+    this.acc = {
+      x: 0.0, y: 0.0, z: 0.0
+    }
+
+    /**
+     * 圧力センサ（6ch）の最新値を保存する連想配列です。
+     * @property {Object} press - 圧力センサの値
+     * @property {number[]} press.values - 6チャネル分のADC生値
+     */
+    this.press = {
+      values: [0, 0, 0, 0, 0, 0]
+    }
+
+    /**
+     * ジャイロレンジに合わせて変換したジャイロセンサの値を保存する連想配列です。
+     */
+    this.converted_gyro = {
+      x: 0.0, y: 0.0, z: 0.0
+    }
+
+    /**
+     * 加速度レンジに合わせて変換した加速度センサの値を保存する連想配列です。
+     */
+    this.converted_acc = {
+      x: 0.0, y: 0.0, z: 0.0
+    }
+
+    /**
+     * データ欠損時に線形補完をするかどうかのオプション設定（beginのオプションで設定可能）。この設定は200Hz sensor_valuesのacc, gyro, quatのみに適用されます。
+     */
+    this.interpolation = {
+      enabled: false,
+      max_consecutive_missing: 1
+    }
+
+    this.history_sensor_values = {
+      acc: new FixedSizeArray(4),
+      gyro: new FixedSizeArray(4),
+      quat: new FixedSizeArray(4),
+      press: new FixedSizeArray(4), // 圧力センサの値を保持する配列
+      converted_acc: new FixedSizeArray(4),
+      converted_gyro: new FixedSizeArray(4)
+    }
+
+    this.half_round_trip_time = 0;
+
+    // Advertisement handling flags
+    this.isFirstAdvertisementReceived = false;
+
+    // メンバ変数の初期化ここまで
+    //////////////////////////
+
+  }
+
+  _log(...args) {
+    if (this.debug) console.info('[ORPHE-INSOLE]', ...args);
+  }
+
+  /**
+  * gotData()がユーザ側でオーバーライドされているかどうかを返す関数です。これを見て，デバッグモード（ORPHE TERMINAL）を有効にするかどうかを判断します。オーバーライドするとgotData()以外の関数はコールバックされません．
+  *
+ */
+  isGotDataOverridden() {
+    return this.gotData !== this.defaultGotData;
+  }
+  /**
+   * UUIDを設定する関数です。UUIDはsetup()で利用するキャラクタリスティック（DEVICE_INFORMATION, SENSOR_VALUES, STEP_ANALYSIS）の指定に利用されます。
+   * @param {string} name
+   * @param {string} serviceUUID
+   * @param {string} characteristicUUID
+   *
+   */
+  setUUID(name, serviceUUID, characteristicUUID) {
+    this.hashUUID[name] = { 'serviceUUID': serviceUUID, 'characteristicUUID': characteristicUUID };
+  }
+  /**
+   * 最初に必要な初期化処理メソッドです。利用するキャラクタリスティック（DEVICE_INFORMATION, SENSOR_VALUES）の指定の他、オプションを指定することができます。通常利用では引数を省略して 今後の機能拡張を見据えたメソッドなので、基本的にはsetup()で呼び出せば良いです。
+   * @param {string[]} [string[]=["DEVICE_INFORMATION","DATE_TIME", "SENSOR_VALUES"]] DEVICE_INFORMATION, DATE_TIME, SENSOR_VALUES,
+   * @param {object} [options = {interpolation}] - interpolationは未実装
+   *
+   */
+  setup(names = ['DEVICE_INFORMATION', 'DATE_TIME', 'SENSOR_VALUES'],
+    options = {
+      interpolation: {
+        enabled: false, // 線形補間の有効化/無効化
+        max_consecutive_missing: 1 // 線形補間する最大の連続欠損数
+      }
+    }
+  ) {
+
+    this.interpolation = options.interpolation;
+    this.history_sensor_values.acc.setSize(this.interpolation.max_consecutive_missing);
+    this.history_sensor_values.gyro.setSize(this.interpolation.max_consecutive_missing);
+    this.history_sensor_values.quat.setSize(this.interpolation.max_consecutive_missing);
+    this.history_sensor_values.converted_acc.setSize(this.interpolation.max_consecutive_missing);
+    this.history_sensor_values.converted_gyro.setSize(this.interpolation.max_consecutive_missing);
+
+    for (const name of names) {
+      if (name == 'DEVICE_INFORMATION') {
+        this.setUUID(name, this.ORPHE_INFORMATION, this.ORPHE_DEVICE_INFORMATION);
+      }
+      else if (name == 'DATE_TIME') {
+        this.setUUID(name, this.ORPHE_INFORMATION, this.ORPHE_DATE_TIME);
+      }
+      else if (name == 'SENSOR_VALUES') {
+        this.setUUID(name, this.ORPHE_OTHER_SERVICE, this.ORPHE_SENSOR_VALUES);
+      }
+    }
+  }
+
+  /**
+   *  begin BLE connection
+   * SENSOR_VALUESのセンサー値の取得を開始します。
+   * @param {string} [notification_type="SENSOR_VALUES"] SENSOR_VALUES
+   * @param {object} [options]
+   * @param {number} [options.streamingMode=4] データストリーミングモード（1, 3, 4）
+   * @param {boolean} [options.autoReconnect=false] 切断時の自動再接続を有効化
+   * @param {number} [options.reconnectIntervalMs=3000] 再接続試行の間隔
+   * @param {number} [options.reconnectMaxAttempts=120] 再接続の最大試行回数
+   * @async
+   * @return {Promise<string>}
+   *
+   */
+  async begin(str_type = 'SENSOR_VALUES', options = {}) {
+    if (typeof str_type === 'object' && str_type !== null) {
+      options = str_type;
+      str_type = 'SENSOR_VALUES';
+    }
+    if (str_type == 'RAW') {
+      str_type = 'SENSOR_VALUES';
+      console.warn("RAW is deprecated. Please use SENSOR_VALUES instead.");
+    }
+    if (str_type != 'SENSOR_VALUES') {
+      console.warn(`${str_type} is not supported on ORPHE INSOLE. SENSOR_VALUES will be used instead.`);
+      str_type = 'SENSOR_VALUES';
+    }
+    const streamingMode = options.streamingMode ?? options.dataStreamingMode ?? 4;
+    const autoReconnect = options.autoReconnect ?? false;
+
+    this.notification_type = str_type;
+    if (autoReconnect) {
+      this._enableAutoReconnect(str_type, options);
+    } else if (!this._autoReconnectInProgress) {
+      this._disableAutoReconnect();
+    }
+
+    try {
+      await this.getDeviceInformation();
+
+      // データストリーミングモードは 100Hzのジャイロ、加速度、圧力、クオータニオンに設定
+      /*
+      0x01 : リアルタイム(クォータニオン、ジャイロ、加速度)
+      0x03 : リアルタイム(ジャイロ、加速度、圧力 200Hz相当)※インソールのみ対応
+      0x04 : リアルタイム(ジャイロ、加速度、圧力、クォータニオン 100Hz相当)※インソールのみ対応
+      */
+      await this.setDataStreamingMode(streamingMode);
+
+      // DateTimeキャラクタリスティックを利用して時刻を同期する．現在のPC時間とデータ取得にかかる統計値からその分コアの時計を進めておく．
+      await this.syncCoreTime();
+
+      await this.startNotify('SENSOR_VALUES');
+
+      // 接続成功: デバイスを記憶し、自動再接続用の切断検知を仕込む
+      if (this.bluetoothDevice) {
+        this._rememberBluetoothDevice(this.bluetoothDevice);
+        this._attachAutoReconnectDisconnectHandler(this.bluetoothDevice);
+      }
+      return "done begin(); SENSOR VALUES";
+    } catch (error) {
+      this._reportError(error);
+      throw error;
+    }
+  }
+
+  /**
+   * stop and disconnect GATT connection
+   */
+  stop() {
+    this.reset();
+  }
+
+
+  // ── エラーレポート ───────────────────────────────────────────
+  // 自動再接続の試行中は onError を逐一発火させず、最後のエラーとして保持する
+  _reportError(error) {
+    if (this._suppressAutoReconnectErrors) {
+      this._lastAutoReconnectError = error;
+      return;
+    }
+    this.onError(error);
+  }
+
+  // ── 自動再接続 ──────────────────────────────────────────────
+  _enableAutoReconnect(str_type, options = {}) {
+    this._autoReconnectEnabled = true;
+    this._autoReconnectOptions = Object.assign({}, options, { autoReconnect: true });
+  }
+
+  _disableAutoReconnect() {
+    this._autoReconnectEnabled = false;
+    this._autoReconnectInProgress = false;
+    this._suppressAutoReconnectErrors = false;
+  }
+
+  _autoReconnectIntervalMs() {
+    const interval = Number(this._autoReconnectOptions.reconnectIntervalMs);
+    return Number.isFinite(interval) && interval >= 0 ? interval : 3000;
+  }
+
+  _autoReconnectMaxAttempts() {
+    const attempts = Number(this._autoReconnectOptions.reconnectMaxAttempts);
+    return Number.isFinite(attempts) && attempts > 0 ? attempts : 120;
+  }
+
+  _autoReconnectWait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  _attachAutoReconnectDisconnectHandler(device) {
+    if (!device?.addEventListener) return;
+    if (this._autoReconnectDevice === device) return;
+    if (this._autoReconnectDevice?.removeEventListener) {
+      try {
+        this._autoReconnectDevice.removeEventListener('gattserverdisconnected', this._autoReconnectDisconnectHandler);
+      } catch (_) { }
+    }
+    this._autoReconnectDevice = device;
+    device.addEventListener('gattserverdisconnected', this._autoReconnectDisconnectHandler);
+  }
+
+  async _restoreAutoReconnectDevice() {
+    if (this.bluetoothDevice) return true;
+    const rememberedDevice = await this._requestRememberedBluetoothDevice();
+    if (!rememberedDevice) return false;
+    this.bluetoothDevice = rememberedDevice;
+    this._usingRememberedBluetoothDevice = true;
+    this.bluetoothDevice.addEventListener('gattserverdisconnected', this._onDisconnectHandler);
+    this._attachAutoReconnectDisconnectHandler(this.bluetoothDevice);
+    this.onScan(this.bluetoothDevice.name);
+    return true;
+  }
+
+  _handleAutoReconnectDisconnect() {
+    if (!this._autoReconnectEnabled || this._autoReconnectInProgress) return;
+    this._startAutoReconnect();
+  }
+
+  async _startAutoReconnect() {
+    if (!this._autoReconnectEnabled || this._autoReconnectInProgress) return;
+
+    this._autoReconnectInProgress = true;
+    const startedAt = Date.now();
+    const maxAttempts = this._autoReconnectMaxAttempts();
+    const intervalMs = this._autoReconnectIntervalMs();
+    let lastError = null;
+
+    for (let attempt = 1; this._autoReconnectEnabled && attempt <= maxAttempts; attempt++) {
+      this.onReconnectAttempt({ attempt, maxAttempts, intervalMs });
+
+      try {
+        const hasDevice = await this._restoreAutoReconnectDevice();
+        if (!hasDevice) throw new Error('Last connected Bluetooth device not found. Please reconnect manually.');
+
+        this._lastAutoReconnectError = null;
+        this._suppressAutoReconnectErrors = true;
+        const result = await this.begin(this.notification_type, this._autoReconnectOptions);
+        this._suppressAutoReconnectErrors = false;
+
+        if (result) {
+          this._autoReconnectInProgress = false;
+          this.onReconnectSuccess({
+            attempt,
+            maxAttempts,
+            elapsedMs: Date.now() - startedAt,
+            result,
+          });
+          return;
+        }
+
+        lastError = this._lastAutoReconnectError || new Error('Auto reconnect attempt failed.');
+      } catch (error) {
+        this._suppressAutoReconnectErrors = false;
+        lastError = error;
+      }
+
+      if (!this._autoReconnectEnabled || attempt >= maxAttempts) break;
+      await this._autoReconnectWait(intervalMs);
+    }
+
+    this._autoReconnectInProgress = false;
+    const error = lastError || new Error('Auto reconnect failed.');
+    this.onReconnectFailed({ maxAttempts, elapsedMs: Date.now() - startedAt, error });
+    this._reportError(error);
+  }
+
+  // ── デバイス記憶（選択ダイアログなしの再接続） ─────────────────
+  /**
+   * 前回デバイスの記憶を使わず、必ずブラウザのBLE選択ダイアログを表示する。
+   * 接続済みINSOLEから別INSOLEへ手動で切り替える場合に利用する。
+   * @param {string} uuid
+   */
+  selectBluetoothDevice(uuid = 'DEVICE_INFORMATION') {
+    this._disableAutoReconnect();
+    this.forgetLastBluetoothDevice();
+    if (this.bluetoothDevice?.gatt?.connected) {
+      try { this.bluetoothDevice.gatt.disconnect(); } catch (_) { }
+    }
+    this.bluetoothDevice = null;
+    this.dataCharacteristic = null;
+    this._usingRememberedBluetoothDevice = false;
+    this._rememberedBluetoothDeviceUnavailable = false;
+    return this.requestDevice(uuid);
+  }
+
+  /**
+   * 最後に接続成功した Bluetooth デバイス情報を忘れる。
+   * 次回 begin() 時に手動選択ダイアログから別デバイスへ切り替えたい場合に利用する。
+   */
+  forgetLastBluetoothDevice() {
+    this._rememberedBluetoothDeviceUnavailable = false;
+    try { localStorage.removeItem(this._lastBluetoothDeviceStorageKey); } catch (_) { }
+  }
+
+  _rememberBluetoothDevice(device) {
+    if (!device) return;
+    this._rememberedBluetoothDeviceUnavailable = false;
+    try {
+      localStorage.setItem(this._lastBluetoothDeviceStorageKey, JSON.stringify({
+        deviceId: this.id,
+        bluetoothId: device.id || '',
+        bluetoothName: device.name || '',
+        lastConnectedAt: Date.now(),
+      }));
+    } catch (_) { }
+  }
+
+  _getLastBluetoothDeviceInfo() {
+    try {
+      const raw = localStorage.getItem(this._lastBluetoothDeviceStorageKey);
+      if (!raw) return null;
+      const info = JSON.parse(raw);
+      if (!info || (!info.bluetoothId && !info.bluetoothName)) return null;
+      return info;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  _findLastBluetoothDevice(devices) {
+    const info = this._getLastBluetoothDeviceInfo();
+    return this._findBluetoothDevice(devices, info);
+  }
+
+  _findBluetoothDevice(devices, info) {
+    if (!info || !Array.isArray(devices)) return null;
+    const bluetoothId = info.bluetoothId || info.id || '';
+    const bluetoothName = info.bluetoothName || info.name || '';
+
+    if (bluetoothId) {
+      const matchedById = devices.find(device => device.id === bluetoothId);
+      if (matchedById) return matchedById;
+    }
+
+    if (bluetoothName) {
+      const matchedByName = devices.filter(device => device.name === bluetoothName);
+      if (matchedByName.length === 1) return matchedByName[0];
+    }
+
+    return null;
+  }
+
+  async _requestRememberedBluetoothDevice() {
+    if (!navigator.bluetooth?.getDevices) return null;
+    try {
+      const devices = await navigator.bluetooth.getDevices();
+      return this._findLastBluetoothDevice(devices);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /**
+   * Reset Analysis logs in the core module.
+   */
+  resetAnalysisLogs() {
+    const data = new Uint8Array([0x04]);
+    this.write('DEVICE_INFORMATION', data);
+  }
+  scan(uuid, options = {}) {
+    this._log('scan()', {
+      uuid,
+      hasBluetoothDevice: !!this.bluetoothDevice,
+      hasNavigatorBluetooth: typeof navigator !== 'undefined' && !!navigator.bluetooth,
+      options
+    });
+    if (this.bluetoothDevice) return Promise.resolve();
+
+    const useRememberedDevice = !options.forceDeviceSelection &&
+      !this._rememberedBluetoothDeviceUnavailable &&
+      this._getLastBluetoothDeviceInfo();
+    return (useRememberedDevice ? this._requestRememberedBluetoothDevice() : Promise.resolve(null))
+      .then(device => {
+        if (!device) return this.requestDevice(uuid);
+        this.bluetoothDevice = device;
+        this._usingRememberedBluetoothDevice = true;
+        this.bluetoothDevice.addEventListener('gattserverdisconnected', this._onDisconnectHandler);
+        this.onScan(this.bluetoothDevice.name);
+      })
+      .catch(error => {
+        this._reportError(error);
+        throw error;
+      });
+  }
+  /**
+   * Execute requestDevice()
+   * @param {string} uuid
+   *
+   */
+  requestDevice(uuid) {
+    let options = {
+      /*
+      ORPHE insole module name: INS
+      一部のINSOLE firmwareはadvertisementにservice UUIDを載せないため、
+      chooserではINSのnamePrefixで候補を絞り、optionalServicesで接続後に必要なserviceへアクセスします。
+      */
+      filters: [
+        { namePrefix: 'INS' }
+      ],
+      acceptAllDevices: false,
+      optionalServices: [
+        this.ORPHE_INFORMATION,
+        this.ORPHE_OTHER_SERVICE
+      ],
+      optionalManufacturerData: [
+        0x0000
+      ]
+    };
+
+    this._log('requestDevice() before navigator.bluetooth.requestDevice', {
+      uuid,
+      options,
+      hasNavigatorBluetooth: typeof navigator !== 'undefined' && !!navigator.bluetooth,
+      isSecureContext: typeof window !== 'undefined' ? window.isSecureContext : undefined,
+      href: typeof window !== 'undefined' ? window.location.href : undefined
+    });
+    return navigator.bluetooth.requestDevice(options)
+      .then(device => {
+        this.bluetoothDevice = device;
+        this._usingRememberedBluetoothDevice = false;
+        this._rememberedBluetoothDeviceUnavailable = false;
+        this.bluetoothDevice.addEventListener('gattserverdisconnected', this._onDisconnectHandler);
+        this._log('requestDevice() selected device', {
+          uuid,
+          deviceName: this.bluetoothDevice.name,
+          deviceId: this.bluetoothDevice.id
+        });
+        this.onScan(this.bluetoothDevice.name);
+
+        // await this.autoStartWatchingAdvertisements();
+      });
+  }
+
+  /**
+   * アドバタイズメント監視を自動開始（機能が利用可能な場合のみ）
+   */
+  async autoStartWatchingAdvertisements() {
+    // 機能が利用可能かチェック
+    if (!this.bluetoothDevice) {
+      return;
+    }
+
+    // watchAdvertisementsがサポートされているかチェック
+    if (!navigator.bluetooth || !BluetoothDevice.prototype.watchAdvertisements) {
+      console.log('Advertisement monitoring not available - Chrome experimental features may be disabled');
+      return;
+    }
+
+    if (!this.bluetoothDevice.watchAdvertisements) {
+      console.warn('watchAdvertisements is not supported on this device/browser');
+      return;
+    }
+
+    // アドバタイズメント監視を自動開始
+    await this.startWatchingAdvertisements();
+  }
+
+  /**
+   * アドバタイズメントデータの監視を開始
+   */
+  startWatchingAdvertisements() {
+    if (!this.bluetoothDevice) {
+      console.error('Bluetooth device not available');
+      return;
+    }
+
+    // watchAdvertisementsがサポートされているかチェック
+    if (!this.bluetoothDevice.watchAdvertisements) {
+      console.warn('watchAdvertisements is not supported on this device/browser');
+      return;
+    }
+
+    // アドバタイズメントイベントリスナーを追加
+    this.bluetoothDevice.addEventListener('advertisementreceived', (event) => {
+      this.onAdvertisementReceived(event);
+    });
+
+    // アドバタイズメント監視を開始
+    this.bluetoothDevice.watchAdvertisements()
+      .then(() => {
+        console.log('Started watching advertisements for', this.bluetoothDevice.name);
+      })
+      .catch(error => {
+        console.error('Error starting advertisement watch:', error);
+      });
+  }
+
+  /**
+   * アドバタイズメントデータ受信時のコールバック
+   * @param {BluetoothAdvertisingEvent} event
+   */
+  onAdvertisementReceived(event) {
+    this._log('Advertisement Received', {
+      name: event.device.name,
+      rssi: event.rssi,
+      txPower: event.txPower
+    });
+
+    const dv = event.manufacturerData.get(0x0000);
+
+    // カスタムコールバックがあれば呼び出し
+    if (this.gotStatus) {
+      const status = {
+        name: event.device.name,
+        rssi: event.rssi,
+        txPower: event.txPower,
+        id: event.device.id,
+        battery: dv.getUint8(14),
+        model_type: dv.getUint8(5),
+        mounting_position: dv.getUint8(6),
+        human_activity_recognition: dv.getUint8(7),
+        version: `${dv.getUint8(15)}.${dv.getUint8(16)}.${dv.getUint8(17)}`
+      }
+      this.gotStatus(status);
+    }
+  }
+
+  /**
+   * アドバタイズメント監視を停止
+   */
+  stopWatchingAdvertisements() {
+    if (this.bluetoothDevice) {
+      this.bluetoothDevice.removeEventListener('advertisementreceived', this.onAdvertisementReceived);
+      console.log('Stopped watching advertisements');
+    }
+  }
+
+  /**
+   * GATT通信を始めるための関数。read, write, startNotify, stopNotifyが呼び出されるとscanと一緒に呼び出されます。
+   * @param {string} uuid
+   *
+   */
+  connectGATT(uuid) {
+    this._log('connectGATT() start', {
+      uuid,
+      hasBluetoothDevice: !!this.bluetoothDevice,
+      gattConnected: !!(this.bluetoothDevice && this.bluetoothDevice.gatt && this.bluetoothDevice.gatt.connected),
+      hasDataCharacteristic: !!this.dataCharacteristic,
+      lastConnected: this.hashUUID_lastConnected
+    });
+    if (!this.bluetoothDevice) {
+      var error = "No Bluetooth Device";
+      this._reportError(error);
+      return Promise.reject(error);
+    }
+    if (this.bluetoothDevice.gatt.connected && this.dataCharacteristic) {
+      if (this.hashUUID_lastConnected == uuid)
+        return Promise.resolve();
+    }
+    this.hashUUID_lastConnected = uuid;
+
+    return this.bluetoothDevice.gatt.connect()
+      .then(server => {
+        return server.getPrimaryService(this.hashUUID[uuid].serviceUUID);
+      })
+      .then(service => {
+        return service.getCharacteristic(this.hashUUID[uuid].characteristicUUID);
+      })
+      .then(characteristic => {
+        this.dataCharacteristic = characteristic;
+        this.onConnectGATT(uuid);
+        this.onConnect(uuid);
+
+        // アドバタイズメント監視を自動開始（機能が利用可能な場合のみ）
+        // this.autoStartWatchingAdvertisements();
+      })
+      .catch(error => {
+        this._reportError(error);
+        // 記憶していたデバイスが見つからない/権限切れの場合は記憶経由の接続を
+        // 一旦諦め、次回 scan() でユーザに選択ダイアログを出す
+        if (this._usingRememberedBluetoothDevice) {
+          this._rememberedBluetoothDeviceUnavailable = true;
+          this._usingRememberedBluetoothDevice = false;
+          this.bluetoothDevice = null;
+          this.dataCharacteristic = null;
+        }
+        throw error;
+      });
+  }
+  /**
+   * サーバからのデータを受信したときに呼び出される関数です。この関数は、characteristicvaluechangedイベントが発生したときに呼び出されます。
+   * @param {function} self
+   * @param {string} uuid
+   *
+   */
+  dataChanged(self, uuid) {
+    return function (event) {
+      self.onRead(event.target.value, uuid);
+    }
+  }
+  /**
+   * サーバからデータを読み込む。notificationからはonReadで呼び出されるので、この関数を利用するのは DEVICE_INFORMATION characteristicのみです。
+   * @param {string} uuid DEVICE_INFORMATION
+   *
+   */
+  read(uuid) {
+    return (this.scan(uuid))
+      .then(() => {
+        return this.connectGATT(uuid);
+      })
+      .then(() => {
+        return this.dataCharacteristic.readValue();
+      })
+      .catch(error => {
+        this._reportError(error);
+        throw error; // エラーを再スローして、呼び出し側でキャッチできるようにする
+      });
+  }
+  /**
+   * write data to the BLE device。実際にwriteを利用するのは DEVICE_INFORMATION characteristicのみです。
+   * @param {string} uuid DEVICE_INFORMATION, SENSOR_VALUES, STEP_ANALYSIS
+   * @param {dataView} array_value write bytes
+   *
+   */
+  write(uuid, array_value) {
+    return (this.scan(uuid))
+      .then(() => {
+        return this.connectGATT(uuid);
+      })
+      .then(() => {
+        const data = Uint8Array.from(array_value);
+        return this.dataCharacteristic.writeValue(data);
+      })
+      .then(() => {
+        this.onWrite(uuid);
+      })
+      .catch(error => {
+        this._reportError(error);
+        throw error;
+      });
+  }
+  /**
+   * Start Notification
+   * @param {string} uuid
+   *
+   */
+  startNotify(uuid) {
+    return this.scan(uuid)
+      .then(() => this.connectGATT(uuid))
+      .then(() => this.dataCharacteristic.startNotifications())
+      .then(() => {
+        this.dataChangedEventHandlerMap[uuid] = this.dataChanged(this, uuid);
+        this.dataCharacteristic.addEventListener('characteristicvaluechanged', this.dataChangedEventHandlerMap[uuid]);
+        this.onStartNotify(uuid);
+      })
+      .catch(error => {
+        console.error('startNotify: Error : ' + error);
+        this._reportError(error);
+        throw error;
+      });
+  }
+  /**
+   * Stop Notification
+   * @param {string} uuid
+   *
+   */
+  stopNotify(uuid) {
+    return this.scan(uuid) // BLEデバイスのスキャンを開始します。
+      .then(() => {
+        return this.connectGATT(uuid); // GATTサーバーに接続します。
+      })
+      .then(() => {
+        // stopNotificationsメソッドを呼び出してNotificationを停止します。
+        // このメソッドはPromiseを返すため、その完了を待つ必要があります。
+        return this.dataCharacteristic.stopNotifications();
+      })
+      .then(() => {
+        // イベントハンドラを解除
+        if (this.dataChangedEventHandlerMap[uuid]) {
+          this.dataCharacteristic.removeEventListener(
+            'characteristicvaluechanged',
+            this.dataChangedEventHandlerMap[uuid]
+          );
+          // 登録されたハンドラをマップから削除
+          delete this.dataChangedEventHandlerMap[uuid];
+        }
+        this.onStopNotify(uuid);
+      })
+      .catch(error => {
+        this._reportError(error);
+      });
+
+  }
+  isConnected() {
+    if (!this.bluetoothDevice) {
+      return false;
+    }
+    return this.bluetoothDevice.gatt.connected;
+  }
+
+  /**
+   * BLEデバイスとの接続を切断します。デバイス接続をマニュアルで切断する場合には reset() を利用してください。切断だけでなくクラス内のメンバ変数もクリア初期化する必要があり、reset()を利用するとそれらの処理が行われます。
+   *
+   */
+  disconnect() {
+    if (!this.bluetoothDevice) {
+      var error = "No Bluetooth Device";
+      this._reportError(error);
+      return;
+    }
+
+    // アドバタイズメント監視を停止
+    this.stopWatchingAdvertisements();
+
+    if (this.bluetoothDevice.gatt.connected) {
+      this.bluetoothDevice.gatt.disconnect();
+    } else {
+      var error = "Bluetooth Device is already disconnected";
+      this._reportError(error);
+      return;
+    }
+  }
+  /**
+   * this.device_informationの連想配列形式でデータを渡すことで、コアモジュールのデバイス設定ができます。
+   * 注意: ORPHE INSOLE の現行ファームウェアでは未対応です。
+   * @param {object} obj
+   */
+  setDeviceInformation(obj) {
+    // この機能は insole では未対応とします。
+    // const senddata = new Uint8Array([0x01, obj.lr, obj.led_brightness, 0, obj.rec_auto_run, obj.time01, obj.time02, obj.range.acc, obj.range.gyro]);
+    // this.write('DEVICE_INFORMATION', senddata);
+    const error = new Error('setDeviceInformation is not supported on ORPHE INSOLE.');
+    console.warn(error.message);
+    this._reportError(error);
+  }
+
+  /**
+   * Sets the data streaming mode for the device.
+   *
+   * @param {number} mode - The streaming mode to set. Should be a valid mode value recognized by the device.
+   * @returns {Promise<void>}
+   */
+  async setDataStreamingMode(mode = 4) {
+    const normalizedMode = Number(mode);
+    const supportedModes = [1, 3, 4];
+    if (!Number.isInteger(normalizedMode) || !supportedModes.includes(normalizedMode)) {
+      throw new Error(`Invalid ORPHE INSOLE data streaming mode: ${mode}. Use 1, 3, or 4.`);
+    }
+    const data = new Uint8Array([0x0D, normalizedMode]);
+    await this.write('DEVICE_INFORMATION', data);
+    this.streaming_mode = normalizedMode;
+  }
+
+
+  /**
+   * COREモジュールの時刻を PCの時刻 + random_trip_time/2 で同期します。
+   *
+   * @param {number}[n=3] n - 平均値算出のためのサンプル数
+   * @return {object} {sum_round_trip_time, average_round_trip_time, standard_time, adjusted_time, round_trip_times}
+   */
+  async syncCoreTime(n = 3) {
+    let average_round_trip_time = 0;
+    let sum_round_trip_time = 0;
+    let core_time;
+    let round_trip_times = [];
+    for (let i = 0; i < n; i++) {
+      core_time = await this.getDateTime();
+      sum_round_trip_time += core_time.round_trip_time;
+      round_trip_times.push(core_time.round_trip_time);
+    }
+    average_round_trip_time = sum_round_trip_time / n;
+    const now = new Date();
+    const standard_time = now.getTime();
+    const adjusted_time = parseInt(standard_time + Math.round(average_round_trip_time / 2));
+    core_time.date.setTime(adjusted_time);
+
+    await this.setDateTime(core_time.date);
+    this.half_round_trip_time = Math.round(average_round_trip_time / 2);
+    return { sum_round_trip_time, average_round_trip_time, standard_time, adjusted_time, round_trip_times };
+
+  }
+  /**
+   * [YY, MM, DD, hh, mm, ss, (sub)ss]の配列を渡すことで、コアモジュールの日時設定ができます。
+   */
+  async setDateTime(set_date) {
+    const array = new Uint8Array(7);
+    array[0] = set_date.getFullYear() - 2000;
+    array[1] = set_date.getMonth() + 1;
+    array[2] = set_date.getDate();
+    array[3] = set_date.getHours();
+    array[4] = set_date.getMinutes();
+    array[5] = set_date.getSeconds();
+    array[6] = parseInt(set_date.getMilliseconds() / 10);
+    const senddata = new Uint8Array([array[0], array[1], array[2], array[3], array[4], array[5], array[6]]);
+    await this.write('DATE_TIME', senddata);
+  }
+
+  /**
+   * 接続情報をクリアします。
+   */
+  clear() {
+    this.bluetoothDevice = null;
+    this.dataCharacteristic = null;
+    this.isFirstAdvertisementReceived = false; // フラグをリセット
+    this.onClear();
+  }
+  /**
+   * reset(disconnect & clear)
+   * マニュアル切断の意思表示とみなし、自動再接続も無効化します。
+   */
+  reset() {
+    this._disableAutoReconnect();
+    this.disconnect(); //disconnect() is not Promise Object
+    this.clear();
+    this.onReset();
+  }
+
+
+
+
+
+  // Readコールバック
+  /**
+   * Incoming byte callback function. コアモジュールから送信されるデータを受信するコールバック関数です。それぞれのUUIDに対応するデータを正しく整形して対応するコールバック関数に渡します。ユーザはコールバック関数を手元のコードでオーバーライドして利用します。gotData()がユーザによってオーバーライドされている場合は、gotData以外のnotifyに伴うコールバック関数はすべて呼び出されないことに注意してください。
+   * @param {dataView} data incoming bytes
+   * @param {string} uuid
+   */
+  onRead(data, uuid) {
+    let ret = this.timestamp.getHz();
+    if (ret > 0) this.gotBLEFrequency(ret);
+
+    // 生データモニタリングの場合はそのままデータをgotDataで渡して、returnする（データ欠損以外の他の処理は行わない）
+    if (this.isGotDataOverridden() == true) {
+      this.gotData(data, uuid);
+      // データ欠損チェック
+      if (uuid == 'SENSOR_VALUES') {
+        // 50,55,56がリアルタームデータ取得時の先頭ヘッダ
+        if (data.getUint8(0) == 50 || data.getUint8(0) == 55 || data.getUint8(0) == 56) {
+          if (this.serial_number) {
+            const serial_number_prev = this.serial_number;
+            this.serial_number = data.getUint16(1);
+
+            // データ欠損が生じた場合
+            if (this.serial_number - serial_number_prev != 1) {
+
+              // 線形補完を有効にしている場合
+              if (this.interpolation.enabled == true) {
+
+              }
+              // ユーザ用コールバック関数の呼び出し
+              this.lostData(this.serial_number, serial_number_prev);
+
+            }
+
+          }
+          else {
+            this.serial_number = data.getUint16(1);
+          }
+        }
+      }
+      return;
+    }
+
+    // デバイス情報Readの場合
+    if (uuid == 'DEVICE_INFORMATION') {
+    }
+    else if (uuid == 'SENSOR_VALUES') {
+      const parsed = parseInsoleSensorValues(data);
+      if (!parsed) {
+        console.warn("SENSOR VALUES: Data length is not 104");
+        return;
+      }
+
+      // データ欠損チェック
+      if (this.serial_number) {
+        const serial_number_prev = this.serial_number;
+        this.serial_number = parsed.serial_number;
+        if (this.serial_number - serial_number_prev != 1) {
+          this.lostData(this.serial_number, serial_number_prev);
+        }
+      }
+      else {
+        this.serial_number = parsed.serial_number;
+      }
+
+      for (const sample of parsed.samples) {
+        if (sample.quat) {
+          this.quat = sample.quat;
+          this.history_sensor_values.quat.push(this.quat);
+        }
+        if (sample.gyro) {
+          this.gyro = sample.gyro;
+          this.history_sensor_values.gyro.push(this.gyro);
+        }
+        if (sample.acc) {
+          this.acc = sample.acc;
+          this.history_sensor_values.acc.push(this.acc);
+        }
+        if (sample.press) {
+          this.press = sample.press;
+          this.history_sensor_values.press.push(this.press);
+        }
+        if (sample.converted_gyro) {
+          this.converted_gyro = sample.converted_gyro;
+          this.history_sensor_values.converted_gyro.push(this.converted_gyro);
+        }
+        if (sample.converted_acc) {
+          this.converted_acc = sample.converted_acc;
+          this.history_sensor_values.converted_acc.push(this.converted_acc);
+        }
+
+        if (sample.quat && typeof Quaternion !== 'undefined') {
+          let q = new Quaternion(this.quat.w, this.quat.x, this.quat.y, this.quat.z);
+          this.euler = q.toEuler();
+        }
+
+        if (parsed.header == 50) {
+          this.gotAcc(this.acc);
+          this.gotQuat(this.quat);
+          this.gotGyro(this.gyro);
+          this.gotConvertedAcc(this.converted_acc);
+          this.gotConvertedGyro(this.converted_gyro);
+          if (sample.quat && typeof Quaternion !== 'undefined') this.gotEuler(this.euler);
+        }
+        else if (parsed.header == 55) {
+          this.gotAcc(this.acc);
+          this.gotGyro(this.gyro);
+          this.gotConvertedAcc(this.converted_acc);
+          this.gotConvertedGyro(this.converted_gyro);
+          this.gotPress(this.press);
+        }
+        else if (parsed.header == 56) {
+          this.gotQuat(this.quat);
+          if (sample.quat && typeof Quaternion !== 'undefined') this.gotEuler(this.euler);
+          this.gotAcc(this.acc);
+          this.gotGyro(this.gyro);
+          this.gotConvertedAcc(this.converted_acc);
+          this.gotConvertedGyro(this.converted_gyro);
+          this.gotPress(this.press);
+        }
+      }
+
+    }
+  }
+
+  /**
+   * Date Timeを取得する
+   * 0	year	0-255	西暦から2000を引いた数
+   * 1	month
+   * 2	day
+   * 3	hour
+   * 4	minute
+   * 5	second
+   * 6	subsecond
+   *
+   * @returns {Promise<object>} date_timeを連想配列形式{timestamp, data,round_trip_time}で返す。dataにはCOREから直接送信されてきたdataviewが格納されている。round_trip_timeはデータを取得にかかった時間[ms]。
+   */
+  async getDateTime() {
+    return new Promise((resolve, reject) => {
+      const startTime = performance.now(); // 関数開始時の時間を取得
+      this.read('DATE_TIME').then((data) => {
+        const endTime = performance.now(); // データの取得が完了したので，時間を記録
+        const date = new Date(
+          data.getUint8(0) + 2000,
+          data.getUint8(1),
+          data.getUint8(2),
+          data.getUint8(3),
+          data.getUint8(4),
+          data.getUint8(5),
+          data.getUint8(6) * 10 // 10ms単位で送られてくる
+        );
+        const elapsedTime = endTime - startTime; // 経過時間を計算
+        this.date_time = {
+          date: date,
+          raw: data,
+          round_trip_time: Math.floor(elapsedTime)
+        };
+        resolve(this.date_time);
+      }).catch(error => {  // ダイアログのキャンセルはそのまま閉じる
+        const message = error && error.message ? error.message : String(error);
+        if (error && error.name === 'NotFoundError') {
+          this._log('requestDevice chooser cancelled', { message });
+        } else {
+          console.log('Error: ' + error);
+        }
+        this._reportError(error);
+        reject(error);
+      });
+    });
+  }
+
+  /**
+   * 呼び出すと現在のデバイス設定を取得します。連想配列形式でリターンされます。asyncに対応させているので、awaitを利用して呼び出すことをおすすめします。
+   * @returns {Promise<object>} device_informationを連想配列形式で返す
+   */
+  async getDeviceInformation() {
+    return new Promise((resolve, reject) => {
+      this.read('DEVICE_INFORMATION').then((data) => {
+        if (!data) {
+          const error = new Error('No data received from DEVICE_INFORMATION');
+          console.error('Error: ' + error.message);
+          this._reportError(error);
+          reject(error);
+          return;
+        }
+
+        this.device_information = {
+          battery: data.getUint8(0),
+          mount_position: data.getUint8(1),
+          range: {
+            acc: data.getUint8(8),
+            gyro: data.getUint8(9)
+          },
+          raw: data
+        }
+        resolve(this.device_information);
+      }).catch(error => {  // ダイアログのキャンセルはそのまま閉じる
+        const message = error && error.message ? error.message : String(error);
+        if (error && error.name === 'NotFoundError') {
+          this._log('requestDevice chooser cancelled', { message });
+        } else {
+          console.log('Error: ' + error);
+        }
+        this._reportError(error);
+        reject(error);
+      });
+    });
+  }
+
+
+  //--------------------------------------------------
+  //一般開発ユーザからアクセス可能な関数のプロトタイプ定義
+  /**
+   * ORPHE TERMINAL用に作成した関数。onReadで受け取ったデータをそのまま渡す。このメソッドがユーザ側でオーバーライドされると、その他のnotifyに伴うコールバック関数（gotAcc等）はすべて呼び出されなくなるので注意してください。dataview形式なので、取り扱い方法については ORPHE TERMINALのソースを参照するとよい。
+   * @param {dataview} data onReadで取得したすべてのデータ
+   */
+  gotData(data) { }
+
+
+  /**
+   * Handles the received status.
+   * @param {Object} status - The status object containing device advertisement information.
+   * @param {string} status.name - デバイス名
+   * @param {number} status.rssi - 受信信号強度 (dBm)
+   * @param {number} status.txPower - 送信出力 (dBm)
+   * @param {string} status.id - デバイスID
+   * @param {number} status.battery - バッテリー残量
+   * @param {number} status.model_type - モデルタイプ
+   * @param {number} status.mounting_position - 取り付け位置
+   * @param {number} status.human_activity_recognition - 人間活動認識
+   * @param {string} status.version - ファームウェアバージョン (例: "1.2.3")
+   */
+  gotStatus(status) {
+  }
+  /**
+   * コアモジュールの圧力情報を取得する
+   * @param {Object} press {values[],timestamp,packet_number} 圧力の取得
+   */
+  gotPress(press) { }
+
+  /**
+   * コアモジュールのクオータニオン情報を取得する
+   * @param {Object} quat {w,x,y,z} クオータニオンの取得
+   */
+  gotQuat(quat) { }
+  /**
+   * ジャイロ（x,y,zの角速度）を取得する
+   * @param {Object} gyro {x,y,z} ジャイロの取得
+   */
+  gotGyro(gyro) { }
+  /**
+   * 加速度を取得する。加速度レンジに応じて変換された値がほしい場合は、gotConvertedAccを利用すること
+   * 対応CharacteristicはSENSOR_VALUES
+   * @param {Object} acc {x,y,z} 加速度の取得
+   */
+  gotAcc(acc) { }
+  /**
+   * ジャイロレンジに応じて変換された値を取得する。
+   * @param {Object} gyro {x,y,z} ジャイロレンジに応じて変換したジャイロの取得
+   */
+  gotConvertedGyro(gyro) { }
+  /**
+   * コアモジュールで設定されている加速度レンジに応じて変換された値を取得する。
+   * @param {Object} acc {x,y,z} 加速度レンジに応じて変換した加速度の取得
+   */
+  gotConvertedAcc(acc) { }
+  /**
+   * 加速度値を2回積分して各x,y,zの単位時間の移動距離を取得する。
+   * @param {Object} delta {x,y,z} x,y,zの前回フレームからの移動距離
+   */
+  gotDelta(delta) { }
+  /**
+   * コアモジュールのオイラー角を取得する。オイラー角の取得は破綻する可能性があるため、姿勢を取る場合はクオータニオンを利用すること
+   * @param {Object} euler {pitch, roll, yaw} オイラー角
+   */
+  gotEuler(euler) { }
+  /**
+   * 歩容解析の取得（STEP_ANALYSIS FW対応待ちのため現状呼び出されません）
+   * @param {Object} gait {type, direction, calorie, distance} 歩行解析の取得
+   */
+  gotGait(gait) { }
+  /**
+   * 現在の歩容タイプを取得する（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} type {value} 0:none, 1:walk, 2:run, 3:stand
+   */
+  gotType(type) { }
+  /**
+   * ランニングの方向を取得する（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} direction {value} 0:none, 1:foward, 2:backward, 3:inside, 4:outside
+   */
+  gotDirection(direction) { }
+  /**
+   * 総消費カロリーを取得する（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} calorie {value}
+   */
+  gotCalorie(calorie) { }
+
+  /**
+   * 総移動距離を取得する（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} distance {value}
+   */
+  gotDistance(distance) { }
+
+  /**
+   * 立脚期継続時間[s]を取得する（STEP_ANALYSIS FW対応待ち）
+   * @param {*} standing_phase_duration
+   */
+  gotStandingPhaseDuration(standing_phase_duration) { }
+
+  /**
+   * 遊脚期継続時間[s]を取得する（STEP_ANALYSIS FW対応待ち）
+   * @param {*} swing_phase_duration
+   */
+  gotSwingPhaseDuration(swing_phase_duration) { }
+  /**
+   * ストライド[m]の取得（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} stride {x,y,z}
+   */
+  gotStride(stride) { }
+  /**
+   * 着地角度[degree]の取得（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} foot_angle {value}
+   */
+  gotFootAngle(foot_angle) { }
+
+  /**
+   * プロネーション[degree]の取得（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} pronation {x,y,z}
+   */
+  gotPronation(pronation) { }
+  /**
+   * 着地衝撃力[kgf/weight]の取得（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} landing_impact {value}
+   */
+  gotLandingImpact(landing_impact) { }
+  /**
+   * 現在までの歩数を取得する（STEP_ANALYSIS FW対応待ち）
+   * @param {Object} steps_number {value}
+   */
+  gotStepsNumber(steps_number) { }
+
+  /**
+   * 以前来たデータとのシリアルナンバーの差が1でない場合に呼び出される。SENSOR_VALUESのcharacteristicを利用したリアルタイムデータ取得時に利用可能。
+   * @param {number} serial_number - 現在のシリアルナンバー
+   * @param {number} serial_number_prev - 一つ前に受診したデータのシリアルナンバー
+   */
+  lostData(serial_number, serial_number_prev) { }
+
+  onScan(deviceName) { console.log("onScan"); }
+  onConnectGATT(uuid) { console.log("onConnectGATT"); }
+  onConnect(uuid) { console.log("onConnect"); }
+  onWrite(uuid) { console.log("onWrite"); }
+  onStartNotify(uuid) { console.log("onStartNotify", uuid); }
+  onStopNotify(uuid) { console.log("onStopNotify", uuid); }
+  onDisconnect() { console.log("onDisconnect"); }
+
+  /**
+   * 自動再接続の試行開始時に呼び出される
+   * @param {Object} info {attempt, maxAttempts, intervalMs}
+   */
+  onReconnectAttempt(info) { }
+  /**
+   * 自動再接続成功時に呼び出される
+   * @param {Object} info {attempt, maxAttempts, elapsedMs, result}
+   */
+  onReconnectSuccess(info) { }
+  /**
+   * 自動再接続が最大試行回数に達して失敗したときに呼び出される
+   * @param {Object} info {maxAttempts, elapsedMs, error}
+   */
+  onReconnectFailed(info) { }
+
+  /**
+   * アドバタイズメントデータを受信した時に呼び出される
+   * @param {BluetoothAdvertisingEvent} event - アドバタイズメントイベント
+   */
+  onAdvertisement(event) { console.log("onAdvertisement", event); }
+
+  /**
+   * notification frequencyの実測値を取得する
+   * @param {float} frequency
+   */
+  gotBLEFrequency(frequency) { }
+  onClear() { console.log("onClear"); }
+  onReset() { console.log("onReset"); }
+  onError(error) { console.log("onError: ", error); }
+
+  //一般開発ユーザからアクセス可能な関数の定義ここまで
+  //--------------------------------------------------
+}
+
+// ── グローバル公開とエイリアス ─────────────────────────────────
+// 推奨クラス名は OrpheInsole。
+// 後方互換のため、同一ページに ORPHE-CORE.js が読み込まれていない場合に限り
+// `Orphe` というエイリアスも公開する（CORE と同時読み込み時は CORE 側の
+// `Orphe` が優先され、INSOLE は OrpheInsole で利用する）。
+if (typeof global.OrpheInsole === 'undefined') {
+  global.OrpheInsole = OrpheInsole;
+}
+let hasLexicalOrphe = false;
+try {
+  // CORE.js が先に読み込まれている場合、class Orphe のレキシカル束縛が見える
+  hasLexicalOrphe = (typeof Orphe !== 'undefined');
+} catch (_) {
+  hasLexicalOrphe = true;
+}
+if (!hasLexicalOrphe && typeof global.Orphe === 'undefined') {
+  global.Orphe = OrpheInsole;
+}
+// 補助クラス/関数も衝突しない形で公開（既存コードの直接利用との互換のため）
+if (typeof global.FixedSizeArray === 'undefined') global.FixedSizeArray = FixedSizeArray;
+if (typeof global.OrpheTimestamp === 'undefined') global.OrpheTimestamp = OrpheTimestamp;
+if (typeof global.parseInsoleSensorValues === 'undefined') global.parseInsoleSensorValues = parseInsoleSensorValues;
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    Orphe: OrpheInsole,
+    OrpheInsole,
+    FixedSizeArray,
+    OrpheTimestamp,
+    parseInsoleSensorValues
+  };
+}
+
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/docs/ai/insole-migration/staging/tests/insole-coexistence.test.js
+++ b/docs/ai/insole-migration/staging/tests/insole-coexistence.test.js
@@ -1,0 +1,93 @@
+// ORPHE-CORE.js と同一ページに読み込んでも識別子衝突しないことの回帰テスト。
+// CORE 本体には依存せず、CORE がトップレベルに宣言するクラス群をスタブで再現する。
+// （トップレベルの class 宣言はグローバルなレキシカル束縛を作るため、
+//   同名宣言が2スクリプトにあると後勝ち側全体が SyntaxError で死ぬ）
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const INSOLE_SRC = fs.readFileSync(path.join(__dirname, '..', 'src', 'ORPHE-INSOLE.js'), 'utf8');
+
+// ORPHE-CORE.js がトップレベルで宣言する識別子のスタブ
+const CORE_STUB = `
+var orphe_js_version_date = 'core-stub';
+function loadScript(src) {}
+class FixedSizeArray { constructor(size) { this.size = size; } }
+class OrpheTimestamp { }
+class Orphe { constructor(id = 0) { this.id = id; this.isCore = true; } }
+`;
+
+function createContext() {
+  const documentMock = {
+    readyState: 'complete',
+    scripts: [],
+    head: { appendChild() { } },
+    createElement: () => ({}),
+    addEventListener() { },
+  };
+  const ctx = vm.createContext({
+    console, performance, Date, Math, JSON, Promise, Number, Object, Array,
+    setTimeout, clearTimeout,
+    document: documentMock,
+    navigator: {},
+    localStorage: { getItem: () => null, setItem() { }, removeItem() { } },
+    DataView, ArrayBuffer, Uint8Array,
+  });
+  ctx.globalThis = ctx;
+  ctx.window = ctx;
+  return ctx;
+}
+
+async function main() {
+  // ── CORE(スタブ) → INSOLE の順 ──────────────────────────────
+  {
+    const ctx = createContext();
+    vm.runInContext(CORE_STUB, ctx, { filename: 'ORPHE-CORE.js (stub)' });
+    vm.runInContext(INSOLE_SRC, ctx, { filename: 'ORPHE-INSOLE.js' });
+    const r = vm.runInContext(`({
+      orpheIsCore: (new Orphe(0)).isCore === true,
+      insoleName: OrpheInsole.name,
+      distinct: Orphe !== OrpheInsole,
+    })`, ctx);
+    assert.equal(r.orpheIsCore, true, 'Orphe must remain CORE when both loaded');
+    assert.equal(r.insoleName, 'OrpheInsole');
+    assert.equal(r.distinct, true);
+  }
+
+  // ── INSOLE → CORE(スタブ) の順 ──────────────────────────────
+  {
+    const ctx = createContext();
+    vm.runInContext(INSOLE_SRC, ctx, { filename: 'ORPHE-INSOLE.js' });
+    vm.runInContext(CORE_STUB, ctx, { filename: 'ORPHE-CORE.js (stub)' });
+    const r = vm.runInContext(`({
+      orpheIsCore: (new Orphe(0)).isCore === true,
+      insoleName: OrpheInsole.name,
+    })`, ctx);
+    assert.equal(r.orpheIsCore, true, 'CORE lexical binding must shadow INSOLE alias');
+    assert.equal(r.insoleName, 'OrpheInsole');
+  }
+
+  // ── INSOLE 単独（後方互換: Orphe エイリアス） ─────────────────
+  {
+    const ctx = createContext();
+    vm.runInContext(INSOLE_SRC, ctx, { filename: 'ORPHE-INSOLE.js' });
+    const r = vm.runInContext(`({
+      aliasWorks: Orphe === OrpheInsole,
+      canInstantiate: (new Orphe(1)).id === 1,
+      helpersExposed: typeof FixedSizeArray === 'function'
+        && typeof OrpheTimestamp === 'function'
+        && typeof parseInsoleSensorValues === 'function',
+    })`, ctx);
+    assert.equal(r.aliasWorks, true, 'Orphe alias must point to OrpheInsole when alone');
+    assert.equal(r.canInstantiate, true);
+    assert.equal(r.helpersExposed, true);
+  }
+
+  console.log('insole-coexistence.test.js passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/ai/insole-migration/staging/tests/insole-stability.test.js
+++ b/docs/ai/insole-migration/staging/tests/insole-stability.test.js
@@ -1,0 +1,98 @@
+// v1.1.0 で追加した接続安定化まわりのユニットテスト。
+// BLE 実機を使わずに検証できる純粋ロジックのみを対象とする。
+const assert = require('node:assert/strict');
+
+// ブラウザ専用グローバルの最小モック（require 時の参照エラー回避）
+globalThis.performance = globalThis.performance || { now: () => Date.now() };
+
+const {
+  Orphe,
+  OrpheInsole,
+  parseInsoleSensorValues,
+} = require('../src/ORPHE-INSOLE.js');
+
+async function main() {
+  // ── クラス名・エイリアス ─────────────────────────────────────
+  assert.equal(OrpheInsole, Orphe, 'Orphe must alias OrpheInsole');
+  assert.equal(OrpheInsole.name, 'OrpheInsole', 'primary class name should be OrpheInsole');
+  assert.equal(typeof OrpheInsole.parseSensorValues, 'function');
+
+  const insole = new OrpheInsole(0);
+
+  // ── デバイス記憶のストレージキーが CORE と衝突しない ───────────
+  assert.equal(insole._lastBluetoothDeviceStorageKey, 'orphe_insole_last_bluetooth_device_0');
+  assert.equal(new OrpheInsole(1)._lastBluetoothDeviceStorageKey, 'orphe_insole_last_bluetooth_device_1');
+
+  // ── _findBluetoothDevice のマッチングロジック ─────────────────
+  const devices = [
+    { id: 'aaa', name: 'INS-L' },
+    { id: 'bbb', name: 'INS-R' },
+    { id: 'ccc', name: 'INS-R' },
+  ];
+  // id 一致が最優先
+  assert.equal(insole._findBluetoothDevice(devices, { bluetoothId: 'bbb' }), devices[1]);
+  // id 不一致でも名前が一意なら名前で一致
+  assert.equal(insole._findBluetoothDevice(devices, { bluetoothId: 'zzz', bluetoothName: 'INS-L' }), devices[0]);
+  // 名前が重複する場合は誤接続防止のため null
+  assert.equal(insole._findBluetoothDevice(devices, { bluetoothName: 'INS-R' }), null);
+  assert.equal(insole._findBluetoothDevice(devices, null), null);
+  assert.equal(insole._findBluetoothDevice('not-an-array', { bluetoothId: 'aaa' }), null);
+
+  // ── 自動再接続の設定値正規化 ──────────────────────────────────
+  insole._autoReconnectOptions = {};
+  assert.equal(insole._autoReconnectIntervalMs(), 3000, 'default interval');
+  assert.equal(insole._autoReconnectMaxAttempts(), 120, 'default attempts');
+  insole._autoReconnectOptions = { reconnectIntervalMs: 500, reconnectMaxAttempts: 5 };
+  assert.equal(insole._autoReconnectIntervalMs(), 500);
+  assert.equal(insole._autoReconnectMaxAttempts(), 5);
+  insole._autoReconnectOptions = { reconnectIntervalMs: -1, reconnectMaxAttempts: 0 };
+  assert.equal(insole._autoReconnectIntervalMs(), 3000, 'negative interval falls back');
+  assert.equal(insole._autoReconnectMaxAttempts(), 120, 'zero attempts falls back');
+
+  insole._enableAutoReconnect('SENSOR_VALUES', { streamingMode: 3 });
+  assert.equal(insole._autoReconnectEnabled, true);
+  assert.equal(insole._autoReconnectOptions.autoReconnect, true);
+  assert.equal(insole._autoReconnectOptions.streamingMode, 3);
+  insole._disableAutoReconnect();
+  assert.equal(insole._autoReconnectEnabled, false);
+
+  // ── _reportError は自動再接続中に onError を抑制する ───────────
+  let errorCount = 0;
+  insole.onError = () => { errorCount++; };
+  insole._reportError(new Error('a'));
+  assert.equal(errorCount, 1);
+  insole._suppressAutoReconnectErrors = true;
+  insole._reportError(new Error('b'));
+  assert.equal(errorCount, 1, 'suppressed during reconnect');
+  assert.equal(insole._lastAutoReconnectError.message, 'b');
+  insole._suppressAutoReconnectErrors = false;
+
+  // ── setDataStreamingMode のバリデーション（write をモック） ────
+  {
+    const written = [];
+    const target = new OrpheInsole(0);
+    target.write = async (uuid, data) => { written.push({ uuid, data: Array.from(data) }); };
+    await target.setDataStreamingMode(3);
+    assert.deepEqual(written[0], { uuid: 'DEVICE_INFORMATION', data: [0x0D, 3] });
+    assert.equal(target.streaming_mode, 3);
+    await assert.rejects(() => target.setDataStreamingMode(2), /Invalid ORPHE INSOLE data streaming mode/);
+    await assert.rejects(() => target.setDataStreamingMode('x'), /Invalid ORPHE INSOLE data streaming mode/);
+  }
+
+  // ── 既存パーサが壊れていないこと（スモーク） ───────────────────
+  {
+    const data = new DataView(new ArrayBuffer(104));
+    data.setUint8(0, 56);
+    data.setUint16(1, 7);
+    const parsed = parseInsoleSensorValues(data);
+    assert.equal(parsed.header, 56);
+    assert.equal(parsed.samples.length, 2);
+  }
+
+  console.log('insole-stability.test.js passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 概要

ORPHE-INSOLE.js を ORPHE-CORE.js と同等の完成度へ引き上げるための移植・改修プランと、INSOLE リポジトリへそのままコピーできる実装ステージング一式を追加します。

## 確定した意思決定

| 論点 | 決定 |
|---|---|
| STEP_ANALYSIS | FW対応を待つ。まずは生データ（SENSOR_VALUES）ストリーミングに集中 |
| クラス名 | `OrpheInsole` を正式名に、`Orphe` は後方互換エイリアス。ライブラリ本体を IIFE で包み CORE と同一ページで共存可能に |
| Toolkit | INSOLE 専用 slim 版 `InsoleToolkit.js` を新規作成 |
| Examples | まず VISUALIZE のみ移植 |
| プラン保管場所 | 本リポジトリ `docs/ai/insole-migration-plan.md` |

## 内容

- `docs/ai/insole-migration-plan.md` — 調査結果（CORE/INSOLE 差分）と確定プラン
- `docs/ai/insole-migration/staging/` — INSOLE リポへコピー可能なファイル一式（適用手順は `docs/ai/insole-migration/README.md`）
  - `src/ORPHE-INSOLE.js` v1.1.0: デバイス記憶によるダイアログレス再接続、autoReconnect（onReconnectAttempt/Success/Failed）、切断リスナーの遅延バインド化、`alert()` 排除、デバッグログのフラグ化
  - `src/InsoleToolkit.js`: ストリーミングモード切替・L/Rバッジ・再接続ステータス付き slim 接続UI（`buildCoreToolkit` 互換ラッパーあり）
  - `examples/VISUALIZE/`: 圧力6ch＋IMU 5チャート×2台、rAF スロットリング
  - `tests/`: 安定化ロジックの単体テスト＋CORE/INSOLE 共存回帰テスト
  - `CLAUDE.md` / `docs-ai/PRESSURE_RECIPES.md`: AI開発ガイドと圧力データ処理レシピ集（接地検出・CoP・バランス・可聴化3種）

## 検証

- INSOLE リポジトリの既存テスト一式（insole-parser / hula-detector）を staged ソースで実行し全パス
- 新規テスト2本（stability / coexistence）全パス
- CORE↔INSOLE の両読み込み順での共存と、INSOLE 単独時の `Orphe` エイリアス後方互換を vm で検証済み
- 全 JS に `node --check` 実施

## 次のステップ

1. staging を ORPHE-INSOLE.js リポジトリへ適用（手順は README 参照）
2. 実機で autoReconnect の検証（電源断・距離・スリープ復帰）
3. float16/quaternion の同梱化（CORE CDN への実行時依存の解消）

https://claude.ai/code/session_01KUQ42GHDL4PTfg9eNB1zU4