### PR TITLE
docs(ai): INSOLE staging を実適用結果と同期（API欠落の修正＋回帰テスト）

### DIFF
--- a/docs/ai/insole-migration/staging/src/ORPHE-INSOLE.js
+++ b/docs/ai/insole-migration/staging/src/ORPHE-INSOLE.js
@@ -989,6 +989,32 @@ class OrpheInsole {
   }
 
   /**
+   * Notificationに接続する処理を実行
+   * @deprecated begin() が同等の処理を行うため通常は不要です。後方互換のために残しています。
+   */
+  async connectToNotifications() {
+    try {
+      console.log('Connecting to notifications...');
+
+      // SENSOR_VALUESのnotificationを開始
+      await this.startNotify('SENSOR_VALUES');
+      console.log('Connected to SENSOR_VALUES notifications');
+
+      // STEP_ANALYSISのnotificationを開始（オプション）
+      try {
+        await this.startNotify('STEP_ANALYSIS');
+        console.log('Connected to STEP_ANALYSIS notifications');
+      } catch (error) {
+        console.warn('STEP_ANALYSIS notification not available:', error.message);
+      }
+
+    } catch (error) {
+      console.error('Failed to connect to notifications:', error);
+      throw error;
+    }
+  }
+
+  /**
    * アドバタイズメント監視を停止
    */
   stopWatchingAdvertisements() {

--- a/docs/ai/insole-migration/staging/tests/insole-stability.test.js
+++ b/docs/ai/insole-migration/staging/tests/insole-stability.test.js
@@ -79,6 +79,36 @@ async function main() {
     await assert.rejects(() => target.setDataStreamingMode('x'), /Invalid ORPHE INSOLE data streaming mode/);
   }
 
+  // ── 公開APIサーフェスの回帰チェック（v1.0.0 からの非意図的削除を防ぐ） ──
+  {
+    const publicMethods = [
+      // v1.0.0 から存在する公開メソッド
+      'setup', 'setUUID', 'begin', 'stop', 'reset', 'clear', 'disconnect', 'isConnected',
+      'scan', 'requestDevice', 'connectGATT', 'read', 'write', 'startNotify', 'stopNotify',
+      'setDataStreamingMode', 'setDeviceInformation', 'getDeviceInformation',
+      'getDateTime', 'setDateTime', 'syncCoreTime', 'resetAnalysisLogs',
+      'autoStartWatchingAdvertisements', 'startWatchingAdvertisements',
+      'stopWatchingAdvertisements', 'connectToNotifications', 'onAdvertisementReceived',
+      'isGotDataOverridden',
+      // v1.0.0 から存在するコールバックプロトタイプ
+      'gotData', 'gotStatus', 'gotPress', 'gotQuat', 'gotGyro', 'gotAcc',
+      'gotConvertedGyro', 'gotConvertedAcc', 'gotDelta', 'gotEuler',
+      'gotGait', 'gotType', 'gotDirection', 'gotCalorie', 'gotDistance',
+      'gotStandingPhaseDuration', 'gotSwingPhaseDuration', 'gotStride', 'gotFootAngle',
+      'gotPronation', 'gotLandingImpact', 'gotStepsNumber', 'gotBLEFrequency', 'lostData',
+      'onScan', 'onConnectGATT', 'onConnect', 'onWrite', 'onStartNotify', 'onStopNotify',
+      'onDisconnect', 'onAdvertisement', 'onClear', 'onReset', 'onError', 'onRead',
+      // v1.1.0 で追加した公開メソッド/コールバック
+      'selectBluetoothDevice', 'forgetLastBluetoothDevice',
+      'onReconnectAttempt', 'onReconnectSuccess', 'onReconnectFailed',
+    ];
+    for (const name of publicMethods) {
+      assert.equal(typeof OrpheInsole.prototype[name], 'function',
+        `public API missing: ${name}`);
+    }
+    assert.equal(typeof OrpheInsole.parseSensorValues, 'function');
+  }
+
   // ── 既存パーサが壊れていないこと（スモーク） ───────────────────
   {
     const data = new DataView(new ArrayBuffer(104));


### PR DESCRIPTION
## 概要

PR #114 でマージした INSOLE 移植ステージングを、ORPHE-INSOLE.js への実適用（ドライラン）で見つかった2点で更新するフォローアップです。

## 変更点

1. **`connectToNotifications` の復元**: v1.0.0 から存在する公開メソッドが、ステージング版 SDK の書き直しで欠落していたことを実適用時の API サーフェス照合で検出。deprecation 注記付きで復元
2. **公開APIサーフェス回帰テストの追加**: v1.0.0 の全公開メソッド/コールバックの存在を `npm test` で検証し、今後の非意図的な削除を防止

## 検証

- ORPHE-INSOLE.js リポジトリの実テスト一式 + 新規テスト（stability / coexistence / API surface）を staged ソースで実行し全パス
- minified ビルド（dist/orphe-insole.min.js）の機能検証・ブラウザ相当環境での共存検証も実施済み

なお、本ステージングの INSOLE リポジトリへの適用は完了済み（bundle / patch 形式で検証済み・実機テスト待ち）です。

https://claude.ai/code/session_01KUQ42GHDL4PTfg9eNB1zU4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUQ42GHDL4PTfg9eNB1zU4)_